### PR TITLE
Removed last vestiges of "annotations-tool" terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ The software devides currently into two parts:
 
 * The frontend component, containing the annotation webapp.
 * The Opencast Backend modules, that need to be integrated into an Opencast installation. A recent version of the i
-  frontend is already included in the entwine-annotations-tool module. 
+  frontend is already included in the annotation-tool module.
 
 ## [Installation](documentation/opencast-installation.md)
 The instruction on how to install the Annotation tool in Opencast 2.3+ [can be found here](documentation/opencast-installation.md)
 
 ## [Building the Frontend](documentation/build-frontend.md)
-Instructions on how to build the frontend webapp [can be found here](documentation/build-frontend.md). 
+Instructions on how to build the frontend webapp [can be found here](documentation/build-frontend.md).
 
 _This is NOT needed to install the Annotation Tool in Opencast!_
 

--- a/documentation/News.md
+++ b/documentation/News.md
@@ -33,9 +33,9 @@ Related to the tickets [#394](https://github.com/entwinemedia/annotations/issues
 * Off-screen rendering for the list.
 * Limit the redraw frequency for the timeline.
 
-For load testing, the method `tracksToImport` can now be implemented in the [configuration file](https://github.com/entwinemedia/annotations/blob/develop/js/annotations-tool-configuration.js) to load a large set of tracks. See the [load test configuration file](https://github.com/entwinemedia/annotations/blob/develop/tests/js/annotations-tool-configuration-loading.js) as example.
+For load testing, the method `tracksToImport` can now be implemented in the [configuration file](https://github.com/entwinemedia/annotations/blob/develop/js/annotation-tool-configuration.js) to load a large set of tracks. See the [load test configuration file](https://github.com/entwinemedia/annotations/blob/develop/tests/js/annotation-tool-configuration-loading.js) as example.
 
-###12.11.2013 
+###12.11.2013
 Some tests have been done with the updates from the 4th november and they resulted with the following work:
 
 * [#307](https://github.com/entwinemedia/annotations/issues/#307) - Moving annotations between public/private tracks and changing track visibility status in timeline did not always update the list view. This is now fixed.
@@ -44,12 +44,12 @@ Some tests have been done with the updates from the 4th november and they result
 * [#382](https://github.com/entwinemedia/annotations/issues/#382) - Automatically select new track.
 * [#383](https://github.com/entwinemedia/annotations/issues/#383) - Switching Public/Private visibility on track was relative slow due to synchronisation of all annotations. Now just the track is synchronised with the backend for this operation.
 
-###05.11.2013 
+###05.11.2013
 Some design related issues have been fixed:
 * [#280](https://github.com/entwinemedia/annotations/issues/#280) - Fix responsive design issue that was happening during tab switching.
 * [#275](https://github.com/entwinemedia/annotations/issues/#275) - Change eye icon for the track visibility status (public/private).
 
-###04.11.2013 
+###04.11.2013
 Small update with the fixes for the following bugs:
 * [#271](https://github.com/entwinemedia/annotations/issues/#271) - Small modifications done on the print design. The labels captions are no more split and the color.
 * [#280](https://github.com/entwinemedia/annotations/issues/#280) - Add responsive design for the categories edit-modus.

--- a/documentation/Test-the-tool-with-an-annotations-preset.md
+++ b/documentation/Test-the-tool-with-an-annotations-preset.md
@@ -4,7 +4,7 @@ To use it, first the tests folder should access through a web server. You can us
 
 If you need to install Grunt, follow [the starting tutorial](http://gruntjs.com/getting-started).
 
-The set of track is loaded only the first time following the [`tracksToImport`](https://github.com/entwinemedia/annotations/blob/t/ANNOT-83/tests/js/annotations-tool-configuration-loading.js#L141) function define in the [configuration file](https://github.com/entwinemedia/annotations/blob/t/ANNOT-83/tests/js/annotations-tool-configuration-loading.js) for the test page. To reset the tracks, use the url parameter `?reset=true`. You can edit this function to get the number of tracks and annotations that you want. The function has to return the track and annotations in the following format:
+The set of track is loaded only the first time following the [`tracksToImport`](https://github.com/entwinemedia/annotations/blob/t/ANNOT-83/tests/js/annotation-tool-configuration-loading.js#L141) function define in the [configuration file](https://github.com/entwinemedia/annotations/blob/t/ANNOT-83/tests/js/annotation-tool-configuration-loading.js) for the test page. To reset the tracks, use the url parameter `?reset=true`. You can edit this function to get the number of tracks and annotations that you want. The function has to return the track and annotations in the following format:
 
         [
             // Array containing the generated tracks

--- a/documentation/build-frontend.md
+++ b/documentation/build-frontend.md
@@ -47,7 +47,7 @@ You will find the webapp in `/opt/annotation/annotation-tool/frontend/`.
     cd /opt/annotation/annotation-tool/frontend/
     grunt integration
 
-The files in `/opt/annotation/annotation-tool/opencast-backend/entwine-annotations-tool/src/main/resources/ui/` should
+The files in `/opt/annotation/annotation-tool/opencast-backend/annotation-tool/src/main/resources/ui/` should
 have been updated. Use the [installation guide for Opencast](opencast-installation.md) to update Opencast with the new frontend.
 
 ## Building __dev__

--- a/frontend/.jshintrc
+++ b/frontend/.jshintrc
@@ -24,7 +24,7 @@
         "FileReader"      : true,
         "console"         : true,
         "window"          : true,
-        "annotationsTool" : true,
+        "annotationTool" : true,
         "localStorage"    : true,
         "Backbone"        : true,
         "$"               : true,

--- a/frontend/Gruntfile.js
+++ b/frontend/Gruntfile.js
@@ -34,7 +34,7 @@ module.exports = function (grunt) {
             integration: {
                 sources : '',
                 target  : '../opencast-backend/annotation-tool/src/main/resources/ui/',
-                config  : 'build/profiles/integration/annotations-tool-configuration.js'
+                config  : 'build/profiles/integration/annotation-tool-configuration.js'
             },
 
             local: {
@@ -42,7 +42,7 @@ module.exports = function (grunt) {
                           <source src=\"/resources/aav1.webm\" type=\"video/webm\" />\n \
                           <source src=\"/resources/aav1.ogv\" type=\"video/ogg\" /> ',
                 target : '<%= webServerDir %>',
-                config : 'build/profiles/local/annotations-tool-configuration.js'
+                config : 'build/profiles/local/annotation-tool-configuration.js'
             },
 
             build: {
@@ -50,14 +50,14 @@ module.exports = function (grunt) {
                           <source src=\"/resources/Annotations_Video.webm\" type=\"video/webm\" />\n \
                           <source src=\"/resources/Annotations_Video.theora.ogv\" type=\"video/ogg\" /> ',
                 target : '<%= buildDir %>',
-                config : 'build/profiles/local/annotations-tool-configuration.js'
+                config : 'build/profiles/local/annotation-tool-configuration.js'
             },
 
             demo: {
                 sources: '<source src=\"/annotation/resources/sinteltrailer.mp4\" type=\"video/mp4\" />\n \
                           <source src=\"/annotation/resources/sinteltrailer.ogv\" type=\"video/ogg\" /> ',
                 target : '/var/www/html/annotation/',
-                config : 'build/profiles/local/annotations-tool-configuration.js'
+                config : 'build/profiles/local/annotation-tool-configuration.js'
             }
         },
 
@@ -269,7 +269,7 @@ module.exports = function (grunt) {
             // ... the configuration
             'config': {
                 src: '<%= currentProfile.config %>',
-                dest: '<%= currentProfile.target %>/js/annotations-tool-configuration.js'
+                dest: '<%= currentProfile.target %>/js/annotation-tool-configuration.js'
             },
             // ... the translations
             'locales': {

--- a/frontend/build/config/INDEX_DOC.md
+++ b/frontend/build/config/INDEX_DOC.md
@@ -1,10 +1,10 @@
 # Javascript documentation for the annotations tool
 <br/>
 ## Main namespace
-The only exported namespace is [`annotationsTool`](annotationsTool.html). Extend this one to extend the tool API.
+The only exported namespace is [`annotationTool`](annotationTool.html). Extend this one to extend the tool API.
 
 ## Tool configuration
-The tool can be configured through this [`configuration file`](module-annotations-tool-configuration.html#Configuration).
+The tool can be configured through this [`configuration file`](module-annotation-tool-configuration.html#Configuration).
 
 ## More informations
 on https://github.com/entwinemedia/annotations/wiki

--- a/frontend/build/profiles/integration/annotation-tool-configuration.js
+++ b/frontend/build/profiles/integration/annotation-tool-configuration.js
@@ -16,7 +16,7 @@
 
 /**
  * Module containing the tool configuration
- * @module annotations-tool-configuration
+ * @module annotation-tool-configuration
  */
 define(["jquery",
         "moment",
@@ -37,14 +37,14 @@ define(["jquery",
             annotate_admin_roles = [],
             /**
              * Annotations tool configuration object
-             * @alias module:annotations-tool-configuration.Configuration
+             * @alias module:annotation-tool-configuration.Configuration
              * @enum
              */
             Configuration =  {
 
                 /**
                  * List of possible layout configuration
-                 * @memberOf module:annotations-tool-configuration.Configuration
+                 * @memberOf module:annotation-tool-configuration.Configuration
                  * @type {Object}
                  */
                 LAYOUT_CONFIGURATION: {
@@ -72,16 +72,16 @@ define(["jquery",
 
                 /**
                  * The minmal duration used for annotation representation on timeline
-                 * @alias module:annotations-tool-configuration.Configuration.MINIMAL_DURATION
-                 * @memberOf module:annotations-tool-configuration.Configuration
+                 * @alias module:annotation-tool-configuration.Configuration.MINIMAL_DURATION
+                 * @memberOf module:annotation-tool-configuration.Configuration
                  * @type {Object}
                  */
                 MINIMAL_DURATION: 5,
 
                 /**
                  * Define the number of categories pro tab in the annotate box. Bigger is number, thinner will be the columns for the categories.
-                 * @alias module:annotations-tool-configuration.Configuration.CATEGORIES_PER_TAB
-                 * @memberOf module:annotations-tool-configuration.Configuration
+                 * @alias module:annotation-tool-configuration.Configuration.CATEGORIES_PER_TAB
+                 * @memberOf module:annotation-tool-configuration.Configuration
                  * @type {Number}
                  */
                 CATEGORIES_PER_TAB: 7,
@@ -94,7 +94,7 @@ define(["jquery",
 
                 /**
                  * Define if the localStorage should be used or not
-                 * @alias module:annotations-tool-configuration.Configuration.localStorage
+                 * @alias module:annotation-tool-configuration.Configuration.localStorage
                  * @type {boolean}
                  * @readOnly
                  */
@@ -104,7 +104,7 @@ define(["jquery",
                 plugins: {
                     Loop: function () {
                         require(["views/loop"], function (Loop) {
-                            annotationsTool.loopView = new Loop();
+                            annotationTool.loopView = new Loop();
                         });
                     }
                 },
@@ -112,7 +112,7 @@ define(["jquery",
 
                 /**
                  * Url from the annotations Rest Endpoints
-                 * @alias module:annotations-tool-configuration.Configuration.restEndpointsUrl
+                 * @alias module:annotation-tool-configuration.Configuration.restEndpointsUrl
                  * @type {string}
                  * @readOnly
                  */
@@ -120,7 +120,7 @@ define(["jquery",
 
                 /**
                  * Url for redirect after the logout
-                 * @alias module:annotations-tool-configuration.Configuration.logoutUrl
+                 * @alias module:annotation-tool-configuration.Configuration.logoutUrl
                  * @type {string}
                  * @readOnly
                  */
@@ -128,7 +128,7 @@ define(["jquery",
 
                 /**
                  * Offer the user a spreadsheet version of the annotations for download.
-                 * @alias module:annotations-tool-configuration.Configuration.export
+                 * @alias module:annotation-tool-configuration.Configuration.export
                  * @param {Video} video The video to export
                  * @param {Track[]} tracks The tracks to include in the export
                  * @param {Category[]} categories The tracks to include in the export
@@ -146,7 +146,7 @@ define(["jquery",
 
                 /**
                  * Player adapter implementation to use for the annotations tool
-                 * @alias module:annotations-tool-configuration.Configuration.playerAdapter
+                 * @alias module:annotation-tool-configuration.Configuration.playerAdapter
                  * @type {module:player-adapter.PlayerAdapter}
                  */
                 playerAdapter: undefined,
@@ -163,7 +163,7 @@ define(["jquery",
 
                 /**
                  * Define if the structured annotations are or not enabled
-                 * @alias module:annotations-tool-configuration.Configuration.isStructuredAnnotationEnabled
+                 * @alias module:annotation-tool-configuration.Configuration.isStructuredAnnotationEnabled
                  * @return {boolean} True if this feature is enabled
                  */
                 isStructuredAnnotationEnabled: function () {
@@ -172,14 +172,14 @@ define(["jquery",
 
                 /**
                  * Define if the private-only mode is enabled
-                 * @alias module:annotations-tool-configuration.Configuration.isPrivateOnly
+                 * @alias module:annotation-tool-configuration.Configuration.isPrivateOnly
                  * @type {boolean}
                  */
                 isPrivateOnly: false,
 
                 /**
                  * Define if the free text annotations are or not enabled
-                 * @alias module:annotations-tool-configuration.Configuration.isFreeTextEnabled
+                 * @alias module:annotation-tool-configuration.Configuration.isFreeTextEnabled
                  * @return {boolean} True if this feature is enabled
                  */
                 isFreeTextEnabled: function () {
@@ -188,7 +188,7 @@ define(["jquery",
 
                 /**
                  * Get the current video id (video_extid)
-                 * @alias module:annotations-tool-configuration.Configuration.getVideoExtId
+                 * @alias module:annotation-tool-configuration.Configuration.getVideoExtId
                  * @return {string} video external id
                  */
                 getVideoExtId: function () {
@@ -198,18 +198,18 @@ define(["jquery",
                 /**
                  * Returns the time interval between each timeupdate event to take into account.
                  * It can improve a bit the performance if the amount of annotations is important.
-                 * @alias module:annotations-tool-configuration.Configuration.getTimeupdateIntervalForTimeline
+                 * @alias module:annotation-tool-configuration.Configuration.getTimeupdateIntervalForTimeline
                  * @return {number} The interval
                  */
                 getTimeupdateIntervalForTimeline: function () {
                     // TODO Check if this function should be linear
-                    return Math.max(500, annotationsTool.getAnnotations().length * 3);
+                    return Math.max(500, annotationTool.getAnnotations().length * 3);
 
                 },
 
                 /**
                  * Sets the behavior of the timeline. Enable it to follow the playhead.
-                 * @alias module:annotations-tool-configuration.Configuration.timelineFollowPlayhead
+                 * @alias module:annotation-tool-configuration.Configuration.timelineFollowPlayhead
                  * @type {Boolean}
                  */
                 timelineFollowPlayhead: true,
@@ -220,7 +220,7 @@ define(["jquery",
                  *     - title: The title of the video
                  *     - src_owner: The owner of the video in the system
                  *     - src_creation_date: The date of the course, when the video itself was created.
-                 * @alias module:annotations-tool-configuration.Configuration.getVideoExtId
+                 * @alias module:annotation-tool-configuration.Configuration.getVideoExtId
                  * @example
                  * {
                  *     video_extid: 123, // Same as the value returned by getVideoExtId
@@ -241,17 +241,17 @@ define(["jquery",
 
                 /**
                  * Get the user id from the current context (user_extid)
-                 * @alias module:annotations-tool-configuration.Configuration.getUserExtId
+                 * @alias module:annotation-tool-configuration.Configuration.getUserExtId
                  * @return {string} user_extid
                  */
                 getUserExtId: function () {
-                    if (_.isUndefined(annotationsTool.userExtId)) {
+                    if (_.isUndefined(annotationTool.userExtId)) {
                         $.ajax({
                             url: "/info/me.json",
                             async: false,
                             dataType: "json",
                             success: function (data) {
-                                annotationsTool.userExtId = data.user.username;
+                                annotationTool.userExtId = data.user.username;
                             },
                             error: function () {
                                 console.warn("Error getting user information from Opencast!");
@@ -259,23 +259,23 @@ define(["jquery",
                         });
                     }
 
-                    return annotationsTool.userExtId;
+                    return annotationTool.userExtId;
                 },
 
                 /**
                  * Controls the behavior of the login form. For truthy values it is prepopulated
                  * with user data from the current context.
-                 * @alias module:annotations-tool-configuration.Configuration.useUserExtData
+                 * @alias module:annotation-tool-configuration.Configuration.useUserExtData
                  * @type {Boolean}
-                 * @see module:annotations-tool-configuration.Configuration.getUserExtData
+                 * @see module:annotation-tool-configuration.Configuration.getUserExtData
                  */
                 useUserExtData: true,
 
                 /**
                  * Skip the login form if possible, for example because user data can be extracted from the context
-                 * @alias module:annotations-tool-configuration.Configuration.skipLoginFormIfPossible
+                 * @alias module:annotation-tool-configuration.Configuration.skipLoginFormIfPossible
                  * @type {Boolean}
-                 * @see module:annotations-tool-configuration.Configuration.useUserExtData
+                 * @see module:annotation-tool-configuration.Configuration.useUserExtData
                  */
                 skipLoginFormIfPossible: true,
 
@@ -306,7 +306,7 @@ define(["jquery",
 
                 /**
                  * Maps a list of roles of the external user to a corresponding user role
-                 * @alias module:annotations-tool-configuration.Configuration.getUserRoleFromExt
+                 * @alias module:annotation-tool-configuration.Configuration.getUserRoleFromExt
                  * @param {string[]} roles The roles of the external user
                  * @return {ROLE} The corresponding user role in the annotations tool
                  */
@@ -330,7 +330,7 @@ define(["jquery",
 
                 /**
                  * Get the name of the admin role
-                 * @alias module:annotations-tool-configuration.Configuration.getAdminRoleName
+                 * @alias module:annotation-tool-configuration.Configuration.getAdminRoleName
                  * @return {ROLE} The name of the admin role
                  */
                 getAdminRoleName: function () {
@@ -339,7 +339,7 @@ define(["jquery",
 
                 /**
                  * Function to load the video
-                 * @alias module:annotations-tool-configuration.Configuration.loadVideo
+                 * @alias module:annotation-tool-configuration.Configuration.loadVideo
                  */
                 loadVideo: function () {
                     var // Supported video formats

--- a/frontend/build/profiles/local/annotation-tool-configuration.js
+++ b/frontend/build/profiles/local/annotation-tool-configuration.js
@@ -16,7 +16,7 @@
 
 /**
  * Module containing the tool configuration
- * @module annotations-tool-configuration
+ * @module annotation-tool-configuration
  */
 define(["jquery",
         "underscore",
@@ -25,21 +25,21 @@ define(["jquery",
         // Add here the files (PlayerAdapter, ...) required for your configuration
         ],
 
-    function ($, _, ROLES, HTML5PlayerAdapter) {
+    function ($, _, ROLES, HTML5PlayerAdapter, LoopView) {
 
         "use strict";
 
         /**
          * Annotations tool configuration object
-         * @alias module:annotations-tool-configuration.Configuration
+         * @alias module:annotation-tool-configuration.Configuration
          * @enum
          */
         var Configuration =  {
 
             /**
              * List of possible layout configuration
-             * @alias module:annotations-tool-configuration.Configuration.LAYOUT_CONFIGURATION
-             * @memberOf module:annotations-tool-configuration.Configuration
+             * @alias module:annotation-tool-configuration.Configuration.LAYOUT_CONFIGURATION
+             * @memberOf module:annotation-tool-configuration.Configuration
              * @type {Object}
              */
             LAYOUT_CONFIGURATION: {
@@ -48,18 +48,10 @@ define(["jquery",
                     timeline : true,
                     list     : true,
                     annotate : true,
-                    loop     : false,
+                    loop     : false
                 }
             },
 
-            /**
-             * Possible tracks selection at startup
-             * @type {Object}
-             */
-            TRACKS: {
-                MINE   : "mine",
-                PUBLIC : "public"
-            },
 
             /**
              * The default tracks at startup
@@ -75,31 +67,30 @@ define(["jquery",
             },
 
             /**
+             * The maximal number of tracks visible in the timeline at the same time
+             * @type {Number}
+             */
+            MAX_VISIBLE_TRACKS: 0,
+
+            /**
              * The minmal duration used for annotation representation on timeline
-             * @alias module:annotations-tool-configuration.Configuration.MINIMAL_DURATION
-             * @memberOf module:annotations-tool-configuration.Configuration
+             * @alias module:annotation-tool-configuration.Configuration.MINIMAL_DURATION
+             * @memberOf module:annotation-tool-configuration.Configuration
              * @type {Object}
              */
             MINIMAL_DURATION: 5,
 
             /**
              * Define the number of categories pro tab in the annotate box. Bigger is number, thinner will be the columns for the categories.
-             * @alias module:annotations-tool-configuration.Configuration.CATEGORIES_PER_TAB
-             * @memberOf module:annotations-tool-configuration.Configuration
+             * @alias module:annotation-tool-configuration.Configuration.CATEGORIES_PER_TAB
+             * @memberOf module:annotation-tool-configuration.Configuration
              * @type {Number}
              */
             CATEGORIES_PER_TAB: 7,
 
             /**
-             * The maximal number of tracks visible in the timeline at the same time
-             * @type {Number}
-             */
-            MAX_VISIBLE_TRACKS: 0,
-
-
-            /**
              * Define if the localStorage should be used or not
-             * @alias module:annotations-tool-configuration.Configuration.localStorage
+             * @alias module:annotation-tool-configuration.Configuration.localStorage
              * @type {boolean}
              * @readOnly
              */
@@ -115,14 +106,14 @@ define(["jquery",
             plugins: {
                 Loop: function () {
                     require(["views/loop"], function (Loop) {
-                        annotationsTool.loopView = new Loop();
+                        annotationTool.loopView = new Loop();
                     });
                 }
             },
 
             /**
              * Url from the annotations Rest Endpoints
-             * @alias module:annotations-tool-configuration.Configuration.restEndpointsUrl
+             * @alias module:annotation-tool-configuration.Configuration.restEndpointsUrl
              * @type {string}
              * @readOnly
              */
@@ -130,23 +121,15 @@ define(["jquery",
 
             /**
              * Url for redirect after the logout
-             * @alias module:annotations-tool-configuration.Configuration.logoutUrl
+             * @alias module:annotation-tool-configuration.Configuration.logoutUrl
              * @type {string}
              * @readOnly
              */
             logoutUrl: undefined,
 
             /**
-             * Url from the export function for statistics usage
-             * @alias module:annotations-tool-configuration.Configuration.exportUrl
-             * @type {string}
-             * @readOnly
-             */
-            exportUrl: "",
-
-            /**
              * Player adapter implementation to use for the annotations tool
-             * @alias module:annotations-tool-configuration.Configuration.playerAdapter
+             * @alias module:annotation-tool-configuration.Configuration.playerAdapter
              * @type {module:player-adapter.PlayerAdapter}
              */
             playerAdapter: undefined,
@@ -158,23 +141,6 @@ define(["jquery",
             tracksToImport: undefined,
 
             /**
-             * Formats the given date in 
-             * @alias module:annotations-tool-configuration.Configuration.formatDate
-             * @type {module:player-adapter.formatDate}
-             */
-            formatDate: function (date) {
-                if (_.isNumber(date)) {
-                    date = new Date(date);
-                }
-
-                if (_.isDate(date)) {
-                    return date.getDate() + "." + (date.getMonth() + 1) + "." + date.getFullYear();
-                } else {
-                    return "Unvalid date";
-                }
-            },
-
-            /**
              * Get the tool layout configuration
              * @return {object} The tool layout configuration
              */
@@ -184,7 +150,7 @@ define(["jquery",
 
             /**
              * Define if the structured annotations are or not enabled
-             * @alias module:annotations-tool-configuration.Configuration.isStructuredAnnotationEnabled
+             * @alias module:annotation-tool-configuration.Configuration.isStructuredAnnotationEnabled
              * @return {boolean} True if this feature is enabled
              */
             isStructuredAnnotationEnabled: function () {
@@ -193,14 +159,14 @@ define(["jquery",
 
             /**
              * Define if the private-only mode is enabled
-             * @alias module:annotations-tool-configuration.Configuration.isPrivateOnly
-             * @type {boolean}
+             * @alias module:annotation-tool-configuration.Configuration.isPrivateOnly
+             * @return {boolean} True if this mode is enabled
              */
             isPrivateOnly: false,
 
             /**
              * Define if the free text annotations are or not enabled
-             * @alias module:annotations-tool-configuration.Configuration.isFreeTextEnabled
+             * @alias module:annotation-tool-configuration.Configuration.isFreeTextEnabled
              * @return {boolean} True if this feature is enabled
              */
             isFreeTextEnabled: function () {
@@ -209,7 +175,7 @@ define(["jquery",
 
             /**
              * Get the current video id (video_extid)
-             * @alias module:annotations-tool-configuration.Configuration.getVideoExtId
+             * @alias module:annotation-tool-configuration.Configuration.getVideoExtId
              * @return {string} video external id
              */
             getVideoExtId: function () {
@@ -219,18 +185,18 @@ define(["jquery",
             /**
              * Returns the time interval between each timeupdate event to take into account.
              * It can improve a bit the performance if the amount of annotations is important. 
-             * @alias module:annotations-tool-configuration.Configuration.getTimeupdateIntervalForTimeline
+             * @alias module:annotation-tool-configuration.Configuration.getTimeupdateIntervalForTimeline
              * @return {number} The interval
              */
             getTimeupdateIntervalForTimeline: function () {
                 // TODO Check if this function should be linear
-                return Math.max(500, annotationsTool.getAnnotations().length * 3);
+                return Math.max(500, annotationTool.getAnnotations().length * 3);
 
             },
 
             /**
              * Sets the behavior of the timeline. Enable it to follow the playhead.
-             * @alias module:annotations-tool-configuration.Configuration.timelineFollowPlayhead
+             * @alias module:annotation-tool-configuration.Configuration.timelineFollowPlayhead
              * @type {Boolean}
              */
             timelineFollowPlayhead: true,
@@ -241,7 +207,7 @@ define(["jquery",
              *     - title: The title of the video
              *     - src_owner: The owner of the video in the system
              *     - src_creation_date: The date of the course, when the video itself was created.
-             * @alias module:annotations-tool-configuration.Configuration.getVideoExtId
+             * @alias module:annotation-tool-configuration.Configuration.getVideoExtId
              * @example
              * {
              *     video_extid: 123, // Same as the value returned by getVideoExtId
@@ -262,16 +228,16 @@ define(["jquery",
 
             /**
              * Get the user id from the current context (user_extid)
-             * @alias module:annotations-tool-configuration.Configuration.getUserExtId
+             * @alias module:annotation-tool-configuration.Configuration.getUserExtId
              * @return {string} user_extid
              */
-            getUserExtId: function () {
-                return "default";
+            getUserExtId: function (email) {
+                return email;
             },
 
             /**
              * Get the name of the admin role
-             * @alias module:annotations-tool-configuration.Configuration.getAdminRoleName
+             * @alias module:annotation-tool-configuration.Configuration.getAdminRoleName
              * @return {ROLE} The name of the admin role
              */
             getAdminRoleName: function () {
@@ -280,7 +246,7 @@ define(["jquery",
 
             /**
              * Get the user authentification token if existing
-             * @alias module:annotations-tool-configuration.Configuration.getUserAuthToken
+             * @alias module:annotation-tool-configuration.Configuration.getUserAuthToken
              * @return {string} Current user token
              */
             getUserAuthToken: function () {
@@ -289,10 +255,10 @@ define(["jquery",
 
             /**
              * Function to load the video
-             * @alias module:annotations-tool-configuration.Configuration.loadVideo
+             * @alias module:annotation-tool-configuration.Configuration.loadVideo
              */
             loadVideo: function () {
-                annotationsTool.playerAdapter = new HTML5PlayerAdapter($("video")[0]);
+                this.playerAdapter = new HTML5PlayerAdapter($("video")[0]);
             }
         };
 

--- a/frontend/js/annotation-sync.js
+++ b/frontend/js/annotation-sync.js
@@ -29,7 +29,7 @@ define(["underscore", "backbone", "localstorage"], function (_, Backbone) {
      * @alias module:annotation-sync.annotationSync
      */
     var annotationSync = function (method, model, options) {
-        if (annotationsTool.localStorage || model.localStorageOnly) {
+        if (annotationTool.localStorage || model.localStorageOnly) {
             return Backbone.localSync.call(this, method, model, options);
         }
 
@@ -42,10 +42,10 @@ define(["underscore", "backbone", "localstorage"], function (_, Backbone) {
         options.data = options.attrs || model.toJSON(options);
 
         // Path along authentication data
-        if (annotationsTool.user) {
-            options.headers["X-ANNOTATIONS-USER-ID"] = annotationsTool.user.id;
+        if (annotationTool.user) {
+            options.headers["X-ANNOTATIONS-USER-ID"] = annotationTool.user.id;
         }
-        var authToken = _.result(annotationsTool, 'getUserAuthToken');
+        var authToken = _.result(annotationTool, 'getUserAuthToken');
         if (authToken) {
             options.headers["X-ANNOTATIONS-USER-AUTH-TOKEN"] = authToken;
         }

--- a/frontend/js/annotation-tool-configuration.js
+++ b/frontend/js/annotation-tool-configuration.js
@@ -16,7 +16,7 @@
 
 /**
  * Module containing the tool configuration
- * @module annotations-tool-configuration
+ * @module annotation-tool-configuration
  */
 define(["jquery",
         "underscore",
@@ -25,21 +25,21 @@ define(["jquery",
         // Add here the files (PlayerAdapter, ...) required for your configuration
         ],
 
-    function ($, _, ROLES, HTML5PlayerAdapter, LoopView) {
+    function ($, _, ROLES, HTML5PlayerAdapter) {
 
         "use strict";
 
         /**
          * Annotations tool configuration object
-         * @alias module:annotations-tool-configuration.Configuration
+         * @alias module:annotation-tool-configuration.Configuration
          * @enum
          */
         var Configuration =  {
 
             /**
              * List of possible layout configuration
-             * @alias module:annotations-tool-configuration.Configuration.LAYOUT_CONFIGURATION
-             * @memberOf module:annotations-tool-configuration.Configuration
+             * @alias module:annotation-tool-configuration.Configuration.LAYOUT_CONFIGURATION
+             * @memberOf module:annotation-tool-configuration.Configuration
              * @type {Object}
              */
             LAYOUT_CONFIGURATION: {
@@ -48,10 +48,18 @@ define(["jquery",
                     timeline : true,
                     list     : true,
                     annotate : true,
-                    loop     : false
+                    loop     : false,
                 }
             },
 
+            /**
+             * Possible tracks selection at startup
+             * @type {Object}
+             */
+            TRACKS: {
+                MINE   : "mine",
+                PUBLIC : "public"
+            },
 
             /**
              * The default tracks at startup
@@ -67,30 +75,31 @@ define(["jquery",
             },
 
             /**
-             * The maximal number of tracks visible in the timeline at the same time
-             * @type {Number}
-             */
-            MAX_VISIBLE_TRACKS: 0,
-
-            /**
              * The minmal duration used for annotation representation on timeline
-             * @alias module:annotations-tool-configuration.Configuration.MINIMAL_DURATION
-             * @memberOf module:annotations-tool-configuration.Configuration
+             * @alias module:annotation-tool-configuration.Configuration.MINIMAL_DURATION
+             * @memberOf module:annotation-tool-configuration.Configuration
              * @type {Object}
              */
             MINIMAL_DURATION: 5,
 
             /**
              * Define the number of categories pro tab in the annotate box. Bigger is number, thinner will be the columns for the categories.
-             * @alias module:annotations-tool-configuration.Configuration.CATEGORIES_PER_TAB
-             * @memberOf module:annotations-tool-configuration.Configuration
+             * @alias module:annotation-tool-configuration.Configuration.CATEGORIES_PER_TAB
+             * @memberOf module:annotation-tool-configuration.Configuration
              * @type {Number}
              */
             CATEGORIES_PER_TAB: 7,
 
             /**
+             * The maximal number of tracks visible in the timeline at the same time
+             * @type {Number}
+             */
+            MAX_VISIBLE_TRACKS: 0,
+
+
+            /**
              * Define if the localStorage should be used or not
-             * @alias module:annotations-tool-configuration.Configuration.localStorage
+             * @alias module:annotation-tool-configuration.Configuration.localStorage
              * @type {boolean}
              * @readOnly
              */
@@ -106,14 +115,14 @@ define(["jquery",
             plugins: {
                 Loop: function () {
                     require(["views/loop"], function (Loop) {
-                        annotationsTool.loopView = new Loop();
+                        annotationTool.loopView = new Loop();
                     });
                 }
             },
 
             /**
              * Url from the annotations Rest Endpoints
-             * @alias module:annotations-tool-configuration.Configuration.restEndpointsUrl
+             * @alias module:annotation-tool-configuration.Configuration.restEndpointsUrl
              * @type {string}
              * @readOnly
              */
@@ -121,15 +130,23 @@ define(["jquery",
 
             /**
              * Url for redirect after the logout
-             * @alias module:annotations-tool-configuration.Configuration.logoutUrl
+             * @alias module:annotation-tool-configuration.Configuration.logoutUrl
              * @type {string}
              * @readOnly
              */
             logoutUrl: undefined,
 
             /**
+             * Url from the export function for statistics usage
+             * @alias module:annotation-tool-configuration.Configuration.exportUrl
+             * @type {string}
+             * @readOnly
+             */
+            exportUrl: "",
+
+            /**
              * Player adapter implementation to use for the annotations tool
-             * @alias module:annotations-tool-configuration.Configuration.playerAdapter
+             * @alias module:annotation-tool-configuration.Configuration.playerAdapter
              * @type {module:player-adapter.PlayerAdapter}
              */
             playerAdapter: undefined,
@@ -141,6 +158,23 @@ define(["jquery",
             tracksToImport: undefined,
 
             /**
+             * Formats the given date in 
+             * @alias module:annotation-tool-configuration.Configuration.formatDate
+             * @type {module:player-adapter.formatDate}
+             */
+            formatDate: function (date) {
+                if (_.isNumber(date)) {
+                    date = new Date(date);
+                }
+
+                if (_.isDate(date)) {
+                    return date.getDate() + "." + (date.getMonth() + 1) + "." + date.getFullYear();
+                } else {
+                    return "Unvalid date";
+                }
+            },
+
+            /**
              * Get the tool layout configuration
              * @return {object} The tool layout configuration
              */
@@ -150,7 +184,7 @@ define(["jquery",
 
             /**
              * Define if the structured annotations are or not enabled
-             * @alias module:annotations-tool-configuration.Configuration.isStructuredAnnotationEnabled
+             * @alias module:annotation-tool-configuration.Configuration.isStructuredAnnotationEnabled
              * @return {boolean} True if this feature is enabled
              */
             isStructuredAnnotationEnabled: function () {
@@ -159,14 +193,14 @@ define(["jquery",
 
             /**
              * Define if the private-only mode is enabled
-             * @alias module:annotations-tool-configuration.Configuration.isPrivateOnly
-             * @return {boolean} True if this mode is enabled
+             * @alias module:annotation-tool-configuration.Configuration.isPrivateOnly
+             * @type {boolean}
              */
             isPrivateOnly: false,
 
             /**
              * Define if the free text annotations are or not enabled
-             * @alias module:annotations-tool-configuration.Configuration.isFreeTextEnabled
+             * @alias module:annotation-tool-configuration.Configuration.isFreeTextEnabled
              * @return {boolean} True if this feature is enabled
              */
             isFreeTextEnabled: function () {
@@ -175,7 +209,7 @@ define(["jquery",
 
             /**
              * Get the current video id (video_extid)
-             * @alias module:annotations-tool-configuration.Configuration.getVideoExtId
+             * @alias module:annotation-tool-configuration.Configuration.getVideoExtId
              * @return {string} video external id
              */
             getVideoExtId: function () {
@@ -185,18 +219,18 @@ define(["jquery",
             /**
              * Returns the time interval between each timeupdate event to take into account.
              * It can improve a bit the performance if the amount of annotations is important. 
-             * @alias module:annotations-tool-configuration.Configuration.getTimeupdateIntervalForTimeline
+             * @alias module:annotation-tool-configuration.Configuration.getTimeupdateIntervalForTimeline
              * @return {number} The interval
              */
             getTimeupdateIntervalForTimeline: function () {
                 // TODO Check if this function should be linear
-                return Math.max(500, annotationsTool.getAnnotations().length * 3);
+                return Math.max(500, annotationTool.getAnnotations().length * 3);
 
             },
 
             /**
              * Sets the behavior of the timeline. Enable it to follow the playhead.
-             * @alias module:annotations-tool-configuration.Configuration.timelineFollowPlayhead
+             * @alias module:annotation-tool-configuration.Configuration.timelineFollowPlayhead
              * @type {Boolean}
              */
             timelineFollowPlayhead: true,
@@ -207,7 +241,7 @@ define(["jquery",
              *     - title: The title of the video
              *     - src_owner: The owner of the video in the system
              *     - src_creation_date: The date of the course, when the video itself was created.
-             * @alias module:annotations-tool-configuration.Configuration.getVideoExtId
+             * @alias module:annotation-tool-configuration.Configuration.getVideoExtId
              * @example
              * {
              *     video_extid: 123, // Same as the value returned by getVideoExtId
@@ -228,16 +262,16 @@ define(["jquery",
 
             /**
              * Get the user id from the current context (user_extid)
-             * @alias module:annotations-tool-configuration.Configuration.getUserExtId
+             * @alias module:annotation-tool-configuration.Configuration.getUserExtId
              * @return {string} user_extid
              */
-            getUserExtId: function (email) {
-                return email;
+            getUserExtId: function () {
+                return "default";
             },
 
             /**
              * Get the name of the admin role
-             * @alias module:annotations-tool-configuration.Configuration.getAdminRoleName
+             * @alias module:annotation-tool-configuration.Configuration.getAdminRoleName
              * @return {ROLE} The name of the admin role
              */
             getAdminRoleName: function () {
@@ -246,7 +280,7 @@ define(["jquery",
 
             /**
              * Get the user authentification token if existing
-             * @alias module:annotations-tool-configuration.Configuration.getUserAuthToken
+             * @alias module:annotation-tool-configuration.Configuration.getUserAuthToken
              * @return {string} Current user token
              */
             getUserAuthToken: function () {
@@ -255,10 +289,10 @@ define(["jquery",
 
             /**
              * Function to load the video
-             * @alias module:annotations-tool-configuration.Configuration.loadVideo
+             * @alias module:annotation-tool-configuration.Configuration.loadVideo
              */
             loadVideo: function () {
-                this.playerAdapter = new HTML5PlayerAdapter($("video")[0]);
+                annotationTool.playerAdapter = new HTML5PlayerAdapter($("video")[0]);
             }
         };
 

--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -16,7 +16,7 @@
 
 /**
  * Module containing the tool main object
- * @module annotations-tool
+ * @module annotation-tool
  * @requires jQuery
  * @requires backbone
  * @requires i18next
@@ -53,9 +53,9 @@ define(["jquery",
 
         /**
          * The main object of the annotations tool
-         * @namespace annotationsTool
+         * @namespace annotationTool
          */
-        var annotationsTool = window.annotationsTool = _.extend({
+        var annotationTool = window.annotationTool = _.extend({
 
             EVENTS: {
                 ANNOTATION_SELECTION : "at:annotation-selection",
@@ -134,8 +134,8 @@ define(["jquery",
 
             /**
              * Initialize the tool
-             * @alias   annotationsTool.start
-             * @param  {module:annotations-tool-configuration.Configuration} config The tool configuration
+             * @alias   annotationTool.start
+             * @param  {module:annotation-tool-configuration.Configuration} config The tool configuration
              */
             start: function (config) {
                 _.bindAll(this, "updateSelectionOnTimeUpdate",
@@ -240,7 +240,7 @@ define(["jquery",
 
             /**
              * Formats the given date
-             * @alias annotationsTool.formatDate
+             * @alias annotationTool.formatDate
              */
             formatDate: function (date) {
                 return moment(date).format("L");
@@ -248,7 +248,7 @@ define(["jquery",
 
             /**
              * Log in the current user of the tool
-             * @alias annotationsTool.login
+             * @alias annotationTool.login
              * @param {Object} The Attributes of the user that is to be logged in.
              * @param {Object} callbacks Callbacks for the user creation
              * @return {User} The logged in user
@@ -267,7 +267,7 @@ define(["jquery",
 
             /**
              * Display an alert modal
-             * @alias   annotationsTool.alertError
+             * @alias   annotationTool.alertError
              * @param  {String} message The message to display
              */
             alertError: function (message) {
@@ -278,7 +278,7 @@ define(["jquery",
              * Display a fatal error.
              * In addition to what {@link alertError} does, this also disables user interaction.
              * It effectively "crashes" the application with a (hopefully useful) error message.
-             * @alias annotationsTool.alertFatal
+             * @alias annotationTool.alertFatal
              * @param {String} message The error message to display
              */
             alertFatal: function (message) {
@@ -287,7 +287,7 @@ define(["jquery",
 
             /**
              * Display an warning modal
-             * @alias   annotationsTool.alertWarning
+             * @alias   annotationTool.alertWarning
              * @param  {String} message The message to display
              */
             alertWarning: function (message) {
@@ -296,7 +296,7 @@ define(["jquery",
 
             /**
              * Display an information modal
-             * @alias   annotationsTool.alertInfo
+             * @alias   annotationTool.alertInfo
              * @param  {String} message The message to display
              */
             alertInfo: function (message) {
@@ -305,7 +305,7 @@ define(["jquery",
 
             /**
              * Function to init the delete warning modal
-             * @alias   annotationsTool.initDeleteModal
+             * @alias   annotationTool.initDeleteModal
              */
             initDeleteModal: function () {
                 $("#dialogs").append(this.deleteModalTmpl({type: "annotation"}));
@@ -317,7 +317,7 @@ define(["jquery",
 
             /**
              * Transform time in seconds (i.e. 12.344) into a well formated time (01:12:04)
-             * @alias   annotationsTool.getWellFormatedTime
+             * @alias   annotationTool.getWellFormatedTime
              * @param {number} time the time in seconds
              * @param {boolean} [noRounted] Define if the number should be rounded or if the decimal should be simply removed. Default is rounding (false). 
              */
@@ -335,7 +335,7 @@ define(["jquery",
 
             /**
              * Check if the current browser is Safari 6
-             * @alias   annotationsTool.isBrowserSafari6
+             * @alias   annotationTool.isBrowserSafari6
              * @return {boolean} true if the browser is safari 6, otherwise false
              */
             isBrowserSafari6: function () {
@@ -344,7 +344,7 @@ define(["jquery",
 
             /**
              * Check if the current browser is Microsoft Internet Explorer 9
-             * @alias   annotationsTool.isBrowserIE9
+             * @alias   annotationTool.isBrowserIE9
              * @return {boolean} true if the browser is IE9, otherwise false
              */
             isBrowserIE9: function () {
@@ -353,7 +353,7 @@ define(["jquery",
 
             /**
              * Listener for mouse down event to get infos about the click
-             * @alias   annotationsTool.onMouseDown
+             * @alias   annotationTool.onMouseDown
              */
             onMouseDown: function () {
                 this.timeMouseDown = undefined;
@@ -363,7 +363,7 @@ define(["jquery",
 
             /**
              * Listener for mouse up event to get infos about the click
-             * @alias   annotationsTool.onMouseUp
+             * @alias   annotationTool.onMouseUp
              */
             onMouseUp: function () {
                 this.timeMouseDown = new Date() - this.startMouseDown;
@@ -373,7 +373,7 @@ define(["jquery",
 
             /**
              * Listen and retrigger timeupdate event from player adapter events with added intervals
-             * @alias   annotationsTool.onTimeUpdate
+             * @alias   annotationTool.onTimeUpdate
              */
             onTimeUpdate: function () {
                 var currentPlayerTime = this.playerAdapter.getCurrentTime(),
@@ -414,7 +414,7 @@ define(["jquery",
 
             /**
              * Add a timeupdate listener with the given interval
-             * @alias   annotationsTool.addTimeupdateListener
+             * @alias   annotationTool.addTimeupdateListener
              * @param {Object} callback the listener callback
              * @param {Number} (interval) the interval between each timeupdate event
              */
@@ -449,7 +449,7 @@ define(["jquery",
 
             /**
              * Remove the given timepudate listener
-             * @alias   annotationsTool.removeTimeupdateListener
+             * @alias   annotationTool.removeTimeupdateListener
              * @param {Object} callback the listener callback
              * @param {Number} (interval) the interval between each timeupdate event
              */
@@ -469,7 +469,7 @@ define(["jquery",
 
             /**
              * Proxy to select annotation by Id on mouse click
-             * @alias   annotationsTool.onClickSelectionById
+             * @alias   annotationTool.onClickSelectionById
              * @param {Array} selection The new selection. This is an array of object containing the id of the annotation and optionnaly the track id. See example below.
              * @example
              * {
@@ -487,7 +487,7 @@ define(["jquery",
 
             /**
              * Listener for destroy event on selected annotation to update the selection
-             * @alias   annotationsTool.onDestroyRemoveSelection
+             * @alias   annotationTool.onDestroyRemoveSelection
              * @param  {Object} annotation The destroyed annotation
              */
             onDestroyRemoveSelection: function (annotation) {
@@ -507,7 +507,7 @@ define(["jquery",
 
             /**
              * Set the given annotation(s) as current selection
-             * @alias   annotationsTool.setSelectionById
+             * @alias   annotationTool.setSelectionById
              * @param {Array} selection The new selection. This is an array of object containing the id of the annotation and optionnaly the track id. See example below.
              * @example
              * {
@@ -537,7 +537,7 @@ define(["jquery",
 
             /**
              * Set the given annotation(s) as current selection
-             * @alias   annotationsTool.setSelection
+             * @alias   annotationTool.setSelection
              * @param {Array} selection The new selection
              * @param {Boolean} moveTo define if the video should be move to the start point of the selection
              * @param {Boolean} isManuallySelected define if the selection has been done manually or through a video timeupdate
@@ -622,7 +622,7 @@ define(["jquery",
 
             /**
              * Returns the current selection of the tool
-             * @alias   annotationsTool.getSelection
+             * @alias   annotationTool.getSelection
              * @return {Annotation} The current selection or undefined if no selection.
              */
             getSelection: function () {
@@ -631,7 +631,7 @@ define(["jquery",
 
             /**
              * Informs if there is or not some items selected
-             * @alias   annotationsTool.hasSelection
+             * @alias   annotationTool.hasSelection
              * @return {Boolean} true if an annotation is selected or false.
              */
             hasSelection: function () {
@@ -640,7 +640,7 @@ define(["jquery",
 
             /**
              * Update the ordering of the tracks and alert everyone who is interested.
-             * @alias  annotationsTool.orderTracks
+             * @alias  annotationTool.orderTracks
              * @param {Array} order The new track order
              */
             orderTracks: function (order) {
@@ -650,7 +650,7 @@ define(["jquery",
 
             /**
              * Get all annotations that cover a given point in time.
-             * @alias   annotationsTool.getCurrentAnnotations
+             * @alias   annotationTool.getCurrentAnnotations
              * @param {Number} [time] The time you are interested in or the current player time if omitted
              */
             getCurrentAnnotations: function (time) {
@@ -667,7 +667,7 @@ define(["jquery",
 
             /**
              * Listener for player "timeupdate" event to highlight the current annotations
-             * @alias   annotationsTool.updateSelectionOnTimeUpdate
+             * @alias   annotationTool.updateSelectionOnTimeUpdate
              */
             updateSelectionOnTimeUpdate: function () {
                 var currentTime = this.playerAdapter.getCurrentTime(),
@@ -688,7 +688,7 @@ define(["jquery",
 
             /**
              * Listener for player "timeupdate" event to open the current annotations in the list view
-             * @alias   annotationsTool.potentiallyOpenCurrentItems
+             * @alias   annotationTool.potentiallyOpenCurrentItems
              */
             potentiallyOpenCurrentItems: function () {
                 var previousAnnotations = [];
@@ -716,7 +716,7 @@ define(["jquery",
 
             /**
              * Create a new track
-             * @alias   annotationsTool.createTrack
+             * @alias   annotationTool.createTrack
              * @param  {Object} parameters The content of the new track
              * @param  {Object} (options) The options for the Backone.js options for the model creation
              * @return {Object}  The created track
@@ -735,7 +735,7 @@ define(["jquery",
              * If it does not specify a `start` time, the current time of the playhead is used.
              * This function also makes the new annotation the "active" annotation which is operated on
              * by global operations like keyboard shortcuts.
-             * @alias annotationsTool.createAnnotation
+             * @alias annotationTool.createAnnotation
              * @param {Object} params The content of the new annotation
              * @return {Object} The created annotation
              */
@@ -771,7 +771,7 @@ define(["jquery",
 
             /**
              * Get the track with the given Id
-             * @alias   annotationsTool.getTrack
+             * @alias   annotationTool.getTrack
              * @param  {String} id The track Id
              * @return {Object}    The track object or undefined if not found
              */
@@ -786,7 +786,7 @@ define(["jquery",
 
             /**
              * Get all the tracks
-             * @alias   annotationsTool.getTracks
+             * @alias   annotationTool.getTracks
              * @return {Object}    The list of the tracks
              */
             getTracks: function () {
@@ -800,7 +800,7 @@ define(["jquery",
 
             /**
              * Get the track with the given Id
-             * @alias   annotationsTool.getTrack
+             * @alias   annotationTool.getTrack
              * @param  {String} id The track Id
              * @return {Object}    The track object or undefined if not found
              */
@@ -810,7 +810,7 @@ define(["jquery",
 
             /**
              * Select the given track
-             * @alias   annotationsTool.selectTrack
+             * @alias   annotationTool.selectTrack
              * @param  {Object} track the track to select
              */
             selectTrack: function (track) {
@@ -820,7 +820,7 @@ define(["jquery",
 
             /**
              * Get the annotation with the given Id
-             * @alias   annotationsTool.getAnnotation
+             * @alias   annotationTool.getAnnotation
              * @param  {String} annotationId The annotation 
              * @param  {String} (trackId)      The track Id (Optional)
              * @return {Object}   The annotation object or undefined if not found
@@ -860,7 +860,7 @@ define(["jquery",
 
             /**
              * Get an array containning all the annotations or only the ones from the given track
-             * @alias   annotationsTool.getAnnotations
+             * @alias   annotationTool.getAnnotations
              * @param  {String} (trackId)      The track Id (Optional)
              * @return {Array}   The annotations
              */
@@ -893,7 +893,7 @@ define(["jquery",
 
             /**
              * Import the given tracks in the tool
-             * @alias annotationsTool.importTracks
+             * @alias annotationTool.importTracks
              * @param {PlainObject} tracks Object containing the tracks in the tool
              */
             importTracks: function (tracks) {
@@ -909,7 +909,7 @@ define(["jquery",
 
             /**
              * Import the given categories in the tool
-             * @alias annotationsTool.importCategories
+             * @alias annotationTool.importCategories
              * @param {PlainObject} imported Object containing the .categories and .scales to insert in the tool
              * @param {PlainObject} defaultCategoryAttributes The default attributes to use to insert the imported categories (like access)
              */
@@ -965,7 +965,7 @@ define(["jquery",
 
             /**
              * Delete the annotation with the given id with the track with the given track id
-             * @alias annotationsTool.deleteAnnotation
+             * @alias annotationTool.deleteAnnotation
              * @param {Integer} annotationId The id of the annotation to delete
              * @param {Integer} trackId Id of the track containing the annotation
              */
@@ -992,7 +992,7 @@ define(["jquery",
 
             /**
              * Get all the annotations for the current user
-             * @alias annotationsTool.fetchData
+             * @alias annotationTool.fetchData
              */
             fetchData: function () {
                 var video,
@@ -1097,7 +1097,7 @@ define(["jquery",
          *   }
          * }
          */
-        annotationsTool.deleteOperation.targetTypes = {
+        annotationTool.deleteOperation.targetTypes = {
 
             ANNOTATION: {
                 name: "annotation",
@@ -1109,15 +1109,15 @@ define(["jquery",
                     target.destroy({
 
                         success: function () {
-                            if (annotationsTool.localStorage) {
-                                annotationsTool.video.get("tracks").each(function (value) {
+                            if (annotationTool.localStorage) {
+                                annotationTool.video.get("tracks").each(function (value) {
                                     if (value.get("annotations").get(target.id)) {
                                         value.get("annotations").remove(target);
                                         value.save({wait: true});
                                         return false;
                                     }
                                 });
-                                annotationsTool.video.save();
+                                annotationTool.video.save();
                             }
                             if (callback) {
                                 callback();
@@ -1141,12 +1141,12 @@ define(["jquery",
                     target.destroy({
 
                         success: function () {
-                            if (annotationsTool.localStorage) {
+                            if (annotationTool.localStorage) {
                                 if (target.collection) {
                                     target.collection.remove(target);
                                 }
 
-                                annotationsTool.video.save();
+                                annotationTool.video.save();
                             }
                             if (callback) {
                                 callback();
@@ -1168,11 +1168,11 @@ define(["jquery",
                     target.destroy({
 
                         success: function () {
-                            if (annotationsTool.localStorage) {
+                            if (annotationTool.localStorage) {
                                 if (target.collection) {
                                     target.collection.remove(target);
                                 }
-                                annotationsTool.video.save();
+                                annotationTool.video.save();
                             }
                             if (callback) {
                                 callback();
@@ -1217,8 +1217,8 @@ define(["jquery",
                     destroyAnnotation();
                     track.destroy({
                         success: function () {
-                            if (annotationsTool.localStorage) {
-                                annotationsTool.video.save();
+                            if (annotationTool.localStorage) {
+                                annotationTool.video.save();
                             }
                             if (callback) {
                                 callback();
@@ -1264,8 +1264,8 @@ define(["jquery",
                     destroyLabels();
                     category.destroy({
                         success: function () {
-                            if (annotationsTool.localStorage) {
-                                annotationsTool.video.save();
+                            if (annotationTool.localStorage) {
+                                annotationTool.video.save();
                             }
                             if (callback) {
                                 callback();
@@ -1288,12 +1288,12 @@ define(["jquery",
                     target.destroy({
 
                         success: function () {
-                            if (window.annotationsTool.localStorage) {
+                            if (window.annotationTool.localStorage) {
                                 if (target.collection) {
                                     target.collection.remove(target);
                                 }
 
-                                annotationsTool.video.save();
+                                annotationTool.video.save();
                             }
                             if (callback) {
                                 callback();
@@ -1340,8 +1340,8 @@ define(["jquery",
 
                     scale.destroy({
                         success: function () {
-                            if (window.annotationsTool.localStorage) {
-                                annotationsTool.video.save();
+                            if (window.annotationTool.localStorage) {
+                                annotationTool.video.save();
                             }
                             if (callback) {
                                 callback();
@@ -1355,6 +1355,6 @@ define(["jquery",
             }
         };
 
-        return annotationsTool;
+        return annotationTool;
     }
 );

--- a/frontend/js/collections/annotations.js
+++ b/frontend/js/collections/annotations.js
@@ -140,7 +140,7 @@ define(["jquery",
                     this.url = track.url() + "/annotations";
                 }
 
-                if (window.annotationsTool && annotationsTool.localStorage) {
+                if (window.annotationTool && annotationTool.localStorage) {
                     this.localStorage = new Backbone.LocalStorage(this.url);
                 }
             }

--- a/frontend/js/collections/categories.js
+++ b/frontend/js/collections/categories.js
@@ -87,14 +87,14 @@ define(["jquery",
              */
             setUrl: function (video) {
                 if (!video || !video.collection) { // If a template
-                    this.url = window.annotationsTool.restEndpointsUrl + "/categories";
+                    this.url = window.annotationTool.restEndpointsUrl + "/categories";
                     this.isTemplate = true;
                 } else {  // If not a template, we add video url
                     this.url = video.url() + "/categories";
                     this.isTemplate = false;
                 }
 
-                if (annotationsTool && annotationsTool.localStorage) {
+                if (annotationTool && annotationTool.localStorage) {
                     this.localStorage = new Backbone.LocalStorage(this.url);
                 }
 

--- a/frontend/js/collections/comments.js
+++ b/frontend/js/collections/comments.js
@@ -102,7 +102,7 @@ define(["jquery",
                     this.url = annotation.url() + "/comments";
                 }
 
-                if (window.annotationsTool && annotationsTool.localStorage) {
+                if (window.annotationTool && annotationTool.localStorage) {
                     var localStorageUrl = this.url;
                     if (replyTo) {
                         localStorageUrl += this.replyTo.id + "/replies";

--- a/frontend/js/collections/labels.js
+++ b/frontend/js/collections/labels.js
@@ -108,7 +108,7 @@ define(["jquery",
                     this.url = category.url() + "/labels";
                 }
 
-                if (window.annotationsTool && annotationsTool.localStorage) {
+                if (window.annotationTool && annotationTool.localStorage) {
                     this.localStorage = new Backbone.LocalStorage(this.url);
                 }
             }

--- a/frontend/js/collections/scales.js
+++ b/frontend/js/collections/scales.js
@@ -85,13 +85,13 @@ define(["jquery",
              */
             setUrl: function (video) {
                 if (!video || !video.collection) { // If a template
-                    this.url = window.annotationsTool.restEndpointsUrl + "/scales";
+                    this.url = window.annotationTool.restEndpointsUrl + "/scales";
                     this.isTemplate = true;
                 } else {  // If not a template, we add video url
                     this.url = video.url() + "/scales";
                     this.isTemplate = false;
 
-                    if (annotationsTool.localStorage) {
+                    if (annotationTool.localStorage) {
                         this.localStorage = new Backbone.LocalStorage(this.url);
                     }
                 }

--- a/frontend/js/collections/scalevalues.js
+++ b/frontend/js/collections/scalevalues.js
@@ -114,7 +114,7 @@ define(["jquery",
                     this.url = this.scale.url() + "/scalevalues";
                 }
 
-                if (annotationsTool.localStorage) {
+                if (annotationTool.localStorage) {
                     this.localStorage = new Backbone.LocalStorage(this.url);
                 }
             }

--- a/frontend/js/collections/tracks.js
+++ b/frontend/js/collections/tracks.js
@@ -87,7 +87,7 @@ define(["jquery",
                         this.showTracks(track, true);
                         
                         // Select the new track
-                        annotationsTool.selectedTrack = track;
+                        annotationTool.selectedTrack = track;
                     });
                 },
 
@@ -205,9 +205,9 @@ define(["jquery",
                  * @param  {boolean} keepPrevious define if the previous visible tracks should be kept if enough place
                  */
                 showTracks: function (tracks, keepPrevious) {
-                    var max = annotationsTool.MAX_VISIBLE_TRACKS || Number.MAX_VALUE,
+                    var max = annotationTool.MAX_VISIBLE_TRACKS || Number.MAX_VALUE,
                         self = this,
-                        selectedTrack = annotationsTool.selectedTrack,
+                        selectedTrack = annotationTool.selectedTrack,
                         showTrack = function (track) {
                             track.set(Track.FIELDS.VISIBLE, true);
                             self.visibleTracks.push(track);
@@ -251,10 +251,10 @@ define(["jquery",
                         selectedTrack = _.find(this.visibleTracks, function (track) {
                                             return track.get("isMine");
                                         }, this);
-                        annotationsTool.selectTrack(selectedTrack);
+                        annotationTool.selectTrack(selectedTrack);
                     }
 
-                    annotationsTool.selectTrack(selectedTrack);
+                    annotationTool.selectTrack(selectedTrack);
 
                     this.trigger(EVENTS.VISIBILITY, this.visibleTracks);
                 },
@@ -325,7 +325,7 @@ define(["jquery",
 
                     this.url = video.url() + "/tracks";
 
-                    if (annotationsTool.localStorage) {
+                    if (annotationTool.localStorage) {
                         this.localStorage = new Backbone.LocalStorage(this.url);
                     }
 

--- a/frontend/js/collections/users.js
+++ b/frontend/js/collections/users.js
@@ -58,7 +58,7 @@ define(["jquery",
              * @alias module:collections-users.User#initialize
              */
             initialize: function () {
-                this.url = window.annotationsTool.restEndpointsUrl + "/users";
+                this.url = window.annotationTool.restEndpointsUrl + "/users";
             },
 
             /**

--- a/frontend/js/collections/videos.js
+++ b/frontend/js/collections/videos.js
@@ -58,7 +58,7 @@ define(["jquery",
              * @alias module:collections-videos.Videos#initialize
              */
             initialize: function () {
-                this.url = window.annotationsTool.restEndpointsUrl + "/videos";
+                this.url = window.annotationTool.restEndpointsUrl + "/videos";
             }
         });
         return Videos;

--- a/frontend/js/handlebarsHelpers.js
+++ b/frontend/js/handlebarsHelpers.js
@@ -7,7 +7,7 @@ define(["handlebars", "underscore", "i18next", "roles"], function (Handlebars, _
      * @return The value of the given property
      */
     Handlebars.registerHelper("annotationTool", function (key) {
-        return annotationsTool[key];
+        return annotationTool[key];
     });
 
     Handlebars.registerHelper("greater", function (value1, value2, options) {
@@ -30,7 +30,7 @@ define(["handlebars", "underscore", "i18next", "roles"], function (Handlebars, _
      * @return {string}      The formated time
      */
     Handlebars.registerHelper("time", function (start) {
-        return annotationsTool.getWellFormatedTime(start);
+        return annotationTool.getWellFormatedTime(start);
     });
 
     /**
@@ -41,7 +41,7 @@ define(["handlebars", "underscore", "i18next", "roles"], function (Handlebars, _
      * @return {string}      The formated time
      */
     Handlebars.registerHelper("end", function (start, duration) {
-        return annotationsTool.getWellFormatedTime(start + (duration || 0.0));
+        return annotationTool.getWellFormatedTime(start + (duration || 0.0));
     });
 
     /**
@@ -52,7 +52,7 @@ define(["handlebars", "underscore", "i18next", "roles"], function (Handlebars, _
      */
     Handlebars.registerHelper("nickname", function (user) {
         if (!_.isObject(user)) {
-            return annotationsTool.users.get(user).get("nickname");
+            return annotationTool.users.get(user).get("nickname");
         } else {
             return user.nickname;
         }
@@ -65,7 +65,7 @@ define(["handlebars", "underscore", "i18next", "roles"], function (Handlebars, _
      * @return {string}      The formated date
      */
     Handlebars.registerHelper("formatDate", function (date) {
-        return annotationsTool.formatDate(date);
+        return annotationTool.formatDate(date);
     });
 
     /**

--- a/frontend/js/libs/require/config/config-build.js
+++ b/frontend/js/libs/require/config/config-build.js
@@ -2,8 +2,8 @@
 require.config({
     baseUrl: "js",
     paths: {
-        "annotations-tool": "annotations-tool",
-        "annotations-tool-configuration": "annotations-tool-configuration",
+        "annotation-tool": "annotation-tool",
+        "annotation-tool-configuration": "annotation-tool-configuration",
         "backbone": "libs/backbone/backbone-0.9.9",
         "bootstrap": "libs/bootstrap/bootstrap.min",
         "domReady": "libs/require/config/domReady",

--- a/frontend/js/libs/require/config/config.js
+++ b/frontend/js/libs/require/config/config.js
@@ -2,8 +2,8 @@
 require.config({
     baseUrl: "js",
     paths: {
-        "annotations-tool": "annotations-tool",
-        "annotations-tool-configuration": "annotations-tool-configuration",
+        "annotation-tool": "annotation-tool",
+        "annotation-tool-configuration": "annotation-tool-configuration",
         "backbone": "libs/backbone/backbone-0.9.9",
         "bootstrap": "libs/bootstrap/bootstrap.min",
         "domReady": "libs/require/config/domReady",

--- a/frontend/js/main.js
+++ b/frontend/js/main.js
@@ -9,7 +9,7 @@ require(["domReady",
          "i18next-browser-language-detector",
          "moment",
          "mediaelementplayer",
-         "annotations-tool-configuration"],
+         "annotation-tool-configuration"],
 
     function (domReady, $, i18next, i18nextXHRBackend, $i18next, LngDetector, moment, mejs, config) {
         i18next
@@ -35,7 +35,7 @@ require(["domReady",
                     mejs.i18n.language(mediaelementLanguage);
                     domReady(function () {
                         $('[data-i18n]').localize();
-                        require(["annotations-tool"], function (app) {
+                        require(["annotation-tool"], function (app) {
                             app.start(config);
                         });
                     });

--- a/frontend/js/models/annotation.js
+++ b/frontend/js/models/annotation.js
@@ -107,7 +107,7 @@ define(["jquery",
                         delete attr.scaleValue;
                     }
 
-                    if (annotationsTool.user.get("id") === attr.created_by) {
+                    if (annotationTool.user.get("id") === attr.created_by) {
                         attr.isMine = true;
                     } else {
                         attr.isMine = false;
@@ -123,12 +123,12 @@ define(["jquery",
                         }
                     }
 
-                    if (annotationsTool.localStorage && _.isArray(attr.comments)) {
+                    if (annotationTool.localStorage && _.isArray(attr.comments)) {
                         attr.comments = new Comments(attr.comments, { annotation: this });
                     }
 
-                    if (!annotationsTool.localStorage &&  attr.label_id && (_.isNumber(attr.label_id) || _.isString(attr.label_id))) {
-                        categories = annotationsTool.video.get("categories");
+                    if (!annotationTool.localStorage &&  attr.label_id && (_.isNumber(attr.label_id) || _.isString(attr.label_id))) {
+                        categories = annotationTool.video.get("categories");
 
                         categories.each(function (cat) {
 
@@ -142,7 +142,7 @@ define(["jquery",
                         attr.label = label;
                     }
 
-                    if (!annotationsTool.localStorage &&  attr.scalevalue) {
+                    if (!annotationTool.localStorage &&  attr.scalevalue) {
                         attr.scaleValue = attr.scalevalue;
                     }
                 });
@@ -163,7 +163,7 @@ define(["jquery",
                 });
                 if (invalidResource) return invalidResource;
 
-                if (!annotationsTool.localStorage && attr.label) {
+                if (!annotationTool.localStorage && attr.label) {
                     if (attr.label.id) {
                         this.attributes.label_id = attr.label.id;
                     } else if (attr.label.attributes) {
@@ -276,7 +276,7 @@ define(["jquery",
              */
             category: function () {
                 var label = this.get("label");
-                return label && annotationsTool.video.get("categories").get(label.category.id);
+                return label && annotationTool.video.get("categories").get(label.category.id);
             }
         });
 

--- a/frontend/js/models/category.js
+++ b/frontend/js/models/category.js
@@ -112,12 +112,12 @@ define(["jquery",
              */
             parse: function (data) {
                 return Resource.prototype.parse.call(this, data, function (attr) {
-                    if (annotationsTool.localStorage && _.isArray(attr.labels)) {
+                    if (annotationTool.localStorage && _.isArray(attr.labels)) {
                         attr.labels = new Labels(attr.labels, this);
                     }
 
-                    if (!annotationsTool.localStorage &&  attr.scale_id && (_.isNumber(attr.scale_id) || _.isString(attr.scale_id))) {
-                        attr.scale = annotationsTool.video.get("scales").get(attr.scale_id);
+                    if (!annotationTool.localStorage &&  attr.scale_id && (_.isNumber(attr.scale_id) || _.isString(attr.scale_id))) {
+                        attr.scale = annotationTool.video.get("scales").get(attr.scale_id);
                     }
                 });
             },
@@ -236,7 +236,7 @@ define(["jquery",
                         json.scale_id = this.attributes.scale.id;
                     }
 
-                    if (!annotationsTool.localStorage) {
+                    if (!annotationTool.localStorage) {
                         delete json.scale;
                     }
                 }
@@ -282,9 +282,9 @@ define(["jquery",
 
                 if (!_.isUndefined(withScale) &&  withScale) {
                     if (this.attributes.scale_id) {
-                        json.scale = annotationsTool.video.get("scales").get(this.attributes.scale_id).toExportJSON();
+                        json.scale = annotationTool.video.get("scales").get(this.attributes.scale_id).toExportJSON();
                     } else if (this.attributes.scale) {
-                        json.scale = annotationsTool.video.get("scales").get(this.attributes.scale.get("id")).toExportJSON();
+                        json.scale = annotationTool.video.get("scales").get(this.attributes.scale.get("id")).toExportJSON();
                     }
                 }
 

--- a/frontend/js/models/resource.js
+++ b/frontend/js/models/resource.js
@@ -41,13 +41,13 @@ var Resource = Backbone.Model.extend({
      * @param {object} attr Object literal containing the model initialion attributes.
      */
     initialize: function (attr) {
-        if (window.annotationsTool.localStorage) {
-            if (annotationsTool.user) {
+        if (window.annotationTool.localStorage) {
+            if (annotationTool.user) {
                 if (!attr.created_by) {
-                    this.set("created_by", annotationsTool.user.id);
+                    this.set("created_by", annotationTool.user.id);
                 }
                 if (!attr.created_by_nickname) {
-                    this.set("created_by_nickname", annotationsTool.user.get("nickname"));
+                    this.set("created_by_nickname", annotationTool.user.get("nickname"));
                 }
             }
             if (!attr.created_at) {
@@ -63,7 +63,7 @@ var Resource = Backbone.Model.extend({
             updateIsPublic.call(self, access);
         });
 
-        this.set("isMine", !attr.created_by || attr.created_by === annotationsTool.user.id);
+        this.set("isMine", !attr.created_by || attr.created_by === annotationTool.user.id);
 
         if (attr.tags) {
             this.set("tags", util.parseJSONString(attr.tags));
@@ -150,7 +150,7 @@ var Resource = Backbone.Model.extend({
             attr.settings = util.parseJSONString(attr.settings);
         }
 
-        attr.isMine = annotationsTool.user.id === attr.created_by;
+        attr.isMine = annotationTool.user.id === attr.created_by;
 
         if (callback) callback.call(this, attr);
 
@@ -186,7 +186,7 @@ var Resource = Backbone.Model.extend({
                 //   so for now we assume that this is only ever checked when the resource is public
                 //   in the right sense, i.e. it can be seen at all.
                 //&& this.get("isPublic")
-                && annotationsTool.user.get("role") === ROLES.ADMINISTRATOR
+                && annotationTool.user.get("role") === ROLES.ADMINISTRATOR
         );
     },
 

--- a/frontend/js/models/user.js
+++ b/frontend/js/models/user.js
@@ -70,8 +70,8 @@ define(["jquery",
 
                 Resource.prototype.initialize.apply(this, arguments);
 
-                if (!attr.role && annotationsTool.getUserRole) {
-                    attr.role = annotationsTool.getUserRole();
+                if (!attr.role && annotationTool.getUserRole) {
+                    attr.role = annotationTool.getUserRole();
 
                     if (!attr.role) {
                         delete attr.role;

--- a/frontend/js/views/annotate-category.js
+++ b/frontend/js/views/annotate-category.js
@@ -137,10 +137,10 @@ define(["jquery",
 
 
                 // Define the colors (global setting for all color pickers)
-                $.fn.colorPicker.defaults.colors = annotationsTool.colorsManager.getColors();
+                $.fn.colorPicker.defaults.colors = annotationTool.colorsManager.getColors();
 
                 // Type use for delete operation
-                this.typeForDelete = annotationsTool.deleteOperation.targetTypes.CATEGORY;
+                this.typeForDelete = annotationTool.deleteOperation.targetTypes.CATEGORY;
                 this.roles = attr.roles;
                 this.labelViews = [];
 
@@ -160,8 +160,8 @@ define(["jquery",
                 this.listenTo(labels, "destroy", this.removeOne);
                 this.listenTo(this.model, "change", this.onChange);
 
-                if (_.contains(this.roles, annotationsTool.user.get("role"))) {
-                    this.listenTo(annotationsTool, annotationsTool.EVENTS.ANNOTATE_TOGGLE_EDIT, this.switchEditModus);
+                if (_.contains(this.roles, annotationTool.user.get("role"))) {
+                    this.listenTo(annotationTool, annotationTool.EVENTS.ANNOTATE_TOGGLE_EDIT, this.switchEditModus);
                 }
 
                 $(window).bind("resize", this.updateInputWidth);
@@ -239,7 +239,7 @@ define(["jquery",
              * @alias module:views-annotate-category.CategoryView#editScale
              */
             editScale: function () {
-                annotationsTool.scaleEditor.show(this.model, this.model.get("access"));
+                annotationTool.scaleEditor.show(this.model, this.model.get("access"));
             },
 
             /**
@@ -248,7 +248,7 @@ define(["jquery",
              * @param  {Event} event
              */
             onDeleteCategory: function () {
-                annotationsTool.deleteOperation.start(this.model, this.typeForDelete);
+                annotationTool.deleteOperation.start(this.model, this.typeForDelete);
             },
 
             /**
@@ -421,7 +421,7 @@ define(["jquery",
 
                 this.$el.find(".colorPicker-picker").addClass("edit");
 
-                this.$el.width((100 / annotationsTool.CATEGORIES_PER_TAB) + "%");
+                this.$el.width((100 / annotationTool.CATEGORIES_PER_TAB) + "%");
 
                 this.updateInputWidth();
 

--- a/frontend/js/views/annotate-label.js
+++ b/frontend/js/views/annotate-label.js
@@ -144,7 +144,7 @@ define(["jquery",
                                 "updateInputWidth");
 
                 // Type use for delete operation
-                this.typeForDelete = annotationsTool.deleteOperation.targetTypes.LABEL;
+                this.typeForDelete = annotationTool.deleteOperation.targetTypes.LABEL;
 
                 // Change the edit modus, if this config is given as parameter
                 if (attr.editModus) {
@@ -164,8 +164,8 @@ define(["jquery",
 
                 this.setupScaling(this.model.get("category"));
 
-                if (_.contains(this.roles, annotationsTool.user.get("role"))) {
-                    this.listenTo(annotationsTool, annotationsTool.EVENTS.ANNOTATE_TOGGLE_EDIT, this.onSwitchEditModus);
+                if (_.contains(this.roles, annotationTool.user.get("role"))) {
+                    this.listenTo(annotationTool, annotationTool.EVENTS.ANNOTATE_TOGGLE_EDIT, this.onSwitchEditModus);
                 }
 
                 return this.render();
@@ -197,8 +197,8 @@ define(["jquery",
                         scalevalue: scalevalue.toJSON()
                     };
 
-                annotation = annotationsTool.createAnnotation(params);
-                annotationsTool.setSelection([annotation], true);
+                annotation = annotationTool.createAnnotation(params);
+                annotationTool.setSelection([annotation], true);
             },
 
             /**
@@ -213,11 +213,11 @@ define(["jquery",
                     return;
                 }
 
-                var annotation = annotationsTool.createAnnotation({
+                var annotation = annotationTool.createAnnotation({
                     text : this.model.get("value"),
                     label: this.model
                 });
-                annotationsTool.setSelection([annotation], true);
+                annotationTool.setSelection([annotation], true);
             },
 
             /**
@@ -255,7 +255,7 @@ define(["jquery",
              */
             setupScaling: function (category) {
                 var scaleId = category.scale_id || (category.scale && category.scale.id),
-                    scale = scaleId && annotationsTool.video.get("scales").get(scaleId);
+                    scale = scaleId && annotationTool.video.get("scales").get(scaleId);
 
                 if (scale) {
                     this.scaleValues = scale.get("scaleValues");
@@ -341,7 +341,7 @@ define(["jquery",
              * @alias module:views-annotate-label.LabelView#onDeleteLabel
              */
             onDeleteLabel: function () {
-                annotationsTool.deleteOperation.start(this.model, this.typeForDelete);
+                annotationTool.deleteOperation.start(this.model, this.typeForDelete);
             },
 
             /**

--- a/frontend/js/views/annotate-tab.js
+++ b/frontend/js/views/annotate-tab.js
@@ -281,9 +281,9 @@ define(["jquery",
                 this.listenTo(this.categories, "remove", this.removeOne);
                 this.listenTo(this.categories, "destroy", this.removeOne);
 
-                this.listenTo(annotationsTool, annotationsTool.EVENTS.ANNOTATE_TOGGLE_EDIT, this.onSwitchEditModus);
+                this.listenTo(annotationTool, annotationTool.EVENTS.ANNOTATE_TOGGLE_EDIT, this.onSwitchEditModus);
 
-                this.hasEditMode = _.contains(this.roles, annotationsTool.user.get("role"));
+                this.hasEditMode = _.contains(this.roles, annotationTool.user.get("role"));
 
                 this.delegateEvents(this.events);
 
@@ -354,7 +354,7 @@ define(["jquery",
                 var attributes = {
                     name    : i18next.t("annotate.new category name"),
                     settings: {
-                        color   : "#" + annotationsTool.colorsManager.getNextColor(),
+                        color   : "#" + annotationTool.colorsManager.getNextColor(),
                         hasScale: false
                     }
                 };
@@ -387,7 +387,7 @@ define(["jquery",
                 var itemsLength = this.categoriesContainer.find("div.category-item").length;
 
                 // Create a new carousel if the current one is full
-                if ((itemsLength % annotationsTool.CATEGORIES_PER_TAB) === 0) {
+                if ((itemsLength % annotationTool.CATEGORIES_PER_TAB) === 0) {
                     this.addCarouselItem();
                 }
 
@@ -398,7 +398,7 @@ define(["jquery",
                 this.itemsCurrentContainer.append(categoryView.$el);
 
                 // Move the carousel to the container of the new item
-                this.carouselElement.carousel(parseInt(itemsLength / annotationsTool.CATEGORIES_PER_TAB, 10)).carousel("pause");
+                this.carouselElement.carousel(parseInt(itemsLength / annotationTool.CATEGORIES_PER_TAB, 10)).carousel("pause");
             },
 
             /**
@@ -407,13 +407,13 @@ define(["jquery",
              */
             addCarouselItem: function () {
                 var length = this.categoriesContainer.find("div.category-item").length,
-                    pageNumber = (length - (length % annotationsTool.CATEGORIES_PER_TAB)) / annotationsTool.CATEGORIES_PER_TAB;
+                    pageNumber = (length - (length % annotationTool.CATEGORIES_PER_TAB)) / annotationTool.CATEGORIES_PER_TAB;
 
                 this.categoriesContainer.append(this.itemContainerTemplate({number: (pageNumber + 1)}));
 
                 this.itemsCurrentContainer = this.categoriesContainer.find("div div div.row-fluid").last();
 
-                if (length >= annotationsTool.CATEGORIES_PER_TAB) {
+                if (length >= annotationTool.CATEGORIES_PER_TAB) {
                     this.carouselPagination.parent().css("display", "block");
                 }
 
@@ -463,8 +463,8 @@ define(["jquery",
                     options = {wait: true};
 
                 // Generate scales
-                if (!annotationsTool.video.get("scales").find(findByNameScale)) {
-                    scale = annotationsTool.video.get("scales").create({
+                if (!annotationTool.video.get("scales").find(findByNameScale)) {
+                    scale = annotationTool.video.get("scales").create({
                         name  : scalesSet[0].name,
                         access: ACCESS.PRIVATE
                     }, options);
@@ -539,11 +539,11 @@ define(["jquery",
                     tmpScaleId;
 
                 // If the used browser is Safari, we display a warning message
-                if (annotationsTool.isBrowserSafari6()) {
-                    annotationsTool.alertWarning(i18next.t("annotate.export not supported", { browser: "Safari" }));
+                if (annotationTool.isBrowserSafari6()) {
+                    annotationTool.alertWarning(i18next.t("annotate.export not supported", { browser: "Safari" }));
                     return;
-                } else if (annotationsTool.isBrowserIE9()) {
-                    annotationsTool.alertWarning(i18next.t("annotate.export not supported", { browser: "Internet Explorer" }));
+                } else if (annotationTool.isBrowserIE9()) {
+                    annotationTool.alertWarning(i18next.t("annotate.export not supported", { browser: "Internet Explorer" }));
                     return;
                 }
 
@@ -551,7 +551,7 @@ define(["jquery",
                     tmpScaleId = category.attributes.scale_id;
 
                     if (tmpScaleId && !tmpScales[tmpScaleId]) {
-                        tmpScales[tmpScaleId] = annotationsTool.video.get("scales").get(tmpScaleId);
+                        tmpScales[tmpScaleId] = annotationTool.video.get("scales").get(tmpScaleId);
                     }
 
                     json.categories.push(category.toExportJSON());
@@ -585,7 +585,7 @@ define(["jquery",
 
                         try {
                             importAsJSON = JSON.parse(importAsString);
-                            annotationsTool.importCategories(importAsJSON, defaultCategoryAttributes);
+                            annotationTool.importCategories(importAsJSON, defaultCategoryAttributes);
                         } catch (error) {
                             // TODO pop up an error modal to the user
                             console.warn("The uploaded file is not valid!");

--- a/frontend/js/views/annotate.js
+++ b/frontend/js/views/annotate.js
@@ -208,16 +208,16 @@ define(["jquery",
 
                     // Print selected track
                     this.trackDIV = this.$el.find("span.currentTrack");
-                    this.changeTrack(annotationsTool.selectedTrack);
+                    this.changeTrack(annotationTool.selectedTrack);
 
-                    this.tracks = annotationsTool.video.get("tracks");
+                    this.tracks = annotationTool.video.get("tracks");
                     this.tracks.bind("selected_track", this.changeTrack, this);
                     this.playerAdapter = attr.playerAdapter;
 
-                    if (annotationsTool.isStructuredAnnotationEnabled()) {
-                        categories = annotationsTool.video.get("categories");
+                    if (annotationTool.isStructuredAnnotationEnabled()) {
+                        categories = annotationTool.video.get("categories");
 
-                        annotationsTool.colorsManager.updateColors(categories.models);
+                        annotationTool.colorsManager.updateColors(categories.models);
 
                         _.each(DEFAULT_TABS, function (params) {
                             this.addTab(categories, params);
@@ -228,7 +228,7 @@ define(["jquery",
                         this.$el.find("#annotate-categories").parent().hide();
                     }
 
-                    if (!annotationsTool.isFreeTextEnabled()) {
+                    if (!annotationTool.isFreeTextEnabled()) {
                         this.layout.freeText = false;
                         this.freeTextElement.hide();
                         this.$el.find("#annotate-text").parent().hide();
@@ -271,10 +271,10 @@ define(["jquery",
                         return;
                     }
 
-                    annotationsTool.createAnnotation({ text: value });
+                    annotationTool.createAnnotation({ text: value });
 
                     if (this.continueVideo) {
-                        annotationsTool.playerAdapter.play();
+                        annotationTool.playerAdapter.play();
                     }
 
                     this.input.val("");
@@ -319,7 +319,7 @@ define(["jquery",
                  * @alias module:views-annotate.Annotate#onFocusIn
                  */
                 onFocusIn: function () {
-                    if (!this.$el.find("#pause-video").attr("checked") || (annotationsTool.playerAdapter.getStatus() === PlayerAdapter.STATUS.PAUSED)) {
+                    if (!this.$el.find("#pause-video").attr("checked") || (annotationTool.playerAdapter.getStatus() === PlayerAdapter.STATUS.PAUSED)) {
                         return;
                     }
 
@@ -327,7 +327,7 @@ define(["jquery",
                     this.playerAdapter.pause();
 
                     // If the video is moved, or played, we do no continue the video after insertion
-                    $(annotationsTool.playerAdapter).one(PlayerAdapter.EVENTS.TIMEUPDATE, function () {
+                    $(annotationTool.playerAdapter).one(PlayerAdapter.EVENTS.TIMEUPDATE, function () {
                         this.continueVideo = false;
                     });
                 },
@@ -345,7 +345,7 @@ define(["jquery",
                  * @alias module:views-annotate.Annotate#checkToContinueVideo
                  */
                 checkToContinueVideo: function () {
-                    if ((annotationsTool.playerAdapter.getStatus() === PlayerAdapter.STATUS.PAUSED) && this.continueVideo) {
+                    if ((annotationTool.playerAdapter.getStatus() === PlayerAdapter.STATUS.PAUSED) && this.continueVideo) {
                         this.continueVideo = false;
                         this.playerAdapter.play();
                     }
@@ -425,7 +425,7 @@ define(["jquery",
                     this.$el.toggleClass("edit-on", status);
 
                     // trigger an event that all element switch in edit modus
-                    annotationsTool.trigger(annotationsTool.EVENTS.ANNOTATE_TOGGLE_EDIT, status);
+                    annotationTool.trigger(annotationTool.EVENTS.ANNOTATE_TOGGLE_EDIT, status);
                 },
 
                 /**
@@ -435,10 +435,10 @@ define(["jquery",
                  */
                 setLayoutFull: function (event) {
                     if (!$(event.target).hasClass("checked")) {
-                        if (annotationsTool.isStructuredAnnotationEnabled()) {
+                        if (annotationTool.isStructuredAnnotationEnabled()) {
                             this.categoriesElement.show();
                         }
-                        if (annotationsTool.isFreeTextEnabled()) {
+                        if (annotationTool.isFreeTextEnabled()) {
                             this.freeTextElement.show();
                         }
                         this.$el.find("#annotate-text").removeClass("checked");
@@ -462,7 +462,7 @@ define(["jquery",
                         this.layout.freeText = enabled;
                     }
 
-                    if (this.layout.freeText && annotationsTool.isFreeTextEnabled()) {
+                    if (this.layout.freeText && annotationTool.isFreeTextEnabled()) {
                         this.freeTextElement.show();
                         if (!this.layout.categories) {
                             $(".toggle-collapse").show();
@@ -491,7 +491,7 @@ define(["jquery",
                         this.layout.categories = enabled;
                     }
 
-                    if (this.layout.categories && annotationsTool.isStructuredAnnotationEnabled()) {
+                    if (this.layout.categories && annotationTool.isStructuredAnnotationEnabled()) {
                         this.categoriesElement.show();
                         if (!this.layout.freeText) {
                             $(".toggle-collapse").show();
@@ -526,7 +526,7 @@ define(["jquery",
                     delete this.tracks;
                     this.undelegateEvents();
 
-                    if (annotationsTool.isStructuredAnnotationEnabled()) {
+                    if (annotationTool.isStructuredAnnotationEnabled()) {
                         this.tabsContainerElement.empty();
                         this.$el.find("#editSwitch input").attr("checked", false);
                         this.tabsButtonsElement.find(".tab-button").remove();

--- a/frontend/js/views/comment.js
+++ b/frontend/js/views/comment.js
@@ -103,7 +103,7 @@ define(["jquery",
                 this.isEditEnable = !!attr.isEditEnable;
 
                 // Type use for delete operation
-                this.typeForDelete = annotationsTool.deleteOperation.targetTypes.COMMENT;
+                this.typeForDelete = annotationTool.deleteOperation.targetTypes.COMMENT;
 
                 // Fix up circular dependency
                 if (!CommentsContainer) CommentsContainer = require("views/comments-container");
@@ -141,7 +141,7 @@ define(["jquery",
                     event.stopImmediatePropagation();
                 }
 
-                annotationsTool.deleteOperation.start(this.model, this.typeForDelete);
+                annotationTool.deleteOperation.start(this.model, this.typeForDelete);
             },
 
             /**

--- a/frontend/js/views/list-annotation.js
+++ b/frontend/js/views/list-annotation.js
@@ -154,7 +154,7 @@ define(["jquery",
                         category = this.model.get("label").get("category");
                     }
 
-                    this.scale = annotationsTool.video.get("scales").get(category.scale_id);
+                    this.scale = annotationTool.video.get("scales").get(category.scale_id);
                 }
 
                 if (this.scale) {
@@ -171,12 +171,12 @@ define(["jquery",
                 this.listenTo(this.model, "remove", this.deleteView);
 
                 // Type use for delete operation
-                this.typeForDelete = annotationsTool.deleteOperation.targetTypes.ANNOTATION;
+                this.typeForDelete = annotationTool.deleteOperation.targetTypes.ANNOTATION;
 
                 if (attr.track) {
                     this.track = attr.track;
                 } else {
-                    this.track = annotationsTool.selectedTrack;
+                    this.track = annotationTool.selectedTrack;
                 }
 
                 this.currentState = ListAnnotation.STATES.COLLAPSED;
@@ -221,7 +221,7 @@ define(["jquery",
                 if (event) {
                     event.stopImmediatePropagation();
                 }
-                annotationsTool.deleteOperation.start(this.model, this.typeForDelete);
+                annotationTool.deleteOperation.start(this.model, this.typeForDelete);
             },
 
             /**
@@ -239,7 +239,7 @@ define(["jquery",
              * @alias module:views-list-annotation.ListAnnotation#jumpTo
              */
             jumpTo: function () {
-                annotationsTool.setSelection([this.model], true);
+                annotationTool.setSelection([this.model], true);
             },
 
             /**
@@ -349,7 +349,7 @@ define(["jquery",
                         seconds = parseInt(values[0], radix);
                     }
 
-                    if (annotationsTool.playerAdapter.getDuration() < seconds || this.model.get("start") > seconds) {
+                    if (annotationTool.playerAdapter.getDuration() < seconds || this.model.get("start") > seconds) {
                         $target.addClass("error");
                         return;
                     }
@@ -416,7 +416,7 @@ define(["jquery",
              * @param  {event} event Event object
              */
             setCurrentTimeAsStart: function (event) {
-                var currentTime = Math.round(annotationsTool.playerAdapter.getCurrentTime()),
+                var currentTime = Math.round(annotationTool.playerAdapter.getCurrentTime()),
                     end = this.model.get("start") + this.model.get("duration");
 
                 event.stopImmediatePropagation();
@@ -433,7 +433,7 @@ define(["jquery",
              * @param  {event} event Event object
              */
             setCurrentTimeAsEnd: function (event) {
-                var currentTime = Math.round(annotationsTool.playerAdapter.getCurrentTime());
+                var currentTime = Math.round(annotationTool.playerAdapter.getCurrentTime());
                 event.stopImmediatePropagation();
                 if (currentTime > this.model.get("start")) {
                     this.model.set({duration: currentTime - this.model.get("start")});
@@ -463,7 +463,7 @@ define(["jquery",
                 modelJSON.textHeight   = $("span.freetext").height();
 
                 if (modelJSON.isMine && this.scale && modelJSON.label.category.scale_id) {
-                    category = annotationsTool.video.get("categories").get(this.model.get("label").category.id);
+                    category = annotationTool.video.get("categories").get(this.model.get("label").category.id);
 
                     // Check if the category is still linked to the video to get the current version
                     if (category) {
@@ -545,14 +545,14 @@ define(["jquery",
              */
             onSelect: _.debounce(function (force) {
                 // If annotation already selected
-                if (annotationsTool.hasSelection() && annotationsTool.getSelection()[0].get("id") === this.model.get("id")) {
+                if (annotationTool.hasSelection() && annotationTool.getSelection()[0].get("id") === this.model.get("id")) {
                     if (!_.isBoolean(force) || (_.isBoolean(force) && !force)) {
-                        annotationsTool.setSelection();
+                        annotationTool.setSelection();
                         this.isSelected = false;
                     }
                 } else {
                     this.isSelected = true;
-                    annotationsTool.setSelection([this.model], true, true);
+                    annotationTool.setSelection([this.model], true, true);
                 }
             }, 100),
 

--- a/frontend/js/views/list.js
+++ b/frontend/js/views/list.js
@@ -122,21 +122,21 @@ define(["jquery",
                                "updateView");
 
                 this.annotationViews = [];
-                this.tracks          = annotationsTool.video.get("tracks");
-                this.playerAdapter   = annotationsTool.playerAdapter;
+                this.tracks          = annotationTool.video.get("tracks");
+                this.playerAdapter   = annotationTool.playerAdapter;
 
                 this.$list = this.$el.find("#content-list-scroll div#content-list");
 
                 this.listenTo(this.tracks, "change:access", this.render);
                 this.listenTo(this.tracks, Tracks.EVENTS.VISIBILITY, this.addTrackList);
-                this.listenTo(annotationsTool, annotationsTool.EVENTS.ANNOTATION_SELECTION, this.select);
+                this.listenTo(annotationTool, annotationTool.EVENTS.ANNOTATION_SELECTION, this.select);
 
                 // Add backbone events to the model
                 _.extend(this, Backbone.Events);
 
                 this.addTrackList(this.tracks.getVisibleTracks());
 
-                this.listenTo(annotationsTool.video.get("categories"), "change:visible", this.render);
+                this.listenTo(annotationTool.video.get("categories"), "change:visible", this.render);
 
                 this.render();
 
@@ -208,7 +208,7 @@ define(["jquery",
                         }
                     });
 
-                    annotationsTool.setSelection([annotation], false);
+                    annotationTool.setSelection([annotation], false);
                     lastAddedAnnotationView = view;
                 }
             },

--- a/frontend/js/views/login.js
+++ b/frontend/js/views/login.js
@@ -66,12 +66,12 @@ define(["jquery",
 
                     _.extend(this, Backbone.Events);
 
-                    this.$el.append(this.loginTemplate({localStorage: annotationsTool.localStorage}));
+                    this.$el.append(this.loginTemplate({localStorage: annotationTool.localStorage}));
                     this.$el.modal({show: true, backdrop: true, keyboard: false });
                     this.$el.modal("hide");
                     this.$el.on("hide", function () {
                         // If user not set, display the login window again
-                        if (_.isUndefined(annotationsTool.user)) {
+                        if (_.isUndefined(annotationTool.user)) {
                             setTimeout(function () {$("#user-login").modal("show"); }, 5);
                         }
                     });
@@ -119,19 +119,19 @@ define(["jquery",
                     // Fields from the login form
                     var userNickname    = this.$el.find("#nickname"),
                         userEmail       = this.$el.find("#email"),
-                        userId          = annotationsTool.getUserExtId(userEmail.val()),
+                        userId          = annotationTool.getUserExtId(userEmail.val()),
                         userRemember    = this.$el.find("#remember"),
                         userError       = this.$el.find(".alert"),
                         user; // the new user
 
                     userError.find("#content").empty();
                     try {
-                        user = annotationsTool.login(
+                        user = annotationTool.login(
                             {
                                 user_extid: userId,
                                 nickname: userNickname.val(),
                                 email: userEmail.val(),
-                                role: annotationsTool.localStorage && (
+                                role: annotationTool.localStorage && (
                                     this.$el.find("#supervisor")[0].checked ? ROLES.ADMINISTRATOR : ROLES.USER
                                 )
                             },
@@ -150,7 +150,7 @@ define(["jquery",
 
                     // If we have to remember the user
                     if (userRemember.is(":checked")) {
-                        annotationsTool.users.add(user);
+                        annotationTool.users.add(user);
                         Backbone.localSync("create", user, {
                             success: function () {
                                 console.log("current user saved locally");

--- a/frontend/js/views/loop.js
+++ b/frontend/js/views/loop.js
@@ -113,7 +113,7 @@ define(["jquery",
              * @alias module:views-loop.Loop#timelineItemTmpl
              */
             timelineItemTmpl: Handlebars.compile("<div class=\"{{class}}\"\
-                                                        onclick=\"annotationsTool.loopFunction.setCurrentLoop({{index}}, true)\">\
+                                                        onclick=\"annotationTool.loopFunction.setCurrentLoop({{index}}, true)\">\
                                                     </div>"),
 
             /**
@@ -155,26 +155,26 @@ define(["jquery",
                                 "toggleVisibity",
                                 "typeLoopLength");
                 var mainView,
-                    defaultVisiblity = annotationsTool.getLayoutConfiguration().loop;
+                    defaultVisiblity = annotationTool.getLayoutConfiguration().loop;
 
-                this.playerAdapter = annotationsTool.playerAdapter;
-                this.loops = new Loops([], annotationsTool.video);
+                this.playerAdapter = annotationTool.playerAdapter;
+                this.loops = new Loops([], annotationTool.video);
 
                 $("#video-container").after(this.loopTemplate());
                 this.setElement($("#loop")[0]);
                 this.initSlider();
 
-                if (!_.isUndefined(annotationsTool.views.main)) {
-                    mainView = annotationsTool.views.main;
+                if (!_.isUndefined(annotationTool.views.main)) {
+                    mainView = annotationTool.views.main;
                     mainView.$el.find("#menu-plugins").append(this.LAYOUT_MENU_TMPL);
                     mainView.$el.find("#menu-plugins #" + this.LAYOUT_MENU_CLASS).bind("click", this.toggleVisibity);
                 }
 
                 this.toggle(false);
 
-                annotationsTool.loopFunction = this;
+                annotationTool.loopFunction = this;
 
-                annotationsTool.onWindowResize();
+                annotationTool.onWindowResize();
 
                 if (!_.isUndefined(defaultVisiblity) && !defaultVisiblity) {
                     this.toggleVisibity({target: mainView.$el.find("#menu-plugins #" + this.LAYOUT_MENU_CLASS)[0]});
@@ -209,7 +209,7 @@ define(["jquery",
                     this.toggle(false);
                 }
 
-                annotationsTool.onWindowResize();
+                annotationTool.onWindowResize();
             },
 
             initSlider: function () {
@@ -246,8 +246,8 @@ define(["jquery",
                     $(this.playerAdapter).unbind(PlayerAdapter.EVENTS.TIMEUPDATE, this.checkLoop);
                     this.$el.addClass("disabled");
                     this.resetLoops();
-                    if (annotationsTool.getLayoutConfiguration().timeline) {
-                        annotationsTool.views.timeline.redraw();
+                    if (annotationTool.getLayoutConfiguration().timeline) {
+                        annotationTool.views.timeline.redraw();
                     }
                 }
 
@@ -316,7 +316,7 @@ define(["jquery",
                     newValue = parseInt(loopInput.val(), 10);
 
                 if (_.isNaN(newValue) || newValue > this.playerAdapter.getDuration() || newValue < 0) {
-                    annotationsTool.alertWarning(i18next.t("loop controller.invalid loop length"));
+                    annotationTool.alertWarning(i18next.t("loop controller.invalid loop length"));
                     loopInput.val(this.currentLoopLength);
                     return;
                 }
@@ -346,9 +346,9 @@ define(["jquery",
              */
             toggleConstrainAnnotations: function (event) {
                 if (event.target.checked) {
-                    annotationsTool.annotationConstraints = currentLoopConstraints.call(this);
+                    annotationTool.annotationConstraints = currentLoopConstraints.call(this);
                 } else {
-                    annotationsTool.annotationConstraints = undefined;
+                    annotationTool.annotationConstraints = undefined;
                 }
             },
 
@@ -393,7 +393,7 @@ define(["jquery",
                 }
 
                 // Update the global annotation constraints.
-                _.extend(annotationsTool.annotationConstraints, currentLoopConstraints.call(this));
+                _.extend(annotationTool.annotationConstraints, currentLoopConstraints.call(this));
             },
 
             /**
@@ -420,7 +420,7 @@ define(["jquery",
                     loop;
 
                 if (loopLength >= duration) {
-                    annotationsTool.alertInfo("Interval too long to create one loop!");
+                    annotationTool.alertInfo("Interval too long to create one loop!");
                     return;
                 }
 
@@ -456,12 +456,12 @@ define(["jquery",
              * @alias module:views-loop.Loop#addTimelineItem
              */
             addTimelineItem: function (loop, isCurrent) {
-                if (!annotationsTool.getLayoutConfiguration().timeline) {
+                if (!annotationTool.getLayoutConfiguration().timeline) {
                     // Timeline is not enabled
                     return;
                 }
 
-                var timeline    = annotationsTool.views.timeline,
+                var timeline    = annotationTool.views.timeline,
                     loopClass   = isCurrent ? "loop current" : "loop";
 
                 timeline.addItem("loop-" + loop.cid, {
@@ -482,9 +482,9 @@ define(["jquery",
              * @alias module:views-loop.Loop#resetLoops
              */
             resetLoops: function () {
-                if (annotationsTool.getLayoutConfiguration().timeline) {
+                if (annotationTool.getLayoutConfiguration().timeline) {
                     this.loops.each(function (loop, index) {
-                        annotationsTool.views.timeline.removeItem("loop-" + loop.cid, (index + 1 == this.loops.length));
+                        annotationTool.views.timeline.removeItem("loop-" + loop.cid, (index + 1 == this.loops.length));
                     }, this);
                 }
 

--- a/frontend/js/views/main.js
+++ b/frontend/js/views/main.js
@@ -133,7 +133,7 @@ define(["jquery",
                                 "setupKeyboardShortcuts",
                                 "tracksSelection",
                                 "setLoadingProgress");
-                annotationsTool.bind(annotationsTool.EVENTS.NOTIFICATION, function (message) {
+                annotationTool.bind(annotationTool.EVENTS.NOTIFICATION, function (message) {
                     this.setLoadingProgress(this.loadingPercent, message);
                 }, this);
 
@@ -142,16 +142,16 @@ define(["jquery",
 
                 this.setLoadingProgress(20, i18next.t("startup.get users saved locally"));
                 // Create a new users collection and get exciting local user
-                annotationsTool.users = new Users();
+                annotationTool.users = new Users();
 
-                if (annotationsTool.localStorage) {
+                if (annotationTool.localStorage) {
                     // Remove link for statistics exports, work only with backend implementation
                     this.$el.find("#export").parent().remove();
                 }
 
-                Backbone.localSync("read", annotationsTool.users, {
+                Backbone.localSync("read", annotationTool.users, {
                     success: function (data) {
-                        annotationsTool.users.add(data);
+                        annotationTool.users.add(data);
                     },
                     error: function (error) {
                         console.warn(error);
@@ -159,24 +159,24 @@ define(["jquery",
                 });
 
                 this.loginView = new LoginView();
-                annotationsTool.scaleEditor = new ScaleEditorView();
+                annotationTool.scaleEditor = new ScaleEditorView();
 
-                this.listenTo(annotationsTool, "deleteAnnotation", annotationsTool.deleteAnnotation);
+                this.listenTo(annotationTool, "deleteAnnotation", annotationTool.deleteAnnotation);
 
-                annotationsTool.onWindowResize = this.onWindowResize;
+                annotationTool.onWindowResize = this.onWindowResize;
                 $(window).resize(this.onWindowResize);
                 $(window).bind("keydown", $.proxy(this.onDeletePressed, this));
 
-                annotationsTool.once(annotationsTool.EVENTS.READY, function () {
-                    this.loadPlugins(annotationsTool.plugins);
-                    this.updateTitle(annotationsTool.video);
+                annotationTool.once(annotationTool.EVENTS.READY, function () {
+                    this.loadPlugins(annotationTool.plugins);
+                    this.updateTitle(annotationTool.video);
                     this.tracksSelectionModal = new TracksSelectionView();
 
-                    if (!annotationsTool.isFreeTextEnabled()) {
+                    if (!annotationTool.isFreeTextEnabled()) {
                         $("#opt-annotate-text").parent().hide();
                     }
 
-                    if (!annotationsTool.isStructuredAnnotationEnabled()) {
+                    if (!annotationTool.isStructuredAnnotationEnabled()) {
                         $("#opt-annotate-categories").parent().hide();
                     }
 
@@ -217,10 +217,10 @@ define(["jquery",
                 this.setLoadingProgress(45, i18next.t("startup.loading video"));
 
                 // Initialize the player
-                annotationsTool.playerAdapter.load();
+                annotationTool.playerAdapter.load();
                 this.setLoadingProgress(50, i18next.t("startup.initializing the player"));
 
-                annotationsTool.views.main = this;
+                annotationTool.views.main = this;
 
                 /**
                  * Loading the video dependant views
@@ -233,39 +233,39 @@ define(["jquery",
 
                     this.setLoadingProgress(60, i18next.t("startup.creating views"));
 
-                    if (annotationsTool.getLayoutConfiguration().timeline) {
+                    if (annotationTool.getLayoutConfiguration().timeline) {
                         // Create views with Timeline
                         this.setLoadingProgress(70, i18next.t("startup.creating timeline"));
-                        this.timelineView = new TimelineView({playerAdapter: annotationsTool.playerAdapter});
-                        annotationsTool.views.timeline = this.timelineView;
+                        this.timelineView = new TimelineView({playerAdapter: annotationTool.playerAdapter});
+                        annotationTool.views.timeline = this.timelineView;
                     }
 
-                    if (annotationsTool.getLayoutConfiguration().annotate) {
+                    if (annotationTool.getLayoutConfiguration().annotate) {
                         // Create view to annotate
                         this.setLoadingProgress(80, i18next.t("startup.creating annotation view"));
-                        this.annotateView = new AnnotateView({playerAdapter: annotationsTool.playerAdapter});
+                        this.annotateView = new AnnotateView({playerAdapter: annotationTool.playerAdapter});
                         this.listenTo(this.annotateView, "change-layout", this.onWindowResize);
                         this.annotateView.$el.show();
-                        annotationsTool.views.annotate = this.annotateView;
+                        annotationTool.views.annotate = this.annotateView;
                     }
 
-                    if (annotationsTool.getLayoutConfiguration().list) {
+                    if (annotationTool.getLayoutConfiguration().list) {
                         // Create annotations list view
                         this.setLoadingProgress(90, i18next.t("startup.creating list view"));
                         this.listView = new ListView();
                         this.listenTo(this.listView, "change-layout", this.onWindowResize);
                         this.listView.$el.show();
-                        annotationsTool.views.list = this.listView;
+                        annotationTool.views.list = this.listView;
                     }
 
                     this.ready();
                 }, this);
 
 
-                if (annotationsTool.playerAdapter.getStatus() === PlayerAdapter.STATUS.PAUSED) {
+                if (annotationTool.playerAdapter.getStatus() === PlayerAdapter.STATUS.PAUSED) {
                     loadVideoDependantView();
                 } else {
-                    $(annotationsTool.playerAdapter).one(PlayerAdapter.EVENTS.READY + " " + PlayerAdapter.EVENTS.PAUSE, loadVideoDependantView);
+                    $(annotationTool.playerAdapter).one(PlayerAdapter.EVENTS.READY + " " + PlayerAdapter.EVENTS.PAUSE, loadVideoDependantView);
                 }
             },
 
@@ -283,11 +283,11 @@ define(["jquery",
                 // Show logout button
                 $("a#logout").css("display", "block");
 
-                if (annotationsTool.getLayoutConfiguration().timeline) {
+                if (annotationTool.getLayoutConfiguration().timeline) {
                     this.timelineView.redraw();
                 }
 
-                annotationsTool.trigger(annotationsTool.EVENTS.READY);
+                annotationTool.trigger(annotationTool.EVENTS.READY);
             },
 
             /**
@@ -297,25 +297,25 @@ define(["jquery",
             setupKeyboardShortcuts: function () {
 
                 var setActiveAnnotationDuration = _.bind(function () {
-                    if (!annotationsTool.activeAnnotation) return;
+                    if (!annotationTool.activeAnnotation) return;
 
-                    var currentTime = annotationsTool.playerAdapter.getCurrentTime();
-                    var start = annotationsTool.activeAnnotation.get("start");
-                    annotationsTool.activeAnnotation.set("duration", currentTime - start);
-                    annotationsTool.activeAnnotation.save();
+                    var currentTime = annotationTool.playerAdapter.getCurrentTime();
+                    var start = annotationTool.activeAnnotation.get("start");
+                    annotationTool.activeAnnotation.set("duration", currentTime - start);
+                    annotationTool.activeAnnotation.save();
                 }, this);
 
                 var addComment = _.bind(function () {
-                    if (!annotationsTool.activeAnnotation) return;
+                    if (!annotationTool.activeAnnotation) return;
                     var annotationView = this.listView.getViewFromAnnotation(
-                        annotationsTool.activeAnnotation.get("id")
+                        annotationTool.activeAnnotation.get("id")
                     );
                     annotationView.toggleCommentsState();
-                    var wasPlaying = annotationsTool.playerAdapter.getStatus() === PlayerAdapter.STATUS.PLAYING;
-                    annotationsTool.playerAdapter.pause();
+                    var wasPlaying = annotationTool.playerAdapter.getStatus() === PlayerAdapter.STATUS.PLAYING;
+                    annotationTool.playerAdapter.pause();
                     annotationView.once("cancel", function () {
                         if (wasPlaying) {
-                            annotationsTool.playerAdapter.play();
+                            annotationTool.playerAdapter.play();
                         }
                     });
                 }, this);
@@ -337,27 +337,27 @@ define(["jquery",
             checkUserAndLogin: function () {
                 this.setLoadingProgress(30, i18next.t("startup.get current user"));
 
-                if (!annotationsTool.modelsInitialized) {
-                    annotationsTool.once(annotationsTool.EVENTS.MODELS_INITIALIZED, this.createViews, this);
+                if (!annotationTool.modelsInitialized) {
+                    annotationTool.once(annotationTool.EVENTS.MODELS_INITIALIZED, this.createViews, this);
                 }
 
                 // If a user has been saved locally, we take it as current user
-                if (annotationsTool.users.length > 0) {
-                    annotationsTool.user = annotationsTool.users.at(0);
+                if (annotationTool.users.length > 0) {
+                    annotationTool.user = annotationTool.users.at(0);
 
-                    annotationsTool.trigger(annotationsTool.EVENTS.USER_LOGGED);
+                    annotationTool.trigger(annotationTool.EVENTS.USER_LOGGED);
 
-                    if (annotationsTool.modelsInitialized) {
+                    if (annotationTool.modelsInitialized) {
                         this.createViews();
                     }
                 } else {
                     var userExtData = {};
-                    if (annotationsTool.useUserExtData) {
-                        userExtData = annotationsTool.getUserExtData();
+                    if (annotationTool.useUserExtData) {
+                        userExtData = annotationTool.getUserExtData();
                     }
-                    if (annotationsTool.skipLoginFormIfPossible) {
+                    if (annotationTool.skipLoginFormIfPossible) {
                         try {
-                            annotationsTool.login(userExtData);
+                            annotationTool.login(userExtData);
                             return;
                         } catch (error) {
                             console.warn(error);
@@ -378,11 +378,11 @@ define(["jquery",
              * @alias module:views-main.Main#export
              */
             export: function () {
-                var tracksToExport = annotationsTool.video.get("tracks").getVisibleTracks();
-                var categoriesToExport = annotationsTool.video.get("categories").filter(function (category) {
+                var tracksToExport = annotationTool.video.get("tracks").getVisibleTracks();
+                var categoriesToExport = annotationTool.video.get("categories").filter(function (category) {
                     return category.get("visible");
                 });
-                annotationsTool.export(annotationsTool.video, tracksToExport, categoriesToExport);
+                annotationTool.export(annotationTool.video, tracksToExport, categoriesToExport);
             },
 
             /**
@@ -399,8 +399,8 @@ define(["jquery",
              */
             logout: function () {
                 // Stop and rewind the video
-                annotationsTool.playerAdapter.pause();
-                annotationsTool.playerAdapter.setCurrentTime(0);
+                annotationTool.playerAdapter.pause();
+                annotationTool.playerAdapter.setCurrentTime(0);
 
                  // Hide logout button
                 $("a#logout").hide();
@@ -408,29 +408,29 @@ define(["jquery",
                 // Hide/remove the views
                 $("#video-container").hide();
 
-                if (annotationsTool.getLayoutConfiguration().timeline) {
+                if (annotationTool.getLayoutConfiguration().timeline) {
                     this.timelineView.reset();
                 }
 
-                if (annotationsTool.getLayoutConfiguration().annotate) {
+                if (annotationTool.getLayoutConfiguration().annotate) {
                     this.annotateView.reset();
                 }
 
-                if (annotationsTool.getLayoutConfiguration().list) {
+                if (annotationTool.getLayoutConfiguration().list) {
                     this.listView.reset();
                 }
 
                 this.loginView.reset();
 
                 // Delete the different objects
-                delete annotationsTool.tracks;
-                delete annotationsTool.video;
-                delete annotationsTool.user;
+                delete annotationTool.tracks;
+                delete annotationTool.video;
+                delete annotationTool.user;
 
                 this.loadingBox.find(".bar").width("0%");
                 this.loadingBox.show();
 
-                annotationsTool.users.each(function (user) {
+                annotationTool.users.each(function (user) {
 
                     Backbone.localSync("delete", user, {
                         success: function () {
@@ -443,10 +443,10 @@ define(["jquery",
 
                 });
 
-                annotationsTool.modelsInitialized = false;
+                annotationTool.modelsInitialized = false;
 
-                if (annotationsTool.logoutUrl) {
-                    document.location = annotationsTool.logoutUrl;
+                if (annotationTool.logoutUrl) {
+                    document.location = annotationTool.logoutUrl;
                 } else {
                     location.reload();
                 }
@@ -459,7 +459,7 @@ define(["jquery",
             print: function () {
                 window.focus();
                 if (document.readyState === "complete") {
-                    var printView = new PrintView(annotationsTool);
+                    var printView = new PrintView(annotationTool);
                     printView.render();
                     window.print();
                     printView.remove();
@@ -490,14 +490,14 @@ define(["jquery",
                 var enabled = !$(event.target).hasClass("checked"),
                     layoutElement = event.currentTarget.id.replace("opt-", ""),
                     checkMainLayout = function () {
-                        if (!annotationsTool.views.annotate.visible && !annotationsTool.views.list.visible) {
+                        if (!annotationTool.views.annotate.visible && !annotationTool.views.list.visible) {
                             $("#left-column").removeClass("span6");
                             $("#left-column").addClass("span12");
                         } else {
                             $("#left-column").addClass("span6");
                             $("#left-column").removeClass("span12");
                         }
-                        annotationsTool.views.timeline.redraw();
+                        annotationTool.views.timeline.redraw();
                     };
 
                 if (enabled) {
@@ -515,11 +515,11 @@ define(["jquery",
                     this.annotateView.enableCategoriesLayout(enabled);
                     break;
                 case "view-annotate":
-                    annotationsTool.views.annotate.toggleVisibility();
+                    annotationTool.views.annotate.toggleVisibility();
                     checkMainLayout();
                     break;
                 case "view-list":
-                    annotationsTool.views.list.toggleVisibility();
+                    annotationTool.views.list.toggleVisibility();
                     checkMainLayout();
                     break;
                 }
@@ -531,7 +531,7 @@ define(["jquery",
              */
             toggleAutoExpand: function (event) {
                 $(event.currentTarget).toggleClass("checked");
-                annotationsTool.autoExpand = !annotationsTool.autoExpand;
+                annotationTool.autoExpand = !annotationTool.autoExpand;
             },
 
             /**
@@ -545,14 +545,14 @@ define(["jquery",
                 if (event.keyCode !== 8 ||
                     document.activeElement.tagName.toUpperCase() === "TEXTAREA" ||
                     document.activeElement.tagName.toUpperCase() === "INPUT" ||
-                    !annotationsTool.hasSelection()) {
+                    !annotationTool.hasSelection()) {
                     return;
                 } else {
                     event.preventDefault();
 
-                    annotation = annotationsTool.getSelection()[0];
+                    annotation = annotationTool.getSelection()[0];
                     if (annotation) {
-                        annotationsTool.trigger("deleteAnnotation", annotation.get("id"), annotation.trackId);
+                        annotationTool.trigger("deleteAnnotation", annotation.get("id"), annotation.trackId);
                     }
                 }
             },
@@ -567,17 +567,17 @@ define(["jquery",
                 var annotation;
 
                 if (typeof trackId === "undefined") {
-                    annotationsTool.video.get("tracks").each(function (track) {
+                    annotationTool.video.get("tracks").each(function (track) {
                         if (track.get("annotations").get(annotationId)) {
                             trackId = track.get("id");
                         }
                     });
                 }
 
-                annotation = annotationsTool.video.getAnnotation(annotationId, trackId);
+                annotation = annotationTool.video.getAnnotation(annotationId, trackId);
 
                 if (annotation) {
-                    annotationsTool.deleteOperation.start(annotation, annotationsTool.deleteOperation.targetTypes.ANNOTATION);
+                    annotationTool.deleteOperation.start(annotation, annotationTool.deleteOperation.targetTypes.ANNOTATION);
                 } else {
                     console.warn("Not able to find annotation %i on track %i", annotationId, trackId);
                 }
@@ -591,8 +591,8 @@ define(["jquery",
                 var listContent,
                     windowHeight = $(window).height(),
                     annotationsContainerHeight = $("#annotate-container").height(),
-                    loopFunctionHeight = !_.isUndefined(annotationsTool.loopFunction) && annotationsTool.loopFunction.isVisible() ?
-                                            annotationsTool.loopFunction.$el.height() + 180 : 145,
+                    loopFunctionHeight = !_.isUndefined(annotationTool.loopFunction) && annotationTool.loopFunction.isVisible() ?
+                                            annotationTool.loopFunction.$el.height() + 180 : 145,
                     videoContainerHeight = $("#video-container").height();
 
 

--- a/frontend/js/views/print.js
+++ b/frontend/js/views/print.js
@@ -49,7 +49,7 @@ define(["underscore", "backbone", "templates/print", "handlebarsHelpers"], funct
         /**
          * Constructor
          * @alias module:views-print.PrintView#initialize
-         * @param {Object} model The model managing all the annotations and related data. See {@link annotations-tool}.
+         * @param {Object} model The model managing all the annotations and related data. See {@link annotation-tool}.
          */
         initialize: function (model) {
             this.model = model;

--- a/frontend/js/views/scale-editor.js
+++ b/frontend/js/views/scale-editor.js
@@ -145,7 +145,7 @@ define(["jquery",
                     _.extend(this, Backbone.Events);
 
                     // Type use for delete operation
-                    this.scaleDeleteType = annotationsTool.deleteOperation.targetTypes.SCALE;
+                    this.scaleDeleteType = annotationTool.deleteOperation.targetTypes.SCALE;
 
                     this.$el.modal({show: true, backdrop: false, keyboard: false });
                     this.$el.modal("hide");
@@ -185,7 +185,7 @@ define(["jquery",
                  * @alias module:views-scale-editor.ScaleEditor#generateScalesForTemplate
                  */
                 generateScalesForTemplate: function () {
-                    var scales = annotationsTool.video.get("scales").toJSON(),
+                    var scales = annotationTool.video.get("scales").toJSON(),
                         selectedScale;
 
                     // Filter by access values
@@ -315,7 +315,7 @@ define(["jquery",
                  */
                 changeScale: function () {
                     this.currentScaleId = this.$el.find("select#scale-id").val();
-                    this.currentScale = annotationsTool.video.get("scales").get(this.currentScaleId);
+                    this.currentScale = annotationTool.video.get("scales").get(this.currentScaleId);
 
                     if (this.currentScale && this.currentScale.isEditable()) {
                         if (this.isInEditMode) {
@@ -345,7 +345,7 @@ define(["jquery",
 
                     this.$el.find("a#save-scale").text(this.TITLES.SAVE_BUTTON);
 
-                    annotationsTool.video.get("scales").add(this.currentScale);
+                    annotationTool.video.get("scales").add(this.currentScale);
                     this.currentScale.save({async: false});
                     this.currentScale.setUrl();
                     this.currentScale.get("scaleValues").each(function (scaleValue) {
@@ -380,7 +380,7 @@ define(["jquery",
                     var self = this;
 
                     event.stopImmediatePropagation();
-                    annotationsTool.deleteOperation.start(this.currentScale, this.scaleDeleteType, self.cancel);
+                    annotationTool.deleteOperation.start(this.currentScale, this.scaleDeleteType, self.cancel);
                 },
 
                 /**

--- a/frontend/js/views/scalevalue-editor.js
+++ b/frontend/js/views/scalevalue-editor.js
@@ -93,7 +93,7 @@ define(["jquery",
                     this.previous = attr.previous;
                     this.onChange = attr.onChange;
 
-                    this.scaleValueDeleteType = annotationsTool.deleteOperation.targetTypes.SCALEVALUE;
+                    this.scaleValueDeleteType = annotationTool.deleteOperation.targetTypes.SCALEVALUE;
                     this.setElement(this.scaleValueEditorTemplate(this.model.toJSON()));
                 },
 
@@ -194,7 +194,7 @@ define(["jquery",
                         sortedCollection = self.getSortedCollection();
 
                     event.stopImmediatePropagation();
-                    annotationsTool.deleteOperation.start(this.model, this.scaleValueDeleteType, function () {
+                    annotationTool.deleteOperation.start(this.model, this.scaleValueDeleteType, function () {
                         var currentOrder = self.model.get("order"),
                             i;
 

--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -267,8 +267,8 @@ define(["util",
                 this.playerAdapter = attr.playerAdapter;
 
                 // Type use for delete operation
-                this.typeForDeleteAnnotation = annotationsTool.deleteOperation.targetTypes.ANNOTATION;
-                this.typeForDeleteTrack = annotationsTool.deleteOperation.targetTypes.TRACK;
+                this.typeForDeleteAnnotation = annotationTool.deleteOperation.targetTypes.ANNOTATION;
+                this.typeForDeleteTrack = annotationTool.deleteOperation.targetTypes.TRACK;
 
                 this.startDate = this.getFormatedDate(0);
                 this.endDate = this.getFormatedDate(this.playerAdapter.getDuration());
@@ -317,11 +317,11 @@ define(["util",
                 // Ensure that the timeline is redraw on window resize
                 $(window).bind("resize", this.onWindowResize);
 
-                annotationsTool.addTimeupdateListener(this.onPlayerTimeUpdate, 1);
+                annotationTool.addTimeupdateListener(this.onPlayerTimeUpdate, 1);
 
                 this.$el.find(".timeline-frame > div:first-child").bind("click", function (event) {
                     if ($(event.target).find(".timeline-event").length > 0) {
-                        annotationsTool.setSelection([]);
+                        annotationTool.setSelection([]);
                     }
                 });
 
@@ -332,13 +332,13 @@ define(["util",
                 links.events.addListener(this.timeline, "add", this.onTimelineItemAdded);
                 links.events.addListener(this.timeline, "rangechange", this.timerangeChange);
 
-                this.tracks = annotationsTool.video.get("tracks");
+                this.tracks = annotationTool.video.get("tracks");
                 this.listenTo(this.tracks, "selected_track", this.markTrackSelected);
                 this.listenTo(this.tracks, Tracks.EVENTS.VISIBILITY, this.addTracksList);
                 this.listenTo(this.tracks, "change", this.changeTrack);
-                this.listenTo(annotationsTool, annotationsTool.EVENTS.ANNOTATION_SELECTION, this.onSelectionUpdate);
+                this.listenTo(annotationTool, annotationTool.EVENTS.ANNOTATION_SELECTION, this.onSelectionUpdate);
 
-                this.listenTo(annotationsTool.video.get("categories"), "change:visible", _.bind(function () {
+                this.listenTo(annotationTool.video.get("categories"), "change:visible", _.bind(function () {
                     this.preprocessAllTracks();
                     this.redraw();
                 }, this));
@@ -361,7 +361,7 @@ define(["util",
                     event.stopPropagation();
                 }, true);
 
-                this.listenTo(annotationsTool, "order", function () {
+                this.listenTo(annotationTool, "order", function () {
                     this.preprocessAllTracks();
                     this.redraw();
                 });
@@ -426,12 +426,12 @@ define(["util",
                 this.$el.find("[data-toggle='tooltip']").tooltip({ html: true });
 
                 // Restore the selections and co.
-                if (annotationsTool.hasSelection()) {
-                    this.onSelectionUpdate(annotationsTool.getSelection());
+                if (annotationTool.hasSelection()) {
+                    this.onSelectionUpdate(annotationTool.getSelection());
                     this.updateDraggingCtrl();
                 }
-                if (annotationsTool.selectedTrack) {
-                    this.markTrackSelected(annotationsTool.selectedTrack);
+                if (annotationTool.selectedTrack) {
+                    this.markTrackSelected(annotationTool.selectedTrack);
                 }
             },
 
@@ -469,7 +469,7 @@ define(["util",
              * @alias module:views-timeline.TimelineView#changeTitleFromCustomPlayhead
              */
             changeTitleFromCustomPlayhead: function () {
-                this.$el.find(".timeline-customtime").attr("title", annotationsTool.getWellFormatedTime(this.playerAdapter.getCurrentTime()));
+                this.$el.find(".timeline-customtime").attr("title", annotationTool.getWellFormatedTime(this.playerAdapter.getCurrentTime()));
             },
 
             /**
@@ -512,7 +512,7 @@ define(["util",
                     marge             = size / 20,
                     startInSecond;
 
-                if (annotationsTool.timelineFollowPlayhead) {
+                if (annotationTool.timelineFollowPlayhead) {
                     if ((currentTime - size / 2) < 0) {
                         start = this.getFormatedDate(0);
                         end = this.getFormatedDate(size);
@@ -1135,7 +1135,7 @@ define(["util",
                     // We also need to, **in front of that**, add some indicator for the track,
                     // as to preserve the ordering.
                     item.group = "<div style=\"height: " + height * 23 + "px;\">" + item.groupContent + "</div>";
-                    item.group = "<!-- track: " + annotationsTool.tracksOrder.indexOf(trackId) + " -->" + item.group;
+                    item.group = "<!-- track: " + annotationTool.tracksOrder.indexOf(trackId) + " -->" + item.group;
 
                     // We also need to set the margin of all the items to shift them to their stacking level
                     function wrap(item, level) {
@@ -1189,7 +1189,7 @@ define(["util",
 
                 this.timeline.setCustomTime(newDate);
 
-                this.$el.find("span.time").html(annotationsTool.getWellFormatedTime(currentTime, true));
+                this.$el.find("span.time").html(annotationTool.getWellFormatedTime(currentTime, true));
 
                 this.moveToCurrentTime();
             },
@@ -1202,7 +1202,7 @@ define(["util",
             selectAnnotation: function (event) {
                 var id = event.target.dataset["annotationid"],
                     trackId = event.target.dataset["trackid"];
-                annotationsTool.onClickSelectionById([{ id: id, trackId: trackId }], true, true);
+                annotationTool.onClickSelectionById([{ id: id, trackId: trackId }], true, true);
             },
 
             /**
@@ -1331,7 +1331,7 @@ define(["util",
                     delete annJSON.created_at;
 
                     destroyCallback = function () {
-                        if (annotationsTool.localStorage) {
+                        if (annotationTool.localStorage) {
                             successCallback(values.newTrack.get("annotations").create(annJSON));
                         } else {
                             values.newTrack.get("annotations").create(annJSON, {
@@ -1368,7 +1368,7 @@ define(["util",
 
                         delete self.annotationItems[annJSON.oldId];
 
-                        annotationsTool.setSelection([newAnnotation], true, true, true);
+                        annotationTool.setSelection([newAnnotation], true, true, true);
 
                         newAnnotation.set({
                             access: values.newTrack.get("access")
@@ -1395,7 +1395,7 @@ define(["util",
                     });
                     values.annotation.save();
 
-                    annotationsTool.playerAdapter.setCurrentTime(values.annotation.get("start"));
+                    annotationTool.playerAdapter.setCurrentTime(values.annotation.get("start"));
                     this.preprocessTrack(values.item.trackId);
                     this.redraw();
 
@@ -1413,7 +1413,7 @@ define(["util",
             onTimelineItemDeleted: function () {
                 var annotation = this.getSelectedItemAndAnnotation().annotation;
                 this.timeline.cancelDelete();
-                annotationsTool.deleteOperation.start(annotation, this.typeForDeleteAnnotation);
+                annotationTool.deleteOperation.start(annotation, this.typeForDeleteAnnotation);
             },
 
             /**
@@ -1483,7 +1483,7 @@ define(["util",
                     self.tracks.remove(track);
 
                     // If the track was selected
-                    if (!annotationsTool.selectedTrack || annotationsTool.selectedTrack.id === track.id) {
+                    if (!annotationTool.selectedTrack || annotationTool.selectedTrack.id === track.id) {
                         if (self.tracks.length > 0) { // If there is still other tracks
                             self.tracks.each(function (t) {
                                 if (t.get("isMine")) {
@@ -1493,7 +1493,7 @@ define(["util",
                             self.markTrackSelected(newTrack);
                         }
                     } else {
-                        self.markTrackSelected(annotationsTool.selectedTrack);
+                        self.markTrackSelected(annotationTool.selectedTrack);
                     }
 
                     delete this.trackItems[track.id];
@@ -1501,7 +1501,7 @@ define(["util",
                     this.redraw();
                 }, this);
 
-                annotationsTool.deleteOperation.start(track, this.typeForDeleteTrack, callback);
+                annotationTool.deleteOperation.start(track, this.typeForDeleteTrack, callback);
             },
 
             /**
@@ -1543,8 +1543,8 @@ define(["util",
             onChangeTrackVisibility: function (event) {
                 event.stopImmediatePropagation();
 
-                if (annotationsTool.isPrivateOnly) {
-                    annotationsTool.alertWarning(i18next.t("timeline.private only.no public tracks allowed"));
+                if (annotationTool.isPrivateOnly) {
+                    annotationTool.alertWarning(i18next.t("timeline.private only.no public tracks allowed"));
                     return;
                 }
 
@@ -1581,7 +1581,7 @@ define(["util",
                 var track = this.getTrackFromGroupHeader(event.target);
                 if (!track.get("isMine")) return;
                 if (!track) return;
-                annotationsTool.selectTrack(
+                annotationTool.selectTrack(
                     this.getTrackFromGroupHeader(event.target)
                 );
             },
@@ -1593,8 +1593,8 @@ define(["util",
             onWindowResize: function () {
                 this.preprocessAllTracks();
                 this.redraw();
-                if (annotationsTool.selectedTrack) {
-                    this.markTrackSelected(annotationsTool.selectedTrack);
+                if (annotationTool.selectedTrack) {
+                    this.markTrackSelected(annotationTool.selectedTrack);
                 }
             },
 
@@ -1633,7 +1633,7 @@ define(["util",
              */
             getSelectedItemAndAnnotation: function () {
                 //var itemId = $("." + this.ITEM_SELECTED_CLASS + " .annotation-id").text(),
-                var annotation = annotationsTool.getSelection()[0],
+                var annotation = annotationTool.getSelection()[0],
                     //selection = this.timeline.getSelection(),
                     item,
                     itemId,
@@ -1651,9 +1651,9 @@ define(["util",
                 item = this.annotationItems[itemId];
                 newTrackId = item.trackId;
                 oldTrackId = $(item.itemContent)[0].dataset.trackid;
-                oldTrack = annotationsTool.getTrack(oldTrackId);
-                newTrack = annotationsTool.getTrack(newTrackId);
-                annotation = annotationsTool.getAnnotation(itemId, oldTrack);
+                oldTrack = annotationTool.getTrack(oldTrackId);
+                newTrack = annotationTool.getTrack(newTrackId);
+                annotation = annotationTool.getAnnotation(itemId, oldTrack);
 
                 return {
                     annotation: annotation,
@@ -1763,7 +1763,7 @@ define(["util",
                 links.events.removeListener(this.timeline, "timechanged", this.onTimelineMoved);
                 links.events.removeListener(this.timeline, "change", this.onTimelineItemChanged);
                 links.events.removeListener(this.timeline, "delete", this.onTimelineItemDeleted);
-                annotationsTool.removeTimeupdateListener(this.onPlayerTimeUpdate, 1);
+                annotationTool.removeTimeupdateListener(this.onPlayerTimeUpdate, 1);
                 $(window).unbind("resize", this.onWindowResize);
 
                 this.undelegateEvents();

--- a/frontend/js/views/tracks-selection.js
+++ b/frontend/js/views/tracks-selection.js
@@ -101,7 +101,7 @@ define(["jquery",
                           "hide",
                           "search");
 
-                this.tracks = annotationsTool.getTracks();
+                this.tracks = annotationTool.getTracks();
             },
 
             /**
@@ -156,7 +156,7 @@ define(["jquery",
                 this.delegateEvents();
 
                 this.trackSelection = this.$el.find("#track-selection");
-                this.order = annotationsTool.tracksOrder;
+                this.order = annotationTool.tracksOrder;
                 this.renderSelection();
 
                 this.$el.modal({ show: true, backdrop: false, keyboard: false });
@@ -198,7 +198,7 @@ define(["jquery",
                     })
                 );
 
-                annotationsTool.orderTracks(this.sortableTrackSelection.toArray());
+                annotationTool.orderTracks(this.sortableTrackSelection.toArray());
 
                 this.hide();
             },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "annotations-tool",
+  "name": "annotationtool",
   "version": "2.0.0",
   "description": "Web application to annotate academic video.",
   "repository": {

--- a/frontend/tests/js/annotation-tool-configuration-lazy-loading.js
+++ b/frontend/tests/js/annotation-tool-configuration-lazy-loading.js
@@ -16,7 +16,7 @@
 
 /**
  * Module containing the tool configuration
- * @module annotations-tool-configuration
+ * @module annotation-tool-configuration
  */
 define(["jquery",
         "underscore",
@@ -31,15 +31,15 @@ define(["jquery",
 
         /**
          * Annotations tool configuration object
-         * @alias module:annotations-tool-configuration.Configuration
+         * @alias module:annotation-tool-configuration.Configuration
          * @enum
          */
         var Configuration =  {
 
             /**
              * List of possible layout configuration
-             * @alias module:annotations-tool-configuration.Configuration.LAYOUT_CONFIGURATION
-             * @memberOf module:annotations-tool-configuration.Configuration
+             * @alias module:annotation-tool-configuration.Configuration.LAYOUT_CONFIGURATION
+             * @memberOf module:annotation-tool-configuration.Configuration
              * @type {Object}
              */
             LAYOUT_CONFIGURATION: {
@@ -53,16 +53,16 @@ define(["jquery",
 
             /**
              * The minmal duration used for annotation representation on timeline
-             * @alias module:annotations-tool-configuration.Configuration.MINIMAL_DURATION
-             * @memberOf module:annotations-tool-configuration.Configuration
+             * @alias module:annotation-tool-configuration.Configuration.MINIMAL_DURATION
+             * @memberOf module:annotation-tool-configuration.Configuration
              * @type {Object}
              */
             MINIMAL_DURATION: 5,
 
             /**
              * Define the number of categories pro tab in the annotate box. Bigger is number, thinner will be the columns for the categories.
-             * @alias module:annotations-tool-configuration.Configuration.CATEGORIES_PER_TAB
-             * @memberOf module:annotations-tool-configuration.Configuration
+             * @alias module:annotation-tool-configuration.Configuration.CATEGORIES_PER_TAB
+             * @memberOf module:annotation-tool-configuration.Configuration
              * @type {Number}
              */
             CATEGORIES_PER_TAB: 7,
@@ -75,7 +75,7 @@ define(["jquery",
 
             /**
              * Define if the localStorage should be used or not
-             * @alias module:annotations-tool-configuration.Configuration.localStorage
+             * @alias module:annotation-tool-configuration.Configuration.localStorage
              * @type {boolean}
              * @readOnly
              */
@@ -101,7 +101,7 @@ define(["jquery",
 
             /**
              * Url from the annotations Rest Endpoints
-             * @alias module:annotations-tool-configuration.Configuration.restEndpointsUrl
+             * @alias module:annotation-tool-configuration.Configuration.restEndpointsUrl
              * @type {string}
              * @readOnly
              */
@@ -109,7 +109,7 @@ define(["jquery",
 
             /**
              * Url for redirect after the logout
-             * @alias module:annotations-tool-configuration.Configuration.logoutUrl
+             * @alias module:annotation-tool-configuration.Configuration.logoutUrl
              * @type {string}
              * @readOnly
              */
@@ -117,7 +117,7 @@ define(["jquery",
 
             /**
              * Url from the export function for statistics usage
-             * @alias module:annotations-tool-configuration.Configuration.exportUrl
+             * @alias module:annotation-tool-configuration.Configuration.exportUrl
              * @type {string}
              * @readOnly
              */
@@ -125,7 +125,7 @@ define(["jquery",
 
             /**
              * Player adapter implementation to use for the annotations tool
-             * @alias module:annotations-tool-configuration.Configuration.playerAdapter
+             * @alias module:annotation-tool-configuration.Configuration.playerAdapter
              * @type {module:player-adapter.PlayerAdapter}
              */
             playerAdapter: undefined,
@@ -138,7 +138,7 @@ define(["jquery",
 
             /**
              * Formats the given date in 
-             * @alias module:annotations-tool-configuration.Configuration.formatDate
+             * @alias module:annotation-tool-configuration.Configuration.formatDate
              * @type {module:player-adapter.formatDate}
              */
             formatDate: function (date) {
@@ -163,7 +163,7 @@ define(["jquery",
 
             /**
              * Define if the structured annotations are or not enabled
-             * @alias module:annotations-tool-configuration.Configuration.isStructuredAnnotationEnabled
+             * @alias module:annotation-tool-configuration.Configuration.isStructuredAnnotationEnabled
              * @return {boolean} True if this feature is enabled
              */
             isStructuredAnnotationEnabled: function () {
@@ -172,14 +172,14 @@ define(["jquery",
 
             /**
              * Define if the private-only mode is enabled
-             * @alias module:annotations-tool-configuration.Configuration.isPrivateOnly
+             * @alias module:annotation-tool-configuration.Configuration.isPrivateOnly
              * @type {boolean}
              */
             isPrivateOnly: false,
 
             /**
              * Define if the free text annotations are or not enabled
-             * @alias module:annotations-tool-configuration.Configuration.isFreeTextEnabled
+             * @alias module:annotation-tool-configuration.Configuration.isFreeTextEnabled
              * @return {boolean} True if this feature is enabled
              */
             isFreeTextEnabled: function () {
@@ -188,7 +188,7 @@ define(["jquery",
 
             /**
              * Get the current video id (video_extid)
-             * @alias module:annotations-tool-configuration.Configuration.getVideoExtId
+             * @alias module:annotation-tool-configuration.Configuration.getVideoExtId
              * @return {string} video external id
              */
             getVideoExtId: function () {
@@ -198,18 +198,18 @@ define(["jquery",
             /**
              * Returns the time interval between each timeupdate event to take into account.
              * It can improve a bit the performance if the amount of annotations is important. 
-             * @alias module:annotations-tool-configuration.Configuration.getTimeupdateIntervalForTimeline
+             * @alias module:annotation-tool-configuration.Configuration.getTimeupdateIntervalForTimeline
              * @return {number} The interval
              */
             getTimeupdateIntervalForTimeline: function () {
                 // TODO Check if this function should be linear
-                return Math.max(500, annotationsTool.getAnnotations().length * 3);
+                return Math.max(500, annotationTool.getAnnotations().length * 3);
 
             },
 
             /**
              * Sets the behavior of the timeline. Enable it to follow the playhead.
-             * @alias module:annotations-tool-configuration.Configuration.timelineFollowPlayhead
+             * @alias module:annotation-tool-configuration.Configuration.timelineFollowPlayhead
              * @type {Boolean}
              */
             timelineFollowPlayhead: true,
@@ -220,7 +220,7 @@ define(["jquery",
              *     - title: The title of the video
              *     - src_owner: The owner of the video in the system
              *     - src_creation_date: The date of the course, when the video itself was created.
-             * @alias module:annotations-tool-configuration.Configuration.getVideoExtId
+             * @alias module:annotation-tool-configuration.Configuration.getVideoExtId
              * @example
              * {
              *     video_extid: 123, // Same as the value returned by getVideoExtId
@@ -241,7 +241,7 @@ define(["jquery",
 
             /**
              * Get the user id from the current context (user_extid)
-             * @alias module:annotations-tool-configuration.Configuration.getUserExtId
+             * @alias module:annotation-tool-configuration.Configuration.getUserExtId
              * @return {string} user_extid
              */
             getUserExtId: function () {
@@ -250,7 +250,7 @@ define(["jquery",
 
             /**
              * Get the role of the current user
-             * @alias module:annotations-tool-configuration.Configuration.getUserRole
+             * @alias module:annotation-tool-configuration.Configuration.getUserRole
              * @return {ROLE} The current user role
              */
             getUserRole: function () {
@@ -259,7 +259,7 @@ define(["jquery",
 
             /**
              * Get the name of the admin role
-             * @alias module:annotations-tool-configuration.Configuration.getAdminRoleName
+             * @alias module:annotation-tool-configuration.Configuration.getAdminRoleName
              * @return {ROLE} The name of the admin role
              */
             getAdminRoleName: function () {
@@ -268,7 +268,7 @@ define(["jquery",
 
             /**
              * Get the user authentification token if existing
-             * @alias module:annotations-tool-configuration.Configuration.getUserAuthToken
+             * @alias module:annotation-tool-configuration.Configuration.getUserAuthToken
              * @return {string} Current user token
              */
             getUserAuthToken: function () {
@@ -277,7 +277,7 @@ define(["jquery",
 
             /**
              * Function to load the video
-             * @alias module:annotations-tool-configuration.Configuration.loadVideo
+             * @alias module:annotation-tool-configuration.Configuration.loadVideo
              */
             loadVideo: function () {
                 this.playerAdapter = new PlayerAdapter();

--- a/frontend/tests/js/annotation-tool-configuration-loading.js
+++ b/frontend/tests/js/annotation-tool-configuration-loading.js
@@ -16,7 +16,7 @@
 
 /**
  * Module containing the tool configuration
- * @module annotations-tool-configuration
+ * @module annotation-tool-configuration
  */
 define(["jquery",
         "underscore",
@@ -31,15 +31,15 @@ define(["jquery",
 
         /**
          * Annotations tool configuration object
-         * @alias module:annotations-tool-configuration.Configuration
+         * @alias module:annotation-tool-configuration.Configuration
          * @enum
          */
         var Configuration =  {
 
             /**
              * List of possible layout configuration
-             * @alias module:annotations-tool-configuration.Configuration.LAYOUT_CONFIGURATION
-             * @memberOf module:annotations-tool-configuration.Configuration
+             * @alias module:annotation-tool-configuration.Configuration.LAYOUT_CONFIGURATION
+             * @memberOf module:annotation-tool-configuration.Configuration
              * @type {Object}
              */
             LAYOUT_CONFIGURATION: {
@@ -54,16 +54,16 @@ define(["jquery",
 
             /**
              * The minmal duration used for annotation representation on timeline
-             * @alias module:annotations-tool-configuration.Configuration.MINIMAL_DURATION
-             * @memberOf module:annotations-tool-configuration.Configuration
+             * @alias module:annotation-tool-configuration.Configuration.MINIMAL_DURATION
+             * @memberOf module:annotation-tool-configuration.Configuration
              * @type {Object}
              */
             MINIMAL_DURATION: 5,
 
             /**
              * Define the number of categories pro tab in the annotate box. Bigger is number, thinner will be the columns for the categories.
-             * @alias module:annotations-tool-configuration.Configuration.CATEGORIES_PER_TAB
-             * @memberOf module:annotations-tool-configuration.Configuration
+             * @alias module:annotation-tool-configuration.Configuration.CATEGORIES_PER_TAB
+             * @memberOf module:annotation-tool-configuration.Configuration
              * @type {Number}
              */
             CATEGORIES_PER_TAB: 7,
@@ -76,7 +76,7 @@ define(["jquery",
 
             /**
              * Define if the localStorage should be used or not
-             * @alias module:annotations-tool-configuration.Configuration.localStorage
+             * @alias module:annotation-tool-configuration.Configuration.localStorage
              * @type {boolean}
              * @readOnly
              */
@@ -99,14 +99,14 @@ define(["jquery",
             plugins: {
                 Loop: function () {
                     require(["views/loop"], function (Loop) {
-                        annotationsTool.loopView = new Loop();
+                        annotationTool.loopView = new Loop();
                     });
                 }
             },
 
             /**
              * Url from the annotations Rest Endpoints
-             * @alias module:annotations-tool-configuration.Configuration.restEndpointsUrl
+             * @alias module:annotation-tool-configuration.Configuration.restEndpointsUrl
              * @type {string}
              * @readOnly
              */
@@ -114,7 +114,7 @@ define(["jquery",
 
             /**
              * Url for redirect after the logout
-             * @alias module:annotations-tool-configuration.Configuration.logoutUrl
+             * @alias module:annotation-tool-configuration.Configuration.logoutUrl
              * @type {string}
              * @readOnly
              */
@@ -122,7 +122,7 @@ define(["jquery",
 
             /**
              * Url from the export function for statistics usage
-             * @alias module:annotations-tool-configuration.Configuration.exportUrl
+             * @alias module:annotation-tool-configuration.Configuration.exportUrl
              * @type {string}
              * @readOnly
              */
@@ -130,19 +130,19 @@ define(["jquery",
 
             /**
              * Player adapter implementation to use for the annotations tool
-             * @alias module:annotations-tool-configuration.Configuration.playerAdapter
+             * @alias module:annotation-tool-configuration.Configuration.playerAdapter
              * @type {module:player-adapter.PlayerAdapter}
              */
             playerAdapter: undefined,
 
             /**
              * Function to generate the tracks to import in the tool at start time.
-             * @alias module:annotations-tool-configuration.Configuration.tracksToImport
+             * @alias module:annotation-tool-configuration.Configuration.tracksToImport
              */
             tracksToImport: function () {
 
                 var annStart = 0,
-                    duration = annotationsTool.playerAdapter.getDuration(),
+                    duration = annotationTool.playerAdapter.getDuration(),
                     track,
                     tracks = [],
                     diff = 50,
@@ -187,25 +187,25 @@ define(["jquery",
             /**
              * Returns the time interval between each timeupdate event to take into account.
              * It can improve a bit the performance if the amount of annotations is important. 
-             * @alias module:annotations-tool-configuration.Configuration.getTimeupdateIntervalForTimeline
+             * @alias module:annotation-tool-configuration.Configuration.getTimeupdateIntervalForTimeline
              * @return {number} The interval
              */
             getTimeupdateIntervalForTimeline: function () {
                 // TODO Check if this function should be linear
-                return Math.max(500, annotationsTool.getAnnotations().length * 3);
+                return Math.max(500, annotationTool.getAnnotations().length * 3);
 
             },
 
             /**
              * Sets the behavior of the timeline. Enable it to follow the playhead.
-             * @alias module:annotations-tool-configuration.Configuration.timelineFollowPlayhead
+             * @alias module:annotation-tool-configuration.Configuration.timelineFollowPlayhead
              * @type {Boolean}
              */
             timelineFollowPlayhead: false,
 
             /**
              * Formats the given date in 
-             * @alias module:annotations-tool-configuration.Configuration.formatDate
+             * @alias module:annotation-tool-configuration.Configuration.formatDate
              * @type {module:player-adapter.formatDate}
              */
             formatDate: function (date) {
@@ -230,7 +230,7 @@ define(["jquery",
 
             /**
              * Define if the structured annotations are or not enabled
-             * @alias module:annotations-tool-configuration.Configuration.isStructuredAnnotationEnabled
+             * @alias module:annotation-tool-configuration.Configuration.isStructuredAnnotationEnabled
              * @return {boolean} True if this feature is enabled
              */
             isStructuredAnnotationEnabled: function () {
@@ -239,14 +239,14 @@ define(["jquery",
 
             /**
              * Define if the private-only mode is enabled
-             * @alias module:annotations-tool-configuration.Configuration.isPrivateOnly
+             * @alias module:annotation-tool-configuration.Configuration.isPrivateOnly
              * @type {boolean}
              */
             isPrivateOnly: false,
 
             /**
              * Define if the free text annotations are or not enabled
-             * @alias module:annotations-tool-configuration.Configuration.isFreeTextEnabled
+             * @alias module:annotation-tool-configuration.Configuration.isFreeTextEnabled
              * @return {boolean} True if this feature is enabled
              */
             isFreeTextEnabled: function () {
@@ -255,7 +255,7 @@ define(["jquery",
 
             /**
              * Get the current video id (video_extid)
-             * @alias module:annotations-tool-configuration.Configuration.getVideoExtId
+             * @alias module:annotation-tool-configuration.Configuration.getVideoExtId
              * @return {string} video external id
              */
             getVideoExtId: function () {
@@ -268,7 +268,7 @@ define(["jquery",
              *     - title: The title of the video
              *     - src_owner: The owner of the video in the system
              *     - src_creation_date: The date of the course, when the video itself was created.
-             * @alias module:annotations-tool-configuration.Configuration.getVideoExtId
+             * @alias module:annotation-tool-configuration.Configuration.getVideoExtId
              * @example
              * {
              *     video_extid: 123, // Same as the value returned by getVideoExtId
@@ -289,7 +289,7 @@ define(["jquery",
 
             /**
              * Get the user id from the current context (user_extid)
-             * @alias module:annotations-tool-configuration.Configuration.getUserExtId
+             * @alias module:annotation-tool-configuration.Configuration.getUserExtId
              * @return {string} user_extid
              */
             getUserExtId: function () {
@@ -298,7 +298,7 @@ define(["jquery",
 
             /**
              * Get the role of the current user
-             * @alias module:annotations-tool-configuration.Configuration.getUserRole
+             * @alias module:annotation-tool-configuration.Configuration.getUserRole
              * @return {ROLE} The current user role
              */
             getUserRole: function () {
@@ -307,7 +307,7 @@ define(["jquery",
 
             /**
              * Get the name of the admin role
-             * @alias module:annotations-tool-configuration.Configuration.getAdminRoleName
+             * @alias module:annotation-tool-configuration.Configuration.getAdminRoleName
              * @return {ROLE} The name of the admin role
              */
             getAdminRoleName: function () {
@@ -316,7 +316,7 @@ define(["jquery",
 
             /**
              * Get the user authentification token if existing
-             * @alias module:annotations-tool-configuration.Configuration.getUserAuthToken
+             * @alias module:annotation-tool-configuration.Configuration.getUserAuthToken
              * @return {string} Current user token
              */
             getUserAuthToken: function () {
@@ -325,10 +325,10 @@ define(["jquery",
 
             /**
              * Function to load the video
-             * @alias module:annotations-tool-configuration.Configuration.loadVideo
+             * @alias module:annotation-tool-configuration.Configuration.loadVideo
              */
             loadVideo: function () {
-                annotationsTool.playerAdapter = new HTML5PlayerAdapter($("video")[0]);
+                annotationTool.playerAdapter = new HTML5PlayerAdapter($("video")[0]);
             },
 
             onWindowResize: function () {

--- a/frontend/tests/js/annotation-tool-configuration.js
+++ b/frontend/tests/js/annotation-tool-configuration.js
@@ -12,7 +12,7 @@ define(['domReady',
         /**
          * Annotations tool configuration
          */
-        window.annotationsTool = {
+        window.annotationTool = {
 
             /** Define if the localStorage should be used or not */
             localStorage: true,
@@ -20,8 +20,8 @@ define(['domReady',
 
             /**
              * List of possible layout configuration
-             * @alias module:annotations-tool-configuration.Configuration.LAYOUT_CONFIGURATION
-             * @memberOf module:annotations-tool-configuration.Configuration
+             * @alias module:annotation-tool-configuration.Configuration.LAYOUT_CONFIGURATION
+             * @memberOf module:annotation-tool-configuration.Configuration
              * @type {Object}
              */
             LAYOUT_CONFIGURATION: {
@@ -73,8 +73,7 @@ define(['domReady',
 
         domReady(function () {
             /* Player adapter implementation to use for the annotations tool */
-            // window.annotationsTool.playerAdapter = new HTML5PlayerAdapter($('video')[0]);
-
+            // window.annotationTool.playerAdapter = new HTML5PlayerAdapter($('video')[0]);
         });
 
         return window.annotations;

--- a/frontend/tests/js/backbone-annotations-sync.js
+++ b/frontend/tests/js/backbone-annotations-sync.js
@@ -29,7 +29,7 @@ define(["jquery",
              
                var self = this;
 
-               if (_.contains(annotationsTool.localStorageOnlyModel ,model.TYPE)) {
+               if (_.contains(annotationTool.localStorageOnlyModel ,model.TYPE)) {
                   return Backbone.localSync(method, model, options);
                }
                
@@ -74,12 +74,12 @@ define(["jquery",
                 */
                this.setHeaderParams = function(xhr) {
                     // Use request user id
-                    if(annotationsTool.user)
-                         xhr.setRequestHeader(self.config.headerParams.userId, annotationsTool.user.id);
+                    if(annotationTool.user)
+                         xhr.setRequestHeader(self.config.headerParams.userId, annotationTool.user.id);
                     
                     // Set user token in request header if a token is given
                     var token;
-                    if(annotationsTool.getUserAuthToken && !_.isUndefined(token = annotationsTool.getUserAuthToken()))
+                    if(annotationTool.getUserAuthToken && !_.isUndefined(token = annotationTool.getUserAuthToken()))
                       xhr.setRequestHeader(self.config.headerParams.token, token); 
                };
                

--- a/frontend/tests/js/lazy-loading.js
+++ b/frontend/tests/js/lazy-loading.js
@@ -1,13 +1,13 @@
 require(["jquery",
-         "../tests/js/annotations-tool-configuration-lazy-loading",
-         "annotations-tool-main",
+         "../tests/js/annotation-tool-configuration-lazy-loading",
+         "annotation-tool-main",
          "models/video",
          "collections/videos",
          "prototypes/player_adapter",
          "backbone-annotations-sync",
          "sinon"],
 
-        function ($, Configuration, annotationsTool, Video, Videos, PlayerAdapter, AnnotationSync, sinon) {
+        function ($, Configuration, annotationTool, Video, Videos, PlayerAdapter, AnnotationSync, sinon) {
 
 
                 var contentJSON = { "Content-Type": "application/json" },
@@ -189,43 +189,43 @@ require(["jquery",
                             server.respondWith("GET",  baseUrl + "/videos/1/tracks/4/annotations", [200, contentJSON, JSON.stringify(annotationsJSON)]);
                             server.autoRespond = true;
 
-                            if (!annotationsTool.started) {
-                                annotationsTool.start(Configuration);
-                                annotationsTool.started = true;
+                            if (!annotationTool.started) {
+                                annotationTool.start(Configuration);
+                                annotationTool.started = true;
                             }
 
                         },
 
                         teardown: function () {
-                            annotationsTool.MAX_VISIBLE_TRACKS = 2;
+                            annotationTool.MAX_VISIBLE_TRACKS = 2;
 
-                            annotationsTool.fetchData();
+                            annotationTool.fetchData();
                             server.restore();
                         }
 
                     });
 
                 test("Load two tracks", function () {
-                    annotationsTool.fetchData();
+                    annotationTool.fetchData();
 
-                    equal(annotationsTool.getTracks().size(), 4, "The video should have a total of 4 tracks.");
-                    equal(annotationsTool.getAnnotations().length, 8, "Only the annotations of the first two tracks should be loaded.");
-                    equal(annotationsTool.getTracks().visibleTracks.length, 2, "Only the first two tracks should be loaded.");
+                    equal(annotationTool.getTracks().size(), 4, "The video should have a total of 4 tracks.");
+                    equal(annotationTool.getAnnotations().length, 8, "Only the annotations of the first two tracks should be loaded.");
+                    equal(annotationTool.getTracks().visibleTracks.length, 2, "Only the first two tracks should be loaded.");
                 });
 
 
                 test("Load one tracks", function () {
-                    annotationsTool.MAX_VISIBLE_TRACKS = 1;
+                    annotationTool.MAX_VISIBLE_TRACKS = 1;
 
-                    annotationsTool.fetchData();
+                    annotationTool.fetchData();
 
-                    equal(annotationsTool.getTracks().size(), 4, "The video should have a total of 4 tracks.");
-                    equal(annotationsTool.getAnnotations().length, 4, "Only the annotations of the first two tracks should be loaded.");
-                    equal(annotationsTool.getTracks().visibleTracks.length, 1, "Only the first two tracks should be loaded.");
+                    equal(annotationTool.getTracks().size(), 4, "The video should have a total of 4 tracks.");
+                    equal(annotationTool.getAnnotations().length, 4, "Only the annotations of the first two tracks should be loaded.");
+                    equal(annotationTool.getTracks().visibleTracks.length, 1, "Only the first two tracks should be loaded.");
                 });
 
                 test("Try to display more tracks than the maximum set (tracks 2,3,4 when MAX_VISIBLE_TRACKS is 2)", function () {
-                    var tracks = annotationsTool.getTracks(),
+                    var tracks = annotationTool.getTracks(),
                         visibleTracks = [];
 
                     tracks.showTracksById([2, 3, 4]);
@@ -243,7 +243,7 @@ require(["jquery",
                 });
 
                 test("Display tracks 3 and 4", function () {
-                    var tracks = annotationsTool.getTracks(),
+                    var tracks = annotationTool.getTracks(),
                         visibleTracks = [];
 
                     tracks.showTracksById([3, 4]);
@@ -260,7 +260,7 @@ require(["jquery",
                 });
 
                 test("Display single track (4)", function () {
-                    var tracks = annotationsTool.getTracks(),
+                    var tracks = annotationTool.getTracks(),
                         visibleTracks = [];
 
                     tracks.showTracks(tracks.get(4));
@@ -277,7 +277,7 @@ require(["jquery",
                 });
 
                 test("Hide tracks 1 and 2", function () {
-                    var tracks = annotationsTool.getTracks(),
+                    var tracks = annotationTool.getTracks(),
                         visibleTracks = [];
 
                     tracks.hideTracksById([1, 2]);
@@ -299,7 +299,7 @@ require(["jquery",
                 });
 
                 test("Hide single track (2)", function () {
-                    var tracks = annotationsTool.getTracks(),
+                    var tracks = annotationTool.getTracks(),
                         visibleTracks = [];
 
                     tracks.hideTracks(tracks.get(2));

--- a/frontend/tests/js/loop.js
+++ b/frontend/tests/js/loop.js
@@ -23,12 +23,12 @@ require(["jquery",
                             }
                         };
 
-                        if (_.isUndefined(annotationsTool)) {
-                            annotationsTool = {};
+                        if (_.isUndefined(annotationTool)) {
+                            annotationTool = {};
                         }
 
-                        if (_.isUndefined(annotationsTool.localStorageOnlyModel)) {
-                            annotationsTool.localStorageOnlyModel = [];
+                        if (_.isUndefined(annotationTool.localStorageOnlyModel)) {
+                            annotationTool.localStorageOnlyModel = [];
                         }
                     };
 
@@ -119,21 +119,21 @@ require(["jquery",
 
                             timeline.getFormatedDate.returns(new Date());
 
-                            annotationsTool.playerAdapter = playerAdapter;
-                            annotationsTool.video = video;
-                            annotationsTool.views = {timeline: timeline};
+                            annotationTool.playerAdapter = playerAdapter;
+                            annotationTool.video = video;
+                            annotationTool.views = {timeline: timeline};
 
                             $("body").append("<div style=\"display:none\"><div id=\"video-container\"></div></div>");
 
-                            _.extend(annotationsTool.playerAdapter, $("#video-container"));
+                            _.extend(annotationTool.playerAdapter, $("#video-container"));
 
                             loopView = new LoopView();
                         },
 
                         teardown: function () {
                             loopView.reset();
-                            delete annotationsTool.playerAdapter;
-                            delete annotationsTool.timeline;
+                            delete annotationTool.playerAdapter;
+                            delete annotationTool.timeline;
                         }
                 });
 
@@ -150,35 +150,35 @@ require(["jquery",
 
                 test("Check loop position on timeupdate", function () {
                     var currentLoop = undefined,
-                        setCurrentTimeCall = annotationsTool.playerAdapter.setCurrentTime.callCount;
+                        setCurrentTimeCall = annotationTool.playerAdapter.setCurrentTime.callCount;
 
-                    annotationsTool.playerAdapter.getCurrentTime.returns(1);
-                    $(annotationsTool.playerAdapter).trigger(PlayerAdapter.EVENTS.TIMEUPDATE);
+                    annotationTool.playerAdapter.getCurrentTime.returns(1);
+                    $(annotationTool.playerAdapter).trigger(PlayerAdapter.EVENTS.TIMEUPDATE);
                     currentLoop = loopView.currentLoop;
                     equal(currentLoop, undefined, "No loop should be active");
 
-                    annotationsTool.playerAdapter.getCurrentTime.returns(0);
+                    annotationTool.playerAdapter.getCurrentTime.returns(0);
                     loopView.toggle(true);
-                    annotationsTool.playerAdapter.getCurrentTime.returns(2);
-                    $(annotationsTool.playerAdapter).trigger(PlayerAdapter.EVENTS.TIMEUPDATE);
+                    annotationTool.playerAdapter.getCurrentTime.returns(2);
+                    $(annotationTool.playerAdapter).trigger(PlayerAdapter.EVENTS.TIMEUPDATE);
                     notEqual(loopView.currentLoop, undefined, "One loop should be active");
                     notEqual(loopView.currentLoop, currentLoop, "The current loop should have changed");
                     currentLoop = loopView.currentLoop;
 
-                    annotationsTool.playerAdapter.getCurrentTime.returns(9);
-                    $(annotationsTool.playerAdapter).trigger(PlayerAdapter.EVENTS.TIMEUPDATE);
+                    annotationTool.playerAdapter.getCurrentTime.returns(9);
+                    $(annotationTool.playerAdapter).trigger(PlayerAdapter.EVENTS.TIMEUPDATE);
                     notEqual(loopView.currentLoop.cid, currentLoop.cid, "The current loop should have changed");
                     currentLoop = loopView.currentLoop;
 
-                    annotationsTool.playerAdapter.getCurrentTime.returns(10);
-                    $(annotationsTool.playerAdapter).trigger(PlayerAdapter.EVENTS.TIMEUPDATE);
-                    notEqual(annotationsTool.playerAdapter.setCurrentTime.callCount, setCurrentTimeCall, "The current loop should have been repeated");
-                    ok(annotationsTool.playerAdapter.play.calledOnce, "The video being at the end and the loop being repeated, the video should contine");
+                    annotationTool.playerAdapter.getCurrentTime.returns(10);
+                    $(annotationTool.playerAdapter).trigger(PlayerAdapter.EVENTS.TIMEUPDATE);
+                    notEqual(annotationTool.playerAdapter.setCurrentTime.callCount, setCurrentTimeCall, "The current loop should have been repeated");
+                    ok(annotationTool.playerAdapter.play.calledOnce, "The video being at the end and the loop being repeated, the video should contine");
                     equal(loopView.currentLoop.cid, currentLoop.cid, "The current loop should still be the same");
                     currentLoop = loopView.currentLoop;
 
-                    annotationsTool.playerAdapter.getCurrentTime.returns(2);
-                    $(annotationsTool.playerAdapter).trigger(PlayerAdapter.EVENTS.TIMEUPDATE);
+                    annotationTool.playerAdapter.getCurrentTime.returns(2);
+                    $(annotationTool.playerAdapter).trigger(PlayerAdapter.EVENTS.TIMEUPDATE);
                     notEqual(loopView.currentLoop.cid, currentLoop.cid, "The current loop should have change");
                 });
 

--- a/frontend/tests/js/require/config-loading.js
+++ b/frontend/tests/js/require/config-loading.js
@@ -2,8 +2,8 @@
 require.config({
     baseUrl: "./../js",
     paths: {
-        "annotations-tool"               : "annotations-tool",
-        "annotations-tool-configuration" : "../tests/js/annotations-tool-configuration-loading",
+        "annotation-tool"               : "annotation-tool",
+        "annotation-tool-configuration" : "../tests/js/annotation-tool-configuration-loading",
         "backbone"                       : "libs/backbone/backbone-0.9.9",
         "bootstrap"                      : "libs/bootstrap/bootstrap.min",
         "carousel"                       : "libs/bootstrap/carousel2.2",
@@ -78,7 +78,7 @@ require.config({
 });
 
 // Bootstrap function for main app
-require(["domReady", "annotations-tool-configuration", "annotations-tool", "raf"],
+require(["domReady", "annotation-tool-configuration", "annotation-tool", "raf"],
 
 function (domReady, config, app) {
     domReady(function () {

--- a/frontend/tests/js/require/config.js
+++ b/frontend/tests/js/require/config.js
@@ -2,9 +2,9 @@
 require.config({
     baseUrl: "./../js",
     paths: {
-        "annotations-tool"               : "annotations-tool-configuration",
-        "annotations-tool-main"          : "annotations-tool",
-        "annotations-tool-configuration" : "../tests/js/annotations-tool-configuration",
+        "annotation-tool"               : "annotation-tool-configuration",
+        "annotation-tool-main"          : "annotation-tool",
+        "annotation-tool-configuration" : "../tests/js/annotation-tool-configuration",
         "backbone"                       : "libs/backbone/backbone-0.9.9",
         "bootstrap"                      : "libs/bootstrap/bootstrap.min",
         "carousel"                       : "libs/bootstrap/carousel2.2",

--- a/frontend/tests/js/require/loop.js
+++ b/frontend/tests/js/require/loop.js
@@ -6,6 +6,6 @@ require(['config'], function () {
     QUnit.config.autostart = false;
     QUnit.config.autorun   = false;
 
-    require(['tests/annotations-tool-configuration',
+    require(['tests/annotation-tool-configuration',
              'tests/loop']);
 });

--- a/frontend/tests/js/require/main-collections.js
+++ b/frontend/tests/js/require/main-collections.js
@@ -7,7 +7,7 @@ require(['config'], function () {
     QUnit.config.autorun = false;
 
     require(['domReady',
-             'tests/annotations-tool-configuration',
+             'tests/annotation-tool-configuration',
              'tests/tracks',
              'tests/annotations',
              'tests/categories',

--- a/frontend/tests/js/require/main-models.js
+++ b/frontend/tests/js/require/main-models.js
@@ -7,7 +7,7 @@ require(['config'], function () {
     QUnit.config.autorun = false;
 
     require(['domReady',
-            'tests/annotations-tool-configuration',
+            'tests/annotation-tool-configuration',
             'tests/user',
             'tests/video',
             'tests/track',

--- a/frontend/tests/js/require/main-rest.js
+++ b/frontend/tests/js/require/main-rest.js
@@ -2,12 +2,11 @@
 // RequireJS configuration for main app
 define(["config"], function () {
     require(["jquery",
-             "annotations-tool-configuration"
+             "annotation-tool-configuration"
              //... add other test file here, files have to be in directory tests/js
              ],
 
-            
-            function($){
+            function ($) {
                     QUnit.config.reorder   = false;
                     QUnit.config.autostart = false;
                     QUnit.config.autorun = false;
@@ -33,7 +32,7 @@ define(["config"], function () {
                                   $.ajax({
                                         type: "DELETE",
                                         async: false,
-                                        url: window.annotationsTool.restEndpointsUrl + "/reset",
+                                        url: window.annotationTool.restEndpointsUrl + "/reset",
                                         success: function () {
                                           QUnit.start.call();
                                         }

--- a/frontend/tests/js/rest-category-and-label.js
+++ b/frontend/tests/js/rest-category-and-label.js
@@ -29,10 +29,10 @@ define(['models/category',
                 
                 loadUser = function(){
                     users = new Users();
-                    var userExtId = window.annotationsTool.getUserExtId();
+                    var userExtId = window.annotationTool.getUserExtId();
                     users.create({user_extid:userExtId,nickname:'pinguin', email: "test@dot.com"});
                     user = users.at(0);
-                    window.annotationsTool.user = user;
+                    window.annotationTool.user = user;
                     isUserLoaded = true;
                 }
                 

--- a/frontend/tests/js/rest-comments.js
+++ b/frontend/tests/js/rest-comments.js
@@ -41,9 +41,9 @@ require(['domReady',
                 
                 var loadUser = function(){
                     users = new Users();
-                    var userExtId = window.annotationsTool.getUserExtId();
+                    var userExtId = window.annotationTool.getUserExtId();
                     user = users.create({user_extid:userExtId,nickname:'pinguin', email: "test@dot.com"});
-                    window.annotationsTool.user = user;
+                    window.annotationTool.user = user;
                     isUserLoaded = true;
                 }
                 

--- a/frontend/tests/js/rest-scale-and-scalevalue.js
+++ b/frontend/tests/js/rest-scale-and-scalevalue.js
@@ -28,10 +28,10 @@ define(['domReady',
                 
                 var loadUser = function(){
                     users = new Users();
-                    var userExtId = window.annotationsTool.getUserExtId();
+                    var userExtId = window.annotationTool.getUserExtId();
                     users.create({user_extid:userExtId,nickname:'pinguin', email: "test@dot.com"});
                     user = users.at(0);
-                    window.annotationsTool.user = user;
+                    window.annotationTool.user = user;
                     isUserLoaded = true;
                 }
                 

--- a/frontend/tests/js/rest-user.js
+++ b/frontend/tests/js/rest-user.js
@@ -15,7 +15,7 @@ define(['domReady',
                     userExtId;
                 
                 users = new Users();
-                userExtId = window.annotationsTool.getUserExtId();
+                userExtId = window.annotationTool.getUserExtId();
                 user = new User({user_extid:userExtId,nickname:'pinguin', email: "test@dot.com"});
                 users.add(user);
                 
@@ -43,7 +43,7 @@ define(['domReady',
                             equal(data.deleted_at, null, "Deleted_at date is correct");
                             equal(data.deleted_by, null, "Deleted_by user is correct");
                             user.set(data);
-                            window.annotationsTool.user = user;
+                            window.annotationTool.user = user;
                             start();
                         }
                     });

--- a/frontend/tests/js/rest-video-and-track.js
+++ b/frontend/tests/js/rest-video-and-track.js
@@ -38,10 +38,10 @@ define(['domReady',
             
             var loadUser = function(){
                 users = new Users();
-                var userExtId = window.annotationsTool.getUserExtId();
+                var userExtId = window.annotationTool.getUserExtId();
                 users.create({user_extid:userExtId,nickname:'pinguin', email: "test@dot.com"});
                 user = users.at(0);
-                window.annotationsTool.user = user;
+                window.annotationTool.user = user;
                 isUserLoaded = true;
             }
             

--- a/frontend/tests/lazy-loading.html
+++ b/frontend/tests/lazy-loading.html
@@ -10,7 +10,7 @@
         <script type="text/javascript" src="../js/libs/tests/qunit.js"></script>
         <script data-main="js/require/lazy-loading.js" src="../js/libs/require/require.js"></script>
         <script src="js/require/lazy-loading.js" ></script>
-        <script src="../js/libs/tests/blanket.js" data-cover-flags="debug" data-cover-only="['./../js/annotations-tool,'./../js/models/track','./../js/models/video','./../js/collections/tracks','./../js/collections/videos']"></script>
+        <script src="../js/libs/tests/blanket.js" data-cover-flags="debug" data-cover-only="['./../js/annotation-tool,'./../js/models/track','./../js/models/video','./../js/collections/tracks','./../js/collections/videos']"></script>
         <script>
             if (location.href.match(/(\?|&)gruntReport($|&|=)/)) {
                 blanket.options("reporter", "reporter/grunt-reporter.js");


### PR DESCRIPTION
I took the freedom to rename all the remaining things called `annotations-tool` (and variations of that) to `annotation-tool` (and the corresponding variation of that ...). For the lazy readers (which includes me): The difference between the two is the plural s.

This PR does nothing else but I would still like to have a second pair of eyes on it, because it is so big.