### PR TITLE
Allow admins to delete public things from other admins

### DIFF
--- a/frontend/build/profiles/integration/annotations-tool-configuration.js
+++ b/frontend/build/profiles/integration/annotations-tool-configuration.js
@@ -358,7 +358,7 @@ define(["jquery",
                         });
                     }
 
-                    return annotationsTool.userRole | ROLES.USER;
+                    return annotationsTool.userRole || ROLES.USER;
                 },
 
                 /**

--- a/frontend/build/profiles/integration/annotations-tool-configuration.js
+++ b/frontend/build/profiles/integration/annotations-tool-configuration.js
@@ -498,8 +498,7 @@ define(["jquery",
                 },
 
                 loadXACML: function (file) {
-
-                  $.ajax({
+                    $.ajax({
                         url: file.url,
                         async: false,
                         crossDomain: true,
@@ -507,12 +506,11 @@ define(["jquery",
                         success: function (xml) {
                             var $rules = $(xml).find("Rule");
 
-                                $rules.each(function(i, element){
-                                  if ($(element).find("Action").find("AttributeValue").text() === "annotate-admin") {
+                            $rules.each(function (i, element){
+                                if ($(element).find("Action").find("AttributeValue").text() === "annotate-admin") {
                                     annotate_admin_roles.push($(element).find("Condition").find("AttributeValue").text());
-                                  }
-                                });
-
+                                }
+                            });
                         }
                   });
                 }

--- a/frontend/build/profiles/integration/annotations-tool-configuration.js
+++ b/frontend/build/profiles/integration/annotations-tool-configuration.js
@@ -319,46 +319,15 @@ define(["jquery",
                     if (annotate_admin_roles.length > 0) {
                       for (var i = 0; i < annotate_admin_roles.length; i++) {
                         if (_.contains(roles, annotate_admin_roles[i])) {
-                            return ROLES.SUPERVISOR;
+                            return ROLES.ADMINISTRATOR;
                         }
                       }
                     } else if (_.contains(roles, ROLE_ADMIN)) {
                         console.log("Using admin role as default supervisor");
-                        return ROLES.SUPERVISOR;
+                        return ROLES.ADMINISTRATOR;
                     }
 
                     return ROLES.USER;
-                },
-
-                /**
-                 * Get the role of the current user
-                 * @alias module:annotations-tool-configuration.Configuration.getUserRole
-                 * @return {ROLE} The current user role
-                 */
-                getUserRole: function () {
-                    var ROLE_ADMIN = "ROLE_ADMIN";
-
-                    if (_.isUndefined(annotationsTool.userRole)) {
-                        $.ajax({
-                            url: "/info/me.json",
-                            async: false,
-                            dataType: "json",
-                            success: function (data) {
-                                if (_.contains(data.roles, ROLE_ADMIN)) {
-                                    annotationsTool.userRole = ROLES.SUPERVISOR;
-                                }
-
-                                if (_.contains(data.roles, data.org.adminRole)) {
-                                    annotationsTool.userRole = ROLES.ADMINISTRATOR;
-                                }
-                            },
-                            error: function () {
-                                console.warn("Error getting user information from Matterhorn!");
-                            }
-                        });
-                    }
-
-                    return annotationsTool.userRole || ROLES.USER;
                 },
 
                 /**

--- a/frontend/build/profiles/local/annotations-tool-configuration.js
+++ b/frontend/build/profiles/local/annotations-tool-configuration.js
@@ -238,15 +238,6 @@ define(["jquery",
             },
 
             /**
-             * Get the role of the current user
-             * @alias module:annotations-tool-configuration.Configuration.getUserRole
-             * @return {ROLE} The current user role
-             */
-            getUserRole: function () {
-                return ROLES.USER;
-            },
-
-            /**
              * Get the name of the admin role
              * @alias module:annotations-tool-configuration.Configuration.getAdminRoleName
              * @return {ROLE} The name of the admin role

--- a/frontend/js/annotations-tool-configuration.js
+++ b/frontend/js/annotations-tool-configuration.js
@@ -272,15 +272,6 @@ define(["jquery",
             },
 
             /**
-             * Get the role of the current user
-             * @alias module:annotations-tool-configuration.Configuration.getUserRole
-             * @return {ROLE} The current user role
-             */
-            getUserRole: function () {
-                return ROLES.USER;
-            },
-
-            /**
              * Get the name of the admin role
              * @alias module:annotations-tool-configuration.Configuration.getAdminRoleName
              * @return {ROLE} The name of the admin role

--- a/frontend/js/annotations-tool.js
+++ b/frontend/js/annotations-tool.js
@@ -96,7 +96,7 @@ define(["jquery",
                             }
                         };
 
-                    if (!target.get("isMine") && this.getUserRole() !== ROLES.ADMINISTRATOR) {
+                    if (!target.isEditable()) {
                         this.alertWarning("You are not authorized to deleted this " + type.name + "!");
                         return;
                     }

--- a/frontend/js/collections/labels.js
+++ b/frontend/js/collections/labels.js
@@ -17,17 +17,19 @@
 /**
  * A module representing a labels collection
  * @module collections-labels
- * @requires jQuery
- * @requires models-label
+ * @requires jquery
+ * @requires underscore
  * @requires backbone
+ * @requires models/label
  * @requires localstorage
  */
 define(["jquery",
-        "models/label",
+        "underscore",
         "backbone",
+        "models/label",
         "localstorage"],
 
-    function ($, Label, Backbone) {
+    function ($, _, Backbone, Label) {
 
         "use strict";
 

--- a/frontend/js/handlebarsHelpers.js
+++ b/frontend/js/handlebarsHelpers.js
@@ -13,19 +13,6 @@ define(["handlebars", "underscore", "i18next", "roles"], function (Handlebars, _
         }
     });
 
-    /**
-     * Handlebars helper to know if the current user can deleted the current model.
-     * @alias module:Handlebars#canBeDeleted
-     * @return {boolean}    True if the current user can deleted the current model.
-     */
-    Handlebars.registerHelper("canBeDeleted", function (options) {
-        if (this.isMine || ROLES.ADMINISTRATOR === annotationsTool.getUserRole()) {
-            return options.fn(this);
-        } else {
-            return options.inverse(this);
-        }
-    });
-
     Handlebars.registerHelper("greater", function (value1, value2, options) {
         console.log(value1 + " type " + typeof value1);
         if (value1 > value2) {

--- a/frontend/js/models/category.js
+++ b/frontend/js/models/category.js
@@ -64,6 +64,11 @@ define(["jquery",
             },
 
             /**
+             * @see module:models-resource.Resource#administratorCanEditPublicInstances
+             */
+            administratorCanEditPublicInstances: true,
+
+            /**
              * Constructor
              * @alias module:models-category.Category#initialize
              * @param {object} attr Object literal containing the model initialion attributes.

--- a/frontend/js/models/label.js
+++ b/frontend/js/models/label.js
@@ -54,6 +54,11 @@ define(["jquery",
                 access    : ACCESS.PUBLIC
             },
 
+            /**
+             * @see module:models-resource.Resource#administratorCanEditPublicInstances
+             */
+            administratorCanEditPublicInstances: true,
+
              /**
              * Constructor
              * @alias module:models-label.Label#initialize

--- a/frontend/js/models/resource.js
+++ b/frontend/js/models/resource.js
@@ -21,8 +21,9 @@
  * @requires backbone
  * @requires util
  * @requires access
+ * @requires roles
  */
-define(["underscore", "backbone", "util", "access"], function (_, Backbone, util, ACCESS) {
+define(["underscore", "backbone", "util", "access", "roles"], function (_, Backbone, util, ACCESS, ROLES) {
 "use strict";
 
 /**
@@ -171,7 +172,30 @@ var Resource = Backbone.Model.extend({
         }
 
         return json;
-    }
+    },
+
+    /**
+     * Decide whether this resource can be deleted by the current user.
+     * @see administratorCanEditPublicInstances
+     * @alias module:models-resource.Resource#isEditable
+     */
+    isEditable: function () {
+        return this.get("isMine") || (
+            this.administratorCanEditPublicInstances
+                // TODO We should check this as well, but it does not work with labels so well ...
+                //   so for now we assume that this is only ever checked when the resource is public
+                //   in the right sense, i.e. it can be seen at all.
+                //&& this.get("isPublic")
+                && annotationsTool.user.get("role") === ROLES.ADMINISTRATOR
+        );
+    },
+
+    /**
+     * Can a user with the administrator role delete instances of this resource, when they are public?
+     * @see module:roles
+     * @type {boolean}
+     */
+    administratorCanEditPublicInstances: false
 });
 
 return Resource;

--- a/frontend/js/models/resource.js
+++ b/frontend/js/models/resource.js
@@ -158,7 +158,7 @@ var Resource = Backbone.Model.extend({
 
     /**
      * Override the default toJSON function to ensure complete JSONing.
-     * @alias module:models-annotation.Annotation#toJSON
+     * @alias module:models-resource.Resource#toJSON
      * @param {options} options Potential options influencing the JSONing process
      * @return {JSON} JSON representation of the instance
      */

--- a/frontend/js/models/scale.js
+++ b/frontend/js/models/scale.js
@@ -61,6 +61,11 @@ define(["jquery",
             },
 
             /**
+             * @see module:models-resource.Resource#administratorCanEditPublicInstances
+             */
+            administratorCanEditPublicInstances: true,
+
+            /**
              * Constructor
              * @alias module:models-scale.Scale#initialize
              * @param {object} attr Object literal containing the model initialion attributes.

--- a/frontend/js/models/scalevalue.js
+++ b/frontend/js/models/scalevalue.js
@@ -59,6 +59,11 @@ define(["jquery",
             },
 
             /**
+             * @see module:models-resource.Resource#administratorCanEditPublicInstances
+             */
+            administratorCanEditPublicInstances: true,
+
+            /**
              * Constructor
              * @alias module:models-scalevalue.Scalevalue#initialize
              * @param {object} attr Object literal containing the model initialion attributes.

--- a/frontend/js/roles.js
+++ b/frontend/js/roles.js
@@ -28,11 +28,7 @@ define([], function () {
      * @enum {String}
      */
     return {
-        /** SUPERVISOR = "supervisor"*/
-        SUPERVISOR: "supervisor",
-        /** STUDENT = "user"*/
         USER: "user",
-        /** ADMINISTRATOR = "administrator"*/
         ADMINISTRATOR: "administrator"
     };
 });

--- a/frontend/js/views/annotate-category.js
+++ b/frontend/js/views/annotate-category.js
@@ -300,10 +300,9 @@ define(["jquery",
                 this.model.get("labels").create({
                     value       : i18next.t("new label defaults.description"),
                     abbreviation: i18next.t("new label defaults.abbreviation"),
-                    category    : this.model
-                },
-                  {wait: true}
-                );
+                    category    : this.model,
+                    access      : this.model.get("access")
+                }, { wait: true });
             },
 
             /**

--- a/frontend/js/views/annotate-label.js
+++ b/frontend/js/views/annotate-label.js
@@ -17,20 +17,22 @@
 /**
  * A module representing the label view for each item contained in annotate window
  * @module views-annotate-label
- * @requires jQuery
- * @requires models-annotation
+ * @requires jquery
+ * @requires underscore
+ * @requires backbone
+ * @requires models/annotation
  * @requires templates/annotate-label.tmpl
  * @requires handlebars
  * @requires jquery.colorPicker
- * @requires backbone
  */
 define(["jquery",
+        "underscore",
+        "backbone",
         "models/annotation",
         "templates/annotate-label",
-        "backbone",
         "handlebarsHelpers"],
 
-    function ($, Annotation, Template, Backbone) {
+    function ($, _, Backbone, Annotation, Template) {
 
         "use strict";
 

--- a/frontend/js/views/annotate.js
+++ b/frontend/js/views/annotate.js
@@ -73,7 +73,7 @@ define(["jquery",
                     filter    : function (category) {
                         return category.get("isPublic");
                     },
-                    roles     : [ROLES.SUPERVISOR, ROLES.ADMINISTRATOR],
+                    roles     : [ROLES.ADMINISTRATOR],
                     attributes: {access: ACCESS.PUBLIC}
                 },
                 MINE: {
@@ -82,7 +82,7 @@ define(["jquery",
                     filter    : function (category) {
                         return category.get("isMine") && !category.get("isPublic");
                     },
-                    roles     : [ROLES.SUPERVISOR, ROLES.USER, ROLES.ADMINISTRATOR],
+                    roles     : [ROLES.USER, ROLES.ADMINISTRATOR],
                     attributes: {access: ACCESS.PRIVATE}
                 }
             },

--- a/frontend/js/views/login.js
+++ b/frontend/js/views/login.js
@@ -132,7 +132,7 @@ define(["jquery",
                                 nickname: userNickname.val(),
                                 email: userEmail.val(),
                                 role: annotationsTool.localStorage && (
-                                    this.$el.find("#supervisor")[0].checked ? ROLES.SUPERVISOR : ROLES.USER
+                                    this.$el.find("#supervisor")[0].checked ? ROLES.ADMINISTRATOR : ROLES.USER
                                 )
                             },
                             {

--- a/frontend/js/views/scale-editor.js
+++ b/frontend/js/views/scale-editor.js
@@ -317,7 +317,7 @@ define(["jquery",
                     this.currentScaleId = this.$el.find("select#scale-id").val();
                     this.currentScale = annotationsTool.video.get("scales").get(this.currentScaleId);
 
-                    if (this.currentScale && this.currentScale.get("isMine")) {
+                    if (this.currentScale && this.currentScale.isEditable()) {
                         if (this.isInEditMode) {
                             this.$el.find("a.edit-scale").hide();
                         } else {

--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -697,7 +697,7 @@ define(["util",
                 var trackJSON = track.toJSON();
 
                 trackJSON.id = track.id;
-                trackJSON.isSupervisor = (annotationsTool.user.get("role") === ROLES.SUPERVISOR);
+                trackJSON.isSupervisor = (annotationsTool.user.get("role") === ROLES.ADMINISTRATOR);
 
                 return {
                     model: track,
@@ -740,7 +740,7 @@ define(["util",
                 // Prepare track informations
                 trackJSON = track.toJSON();
                 trackJSON.id = track.id;
-                trackJSON.isSupervisor = (annotationsTool.user.get("role") === ROLES.SUPERVISOR);
+                trackJSON.isSupervisor = (annotationsTool.user.get("role") === ROLES.ADMINISTRATOR);
 
                 // Calculate start/end time
                 startTime = annotation.get("start");
@@ -828,7 +828,7 @@ define(["util",
                 } else if (!this.createGroupModal) {
                     // Otherwise we load the login modal if not loaded
                     $("body").append(this.modalAddGroupTemplate({
-                        isSupervisor: annotationsTool.user.get("role") === ROLES.SUPERVISOR
+                        isSupervisor: annotationsTool.user.get("role") === ROLES.ADMINISTRATOR
                     }));
                     this.createGroupModal = $("#modal-add-group");
                     this.createGroupModal.modal({
@@ -1558,7 +1558,7 @@ define(["util",
                     trackJSON = track.toJSON(),
                     redrawRequired = false;
 
-                trackJSON.isSupervisor = (annotationsTool.user.get("role") === ROLES.SUPERVISOR);
+                trackJSON.isSupervisor = (annotationsTool.user.get("role") === ROLES.ADMINISTRATOR);
                 newGroup = this.groupTemplate(trackJSON);
 
                 _.each(_.values(this.annotationItems).concat(_.values(this.trackItems)), function (item) {

--- a/frontend/templates/list-annotation-edit.tmpl
+++ b/frontend/templates/list-annotation-edit.tmpl
@@ -49,11 +49,9 @@
     </div>
 
     <div class="right">
-        {{#canBeDeleted}}
-        <i class="delete icon-trash" title="{{t "annotation.edit.delete"}}"></i>
-        {{/canBeDeleted}}
-
         {{#if isMine}}
+        <i class="delete icon-trash" title="{{t "annotation.edit.delete"}}"></i>
+
         <i class="toggle-edit icon-pencil" title="{{t "annotation.edit.edit"}}"></i>
         {{/if}}
 

--- a/frontend/templates/list-annotation-expanded.tmpl
+++ b/frontend/templates/list-annotation-expanded.tmpl
@@ -41,11 +41,9 @@
     </div>
 
     <div class="right">
-        {{#canBeDeleted}}
-        <i class="delete icon-trash" title="{{t "annotation.edit.delete"}}"></i>
-        {{/canBeDeleted}}
-
         {{#if isMine}}
+        <i class="delete icon-trash" title="{{t "annotation.edit.delete"}}"></i>
+
         <i class="toggle-edit icon-pencil" title="{{t "annotation.edit.edit"}}"></i>
         {{/if}}
 

--- a/frontend/templates/timeline-group.tmpl
+++ b/frontend/templates/timeline-group.tmpl
@@ -14,11 +14,11 @@
         <div class="content">
             {{name}}
         </div>
-    {{#canBeDeleted}}
+    {{#if isMine}}
         <div class="group-edit">
             <i onclick="annotationsTool.views.timeline.onDeleteTrack(event,'{{id}}');" class="delete icon-trash" title="{{t "timeline.delete track"}}"></i>
-            {{#if isMine}}<i onclick="annotationsTool.views.timeline.initTrackUpdate(event,'{{id}}');" class="update  icon-pencil" title="{{t "timeline.update track.button"}}"></i>{{/if}}
-            {{#if isMine}}<span class="visibility"
+            <i onclick="annotationsTool.views.timeline.initTrackUpdate(event,'{{id}}');" class="update  icon-pencil" title="{{t "timeline.update track.button"}}"></i>
+            <span class="visibility"
                   onmouseup="{{#isPrivateOnly}}{{else}}$(this).parent().parent().popover('show');{{/isPrivateOnly}}"
                   onmousedown="{{#isPrivateOnly}}
                                       annotationsTool.alertWarning('{{t "timeline.private only.no public tracks allowed"}}');
@@ -26,9 +26,9 @@
                                       annotationsTool.views.timeline.onUpdateTrack(event,'{{id}}');
                               {{/isPrivateOnly}}"
                   title="{{#isPrivateOnly}}{{t "timeline.private only.no public tracks allowed"}}{{else}}{{#if isPublic}}{{t "timeline.change visibility.to private"}}{{else}}{{t "timeline.change visibility.to public"}}{{/if}}{{/isPrivateOnly}}">
-                    <i class="icon-dark-grey {{#isPrivateOnly}}icon-private{{else}}{{#if isPublic}}icon-public{{else}}icon-private{{/if}}{{/isPrivateOnly}}"></i> {{#isPrivateOnly}}{{t "timeline.track.private"}}{{else}}{{#if isPublic}}{{t "timeline.track.public"}}{{else}}{{t "timeline.track.private"}}{{/if}}{{/isPrivateOnly}}</span>{{/if}}
+                    <i class="icon-dark-grey {{#isPrivateOnly}}icon-private{{else}}{{#if isPublic}}icon-public{{else}}icon-private{{/if}}{{/isPrivateOnly}}"></i> {{#isPrivateOnly}}{{t "timeline.track.private"}}{{else}}{{#if isPublic}}{{t "timeline.track.public"}}{{else}}{{t "timeline.track.private"}}{{/if}}{{/isPrivateOnly}}</span>
         </div>
-    {{/canBeDeleted}}
-    <span class="toggle-expansion" href="#">{{t "timeline.track.expand/collapse"}}</span>
+    {{/if}}
+    <span class="toggle-expansion" href="#">Expand/Collapse</span>
     </a>
 </div>

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/AbstractExtendedAnnotationsRestService.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/AbstractExtendedAnnotationsRestService.java
@@ -510,12 +510,13 @@ public abstract class AbstractExtendedAnnotationsRestService {
   @Path("/scales/{scaleId}/scalevalues")
   public Response postScaleValue(@PathParam("scaleId") final long scaleId, @FormParam("name") final String name,
           @DefaultValue("0") @FormParam("value") final double value,
-          @DefaultValue("0") @FormParam("order") final int order, @FormParam("tags") final String tags) {
-    return postScaleValueResponse(Option.<Long> none(), scaleId, name, value, order, tags);
+          @DefaultValue("0") @FormParam("order") final int order, @FormParam("access") final Integer access,
+          @FormParam("tags") final String tags) {
+    return postScaleValueResponse(Option.<Long> none(), scaleId, name, value, order, access, tags);
   }
 
   Response postScaleValueResponse(final Option<Long> videoId, final long scaleId, final String name,
-          final double value, final int order, final String tags) {
+          final double value, final int order, final Integer access, final String tags) {
     return run(array(name), new Function0<Response>() {
       @Override
       public Response apply() {
@@ -524,7 +525,8 @@ public abstract class AbstractExtendedAnnotationsRestService {
                 || (tagsMap.isSome() && tagsMap.get().isNone()))
           return BAD_REQUEST;
 
-        Resource resource = eas().createResource(tagsMap.bind(Functions.<Option<Map<String, String>>> identity()));
+        Resource resource = eas().createResource(tagsMap.bind(Functions.<Option<Map<String, String>>> identity()),
+                option(access));
         final ScaleValue scaleValue = eas().createScaleValue(scaleId, name, value, order, resource);
 
         return Response.created(scaleValueLocationUri(scaleValue, videoId))
@@ -538,12 +540,13 @@ public abstract class AbstractExtendedAnnotationsRestService {
   @Path("/scales/{scaleId}/scalevalues/{scaleValueId}")
   public Response putScaleValue(@PathParam("scaleId") final long scaleId, @PathParam("scaleValueId") final long id,
           @FormParam("name") final String name, @DefaultValue("0") @FormParam("value") final double value,
-          @DefaultValue("0") @FormParam("order") final int order, @FormParam("tags") final String tags) {
-    return putScaleValueResponse(Option.<Long> none(), scaleId, id, name, value, order, tags);
+          @DefaultValue("0") @FormParam("order") final int order, @FormParam("access") final Integer access,
+          @FormParam("tags") final String tags) {
+    return putScaleValueResponse(Option.<Long> none(), scaleId, id, name, value, order, access, tags);
   }
 
   Response putScaleValueResponse(final Option<Long> videoId, final long scaleId, final long id,
-          final String name, final double value, final int order, final String tags) {
+          final String name, final double value, final int order, final Integer access, final String tags) {
     return run(array(name), new Function0<Response>() {
       @Override
       public Response apply() {
@@ -571,7 +574,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
 
           @Override
           public Response none() {
-            Resource resource = eas().createResource(tags);
+            Resource resource = eas().createResource(tags, option(access));
             final ScaleValue scaleValue = eas().createScaleValue(scaleId, name, value, order, resource);
 
             return Response.created(scaleValueLocationUri(scaleValue, videoId))

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/AbstractExtendedAnnotationsRestService.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/AbstractExtendedAnnotationsRestService.java
@@ -868,12 +868,15 @@ public abstract class AbstractExtendedAnnotationsRestService {
   @Path("/categories/{categoryId}/labels")
   public Response postLabel(@PathParam("categoryId") final long categoryId, @FormParam("value") final String value,
           @FormParam("abbreviation") final String abbreviation, @FormParam("description") final String description,
-          @FormParam("settings") final String settings, @FormParam("tags") final String tags) {
-    return postLabelResponse(Option.<Long> none(), categoryId, value, abbreviation, description, settings, tags);
+          @FormParam("access") final Integer access, @FormParam("settings") final String settings,
+          @FormParam("tags") final String tags) {
+    return postLabelResponse(Option.<Long> none(), categoryId, value, abbreviation, description, access, settings,
+            tags);
   }
 
   Response postLabelResponse(final Option<Long> videoId, final long categoryId, final String value,
-          final String abbreviation, final String description, final String settings, final String tags) {
+          final String abbreviation, final String description, final Integer access, final String settings,
+          final String tags) {
     return run(array(value, abbreviation), new Function0<Response>() {
       @Override
       public Response apply() {
@@ -882,7 +885,8 @@ public abstract class AbstractExtendedAnnotationsRestService {
                 || eas().getCategory(categoryId, false).isNone() || (tagsMap.isSome() && tagsMap.get().isNone()))
           return BAD_REQUEST;
 
-        Resource resource = eas().createResource(tagsMap.bind(Functions.<Option<Map<String, String>>> identity()));
+        Resource resource = eas().createResource(tagsMap.bind(Functions.<Option<Map<String, String>>> identity()),
+                option(access));
         final Label label = eas().createLabel(categoryId, value, abbreviation, trimToNone(description),
                 trimToNone(settings), resource);
 
@@ -897,14 +901,15 @@ public abstract class AbstractExtendedAnnotationsRestService {
   @Path("/categories/{categoryId}/labels/{labelId}")
   public Response putLabel(@PathParam("categoryId") final long categoryId, @PathParam("labelId") final long id,
           @FormParam("value") final String value, @FormParam("abbreviation") final String abbreviation,
-          @FormParam("description") final String description, @FormParam("settings") final String settings,
-          @FormParam("tags") final String tags) {
-    return putLabelResponse(Option.<Long> none(), categoryId, id, value, abbreviation, description, settings, tags);
+          @FormParam("description") final String description, @FormParam("access") final Integer access,
+          @FormParam("settings") final String settings, @FormParam("tags") final String tags) {
+    return putLabelResponse(Option.<Long> none(), categoryId, id, value, abbreviation, description, access, settings,
+            tags);
   }
 
   Response putLabelResponse(final Option<Long> videoId, final long categoryId, final long id,
-          final String value, final String abbreviation, final String description, final String settings,
-          final String tags) {
+          final String value, final String abbreviation, final String description, final Integer access,
+          final String settings, final String tags) {
     return run(array(value, abbreviation), new Function0<Response>() {
       @Override
       public Response apply() {
@@ -933,7 +938,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
 
           @Override
           public Response none() {
-            Resource resource = eas().createResource(tags);
+            Resource resource = eas().createResource(tags, option(access));
             final Label label = eas().createLabel(categoryId, value, abbreviation, trimToNone(description),
                     trimToNone(settings), resource);
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/VideoEndpoint.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/VideoEndpoint.java
@@ -595,8 +595,9 @@ public class VideoEndpoint {
   @Path("scales/{scaleId}/scalevalues")
   public Response postScaleValue(@PathParam("scaleId") final long scaleId, @FormParam("name") final String name,
           @DefaultValue("0") @FormParam("value") final double value,
-          @DefaultValue("0") @FormParam("order") final int order, @FormParam("tags") final String tags) {
-    return host.postScaleValueResponse(some(videoId), scaleId, name, value, order, tags);
+          @DefaultValue("0") @FormParam("order") final int order, @FormParam("access") final Integer access,
+          @FormParam("tags") final String tags) {
+    return host.postScaleValueResponse(some(videoId), scaleId, name, value, order, access, tags);
   }
 
   @PUT
@@ -604,8 +605,9 @@ public class VideoEndpoint {
   @Path("scales/{scaleId}/scalevalues/{scaleValueId}")
   public Response putScaleValue(@PathParam("scaleId") final long scaleId, @PathParam("scaleValueId") final long id,
           @FormParam("name") final String name, @DefaultValue("0") @FormParam("value") final double value,
-          @DefaultValue("0") @FormParam("order") final int order, @FormParam("tags") final String tags) {
-    return host.putScaleValueResponse(some(videoId), scaleId, id, name, value, order, tags);
+          @DefaultValue("0") @FormParam("order") final int order, @FormParam("access") final Integer access,
+          @FormParam("tags") final String tags) {
+    return host.putScaleValueResponse(some(videoId), scaleId, id, name, value, order, access, tags);
   }
 
   @GET

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/VideoEndpoint.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/VideoEndpoint.java
@@ -540,7 +540,7 @@ public class VideoEndpoint {
           @FormParam("scale_id") final Long scaleId, @FormParam("access") final Integer access,
           @FormParam("tags") final String tags) {
     if (scaleId == null)
-      return host.createScale(option(videoId), name, description, access, tags);
+        return host.createScale(some(videoId), name, description, access, tags);
 
     // TODO Why does this not use `createScale`?
     return run(array(scaleId), new Function0<Response>() {
@@ -565,14 +565,14 @@ public class VideoEndpoint {
   @Path("scales/{scaleId}")
   public Response putScale(@PathParam("scaleId") final long id, @FormParam("name") final String name,
           @FormParam("description") final String description, @FormParam("tags") final String tags) {
-    return host.updateScale(option(videoId), id, name, description, tags);
+    return host.updateScale(some(videoId), id, name, description, tags);
   }
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("scales/{scaleId}")
   public Response getScale(@PathParam("scaleId") final long id) {
-    return host.getScaleResponse(option(videoId), id);
+    return host.getScaleResponse(some(videoId), id);
   }
 
   @GET
@@ -581,13 +581,13 @@ public class VideoEndpoint {
   public Response getScales(@QueryParam("limit") final int limit, @QueryParam("offset") final int offset,
           @QueryParam("since") final String date, @QueryParam("tags-and") final String tagsAnd,
           @QueryParam("tags-or") final String tagsOr) {
-    return host.getScalesResponse(option(videoId), limit, offset, date, tagsAnd, tagsOr);
+    return host.getScalesResponse(some(videoId), limit, offset, date, tagsAnd, tagsOr);
   }
 
   @DELETE
   @Path("scales/{scaleId}")
   public Response deleteScale(@PathParam("scaleId") final long id) {
-    return host.deleteScaleResponse(option(videoId), id);
+    return host.deleteScaleResponse(some(videoId), id);
   }
 
   @POST
@@ -596,7 +596,7 @@ public class VideoEndpoint {
   public Response postScaleValue(@PathParam("scaleId") final long scaleId, @FormParam("name") final String name,
           @DefaultValue("0") @FormParam("value") final double value,
           @DefaultValue("0") @FormParam("order") final int order, @FormParam("tags") final String tags) {
-    return host.postScaleValueResponse(option(videoId), scaleId, name, value, order, tags);
+    return host.postScaleValueResponse(some(videoId), scaleId, name, value, order, tags);
   }
 
   @PUT
@@ -605,14 +605,14 @@ public class VideoEndpoint {
   public Response putScaleValue(@PathParam("scaleId") final long scaleId, @PathParam("scaleValueId") final long id,
           @FormParam("name") final String name, @DefaultValue("0") @FormParam("value") final double value,
           @DefaultValue("0") @FormParam("order") final int order, @FormParam("tags") final String tags) {
-    return host.putScaleValueResponse(option(videoId), scaleId, id, name, value, order, tags);
+    return host.putScaleValueResponse(some(videoId), scaleId, id, name, value, order, tags);
   }
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("scales/{scaleId}/scalevalues/{scaleValueId}")
   public Response getScaleValue(@PathParam("scaleId") final long scaleId, @PathParam("scaleValueId") final long id) {
-    return host.getScaleValueResponse(option(videoId), scaleId, id);
+    return host.getScaleValueResponse(some(videoId), scaleId, id);
   }
 
   @GET
@@ -621,13 +621,13 @@ public class VideoEndpoint {
   public Response getScaleValues(@PathParam("scaleId") final long scaleId, @QueryParam("limit") final int limit,
           @QueryParam("offset") final int offset, @QueryParam("since") final String date,
           @QueryParam("tags-and") final String tagsAnd, @QueryParam("tags-or") final String tagsOr) {
-    return host.getScaleValuesResponse(option(videoId), scaleId, limit, offset, date, tagsAnd, tagsOr);
+    return host.getScaleValuesResponse(some(videoId), scaleId, limit, offset, date, tagsAnd, tagsOr);
   }
 
   @DELETE
   @Path("scales/{scaleId}/scalevalues/{scaleValueId}")
   public Response deleteScaleValue(@PathParam("scaleId") final long scaleId, @PathParam("scaleValueId") final long id) {
-    return host.deleteScaleValueResponse(option(videoId), scaleId, id);
+    return host.deleteScaleValueResponse(some(videoId), scaleId, id);
   }
 
   @POST
@@ -639,7 +639,7 @@ public class VideoEndpoint {
           @FormParam("category_id") final Long id, @FormParam("access") final Integer access,
           @FormParam("tags") final String tags) {
     if (id == null)
-      return host.postCategoryResponse(option(videoId), name, description, hasDuration, scaleId, settings, access,
+      return host.postCategoryResponse(some(videoId), name, description, hasDuration, scaleId, settings, access,
               tags);
 
     return run(array(id), new Function0<Response>() {
@@ -677,7 +677,7 @@ public class VideoEndpoint {
           @DefaultValue("true") @FormParam("has_duration") final boolean hasDuration,
           @FormParam("scale_id") final Long scaleId, @FormParam("settings") final String settings,
           @FormParam("tags") final String tags) {
-    return host.putCategoryResponse(option(videoId), id, name, description, hasDuration, option(scaleId), settings, tags);
+    return host.putCategoryResponse(some(videoId), id, name, description, hasDuration, option(scaleId), settings, tags);
   }
 
   @GET
@@ -707,8 +707,9 @@ public class VideoEndpoint {
   @Path("categories/{categoryId}/labels")
   public Response postLabel(@PathParam("categoryId") final long categoryId, @FormParam("value") final String value,
           @FormParam("abbreviation") final String abbreviation, @FormParam("description") final String description,
-          @FormParam("settings") final String settings, @FormParam("tags") final String tags) {
-    return host.postLabelResponse(option(videoId), categoryId, value, abbreviation, description, settings, tags);
+          @FormParam("access") final Integer access, @FormParam("settings") final String settings,
+          @FormParam("tags") final String tags) {
+    return host.postLabelResponse(some(videoId), categoryId, value, abbreviation, description, access, settings, tags);
   }
 
   @PUT
@@ -716,9 +717,10 @@ public class VideoEndpoint {
   @Path("categories/{categoryId}/labels/{labelId}")
   public Response putLabel(@PathParam("categoryId") final long categoryId, @PathParam("labelId") final long id,
           @FormParam("value") final String value, @FormParam("abbreviation") final String abbreviation,
-          @FormParam("description") final String description, @FormParam("settings") final String settings,
-          @FormParam("tags") final String tags) {
-    return host.putLabelResponse(option(videoId), categoryId, id, value, abbreviation, description, settings, tags);
+          @FormParam("description") final String description, @FormParam("access") final Integer access,
+          @FormParam("settings") final String settings, @FormParam("tags") final String tags) {
+    return host.putLabelResponse(some(videoId), categoryId, id, value, abbreviation, description, access, settings,
+            tags);
   }
 
   @GET


### PR DESCRIPTION
Closes #30. As the comment in pull request #78 suggests, this one pulls in that one. :wink: 

Every admin (= Opencast admin or user with annotate-admin action on the video) can now delete anything and everything that is public in the "structured annotation panel".