### PR TITLE
Fix exception during export when no e-mail is set

### DIFF
--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/VideoEndpoint.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/VideoEndpoint.java
@@ -1028,7 +1028,7 @@ public class VideoEndpoint {
           line.add(annotation.getCreatedAt().map(AbstractResourceDto.getDateAsUtc).getOrElse(""));
           line.add(annotation.getUpdatedAt().map(AbstractResourceDto.getDateAsUtc).getOrElse(""));
           line.add(annotation.getCreatedBy().map(AbstractResourceDto.getUserNickname.curry(eas)).getOrElse(""));
-          line.add(option(annotation.getCreatedBy().map(getUserEmail.curry(eas)).getOrElse("")).getOrElse(""));
+          line.add(annotation.getCreatedBy().map(getUserEmail.curry(eas)).getOrElse(""));
           line.add(track.getName());
 
           double start = annotation.getStart(); // start, stop, duration
@@ -1078,7 +1078,7 @@ public class VideoEndpoint {
       if (user.isNone())
         return null;
 
-      return user.get().getEmail().getOrElse((String) null);
+      return user.get().getEmail().getOrElse("");
     }
   };
 


### PR DESCRIPTION
`getCreatedBy()` returns a `some` value, which can only be mapped to non-`null` values. When the e-mail is `null` the `map` fails and an exception is thrown. A CSV with status 200 is still returned leaving the user with a truncated file (or empty if nothing has been send yet). Note that the e-mail can easily be `null` in the case of LTI authentication.

This PR changes `getUserEmail()` to return an empty string in case there is no e-mail. This function is only used for exporting; the change should therefore be safe.

The call to `option` is also removed; a call to `getOrElse` is already done after the map.