### PR TITLE
Added a border to the timeline items

### DIFF
--- a/frontend/style/timeline/timeline-custom.less
+++ b/frontend/style/timeline/timeline-custom.less
@@ -285,7 +285,7 @@ div.timeline-bottom-controls {
 
 div.timeline-item {
     background-color: fade(@grayLight,25%);
-    border: 1px solid transparent;
+    border: 0.5px solid @black;
     padding: 2px;
     overflow: hidden;
     z-index: 4;


### PR DESCRIPTION
Especially the free text annotations were colored in the same gray
as the selected track, so they were basically invisible. ;)

Closes #99.

@rrolf I mean you just saw it, but just to make sure it works everywhere, here is a PR. :wink: 