### PR TITLE
Allow an empty email address

### DIFF
--- a/frontend/js/models/user.js
+++ b/frontend/js/models/user.js
@@ -103,7 +103,7 @@ define(["jquery",
                     };
                 }
 
-                if (!emailAddresses.parseOneAddress(attr.email)) {
+                if (attr.email && !emailAddresses.parseOneAddress(attr.email)) {
                     return {
                         attribute: "email",
                         message: "Given email is not valid!"


### PR DESCRIPTION
Commit 78eb24de, among others, cleaned up some of the user validation code. This also changed the behavior from "if there is an E-Mail address it has to be valid" to "there has to be a valid E-Mail address". For us this leads to failed login attempts, which in turn presents the user with the old login dialog. Our users exist only temporarily in Opencast through the LTI integration. In Moodle there is the possibility to also transmit the E-Mail address to Opencast, but currently there is no code that would handle that. Also I'm not sure if this can be configured for every LMS. So this PR restores the old behavior.