### PR TITLE
Fix artifactPrefix for 5.0 and newer

### DIFF
--- a/documentation/opencast-installation.md
+++ b/documentation/opencast-installation.md
@@ -30,9 +30,9 @@ In this manual we use `<annotationtool-dir>` for the base dir of the Annotation 
 This should build the frontend, include it into the Opencast modules and copies the JARs
 to your Opencast installation.
 
-Note that if you build with `opencast.version` set to something `>= 5`, you also have to specify
-`-Dopencast.artifactPrefix=opencast` because of the transition away from the `matterhorn` name
-between versions `4` and `5`.
+Note that if you build with `opencast.version` set to something `<= 4`, you also have to specify
+`-Dopencast.artifactPrefix="matterhorn-" -Dopencast.osgi.jndi.service.name=jdbc/matterhorn` because
+of the transition away from the `matterhorn` name between versions `4` and `5`.
 
 #### As a Karaf Feature
 
@@ -110,7 +110,7 @@ Users are only allowed to access the annotation tool if the have the action `ann
 
 ### Adding Distribution to Annotation Tool to the Workflow
 
-Although the Annotation Tool can access a recording when it shows up in the Opencast search service, the Annotation Tool can also be added to the list of publications for an event. 
+Although the Annotation Tool can access a recording when it shows up in the Opencast search service, the Annotation Tool can also be added to the list of publications for an event.
 
 Within the `etc/workflows/ng-partial-publish` you need to add this operation to the `<operations>` section. It is recommended to add it after the "publish-engage" operation.
 

--- a/opencast-backend/annotation-api/pom.xml
+++ b/opencast-backend/annotation-api/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>${opencast.artifactPrefix}-common</artifactId>
+      <artifactId>${opencast.artifactPrefix}common</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/opencast-backend/annotation-impl/pom.xml
+++ b/opencast-backend/annotation-impl/pom.xml
@@ -23,11 +23,11 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>${opencast.artifactPrefix}-common</artifactId>
+      <artifactId>${opencast.artifactPrefix}common</artifactId>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>${opencast.artifactPrefix}-search-service-api</artifactId>
+      <artifactId>${opencast.artifactPrefix}search-service-api</artifactId>
       <version>${opencast.version}</version>
     </dependency>
     <!-- Logging -->

--- a/opencast-backend/annotation-impl/src/main/resources/META-INF/persistence.xml
+++ b/opencast-backend/annotation-impl/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.1" xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence     http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
   <persistence-unit name="org.opencast.annotation.impl.persistence" transaction-type="RESOURCE_LOCAL">
     <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-    <non-jta-data-source>osgi:service/javax.sql.DataSource/(osgi.jndi.service.name=jdbc/${opencast.artifactPrefix})</non-jta-data-source>
+    <non-jta-data-source>osgi:service/javax.sql.DataSource/(osgi.jndi.service.name=${opencast.osgi.jndi.service.name})</non-jta-data-source>
     <class>org.opencast.annotation.impl.persistence.VideoDto</class>
     <class>org.opencast.annotation.impl.persistence.LabelDto</class>
     <class>org.opencast.annotation.impl.persistence.ScaleValueDto</class>

--- a/opencast-backend/annotation-tool/pom.xml
+++ b/opencast-backend/annotation-tool/pom.xml
@@ -21,7 +21,7 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>${opencast.artifactPrefix}-common</artifactId>
+      <artifactId>${opencast.artifactPrefix}common</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>

--- a/opencast-backend/pom.xml
+++ b/opencast-backend/pom.xml
@@ -27,7 +27,7 @@
     <dependencies>
       <dependency>
         <groupId>org.opencastproject</groupId>
-        <artifactId>${opencast.artifactPrefix}-common</artifactId>
+        <artifactId>${opencast.artifactPrefix}common</artifactId>
         <version>${opencast.version}</version>
         <scope>provided</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,8 @@
     <cxf.version>3.1.7</cxf.version>
     <jackson.version>2.7.0</jackson.version>
     <opencast.version>[2.3,)</opencast.version>
-    <opencast.artifactPrefix>matterhorn</opencast.artifactPrefix>
+    <opencast.artifactPrefix></opencast.artifactPrefix>
+    <opencast.osgi.jndi.service.name>jdbc/opencast</opencast.osgi.jndi.service.name>
   </properties>
 
   <modules>


### PR DESCRIPTION
The `artifactPrefix` assumes that matterhorn is simply renamed to "opencast"; instead "matterhorn-" is just dropped form the `artefactId`. This also adds the `opencast.osgi.jndi.service.name` property and updates the documentation accordingly. By default the main `pom.xml` file is now configured for Opencast 5.0.