### PR TITLE
Made comment counts update recursively

### DIFF
--- a/frontend/js/models/comment.js
+++ b/frontend/js/models/comment.js
@@ -65,10 +65,16 @@ define(["jquery",
                 // Fix up circular dependency
                 if (!Comments) Comments = require("collections/comments");
 
-                if (!this.replies) this.replies = new Comments(null, {
-                    annotation: this.collection.annotation,
-                    replyTo: this
-                });
+                if (!this.replies) {
+                    this.replies = new Comments(null, {
+                        annotation: this.collection.annotation,
+                        replyTo: this
+                    });
+
+                    this.listenTo(this.replies, "add remove reset reply", function () {
+                        this.trigger("reply");
+                    });
+                }
 
                 var invalidResource = Resource.prototype.validate.call(this, attr, {
                     onIdChange: function () {

--- a/frontend/js/views/comment.js
+++ b/frontend/js/views/comment.js
@@ -106,6 +106,8 @@ define(["jquery",
 
                 this.replyContainer = new CommentsContainer({ collection: this.model.replies });
 
+                this.listenTo(this.model, "reply", this.render);
+
                 return this;
             },
 

--- a/frontend/js/views/list-annotation.js
+++ b/frontend/js/views/list-annotation.js
@@ -114,6 +114,7 @@ define(["jquery",
                 });
 
                 this.model.fetchComments();
+                this.listenTo(this.model.get("comments"), "add remove reset reply", this.render);
 
                 if (this.model.get("label")) {
                     category = this.model.get("label").category;


### PR DESCRIPTION
The comment/reply counts in the annotation list were not always up to date. When you create a reply to a comment, the reply count for **that** comment should be updated, but all its descendants did not have their count updated! This PR fixes that.