### PR TITLE
Remove redundant shim configuration

### DIFF
--- a/frontend/js/require.config.js
+++ b/frontend/js/require.config.js
@@ -35,12 +35,6 @@ require.config({
     waitSeconds: 10,
 
     shim: {
-        "handlebarsHelpers": ["handlebars"],
-
-        "handlebars": {
-            exports: "Handlebars"
-        },
-
         "backbone": {
             deps: ["underscore", "jquery"],
             exports: "Backbone"
@@ -62,8 +56,7 @@ require.config({
         },
 
         "mediaelementplayer": {
-            exports: "mejs",
-            deps: ["jquery"]
+            exports: "mejs"
         }
     }
 });


### PR DESCRIPTION
As stated in #204, some of the RequireJS shim configuration is actually not needed. This gets rid of it.