### PR TITLE
Remove the `/reset`-endpoint (from the public API at least)

### DIFF
--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/AbstractExtendedAnnotationsRestService.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/AbstractExtendedAnnotationsRestService.java
@@ -1023,13 +1023,6 @@ public abstract class AbstractExtendedAnnotationsRestService {
     });
   }
 
-  @DELETE
-  @Path("/reset")
-  public Response reset() {
-    eas().clearDatabase();
-    return Response.noContent().build();
-  }
-
   // --
 
   public static final Response NOT_FOUND = Response.status(Response.Status.NOT_FOUND).build();

--- a/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestServiceTest.java
+++ b/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestServiceTest.java
@@ -68,40 +68,6 @@ public class ExtendedAnnotationsRestServiceTest {
   }
 
   @Test
-  public void testClearTables() throws Exception {
-    // create all
-    final String userId = extractLocationId(given().formParam("user_extid", "admin").formParam("nickname", "klausi")
-            .expect().body("user_extid", equalTo("admin")).when().put(host("/users")));
-    final String videoId = extractLocationId(given().formParam("video_extid", "lecture99").expect().statusCode(CREATED)
-            .when().put(host("/videos")));
-    final String trackId = extractLocationId(given().pathParam("videoId", videoId).formParam("name", "track99")
-            .formParam("settings", "{\"type\":\"lecture\"}").formParam("description", "just a track").expect()
-            .statusCode(CREATED).when().post(host("/videos/{videoId}/tracks")));
-    final String annotationId = extractLocationId(given().pathParam("videoId", videoId).pathParam("trackId", trackId)
-            .formParam("text", "cool video").formParam("start", 40).expect().statusCode(CREATED).when()
-            .post(host("/videos/{videoId}/tracks/{trackId}/annotations")));
-
-    // get all
-    given().pathParam("id", userId).expect().statusCode(OK).when().get(host("/users/{id}"));
-    given().pathParam("id", videoId).expect().statusCode(OK).when().get(host("/videos/{id}"));
-    given().pathParam("videoId", videoId).pathParam("trackId", trackId).expect().statusCode(OK).when()
-            .get(host("/videos/{videoId}/tracks/{trackId}"));
-    given().pathParam("videoId", videoId).pathParam("trackId", trackId).pathParam("id", annotationId).expect()
-            .statusCode(OK).when().get(host("/videos/{videoId}/tracks/{trackId}/annotations/{id}"));
-
-    // delete all
-    given().expect().statusCode(NO_CONTENT).when().delete(host("/reset"));
-
-    // get all
-    given().pathParam("id", userId).expect().statusCode(NOT_FOUND).when().get(host("/users/{id}"));
-    given().pathParam("id", videoId).expect().statusCode(NOT_FOUND).when().get(host("/videos/{id}"));
-    given().pathParam("videoId", videoId).pathParam("trackId", trackId).expect().statusCode(BAD_REQUEST).when()
-            .get(host("/videos/{videoId}/tracks/{trackId}"));
-    given().pathParam("videoId", videoId).pathParam("trackId", trackId).pathParam("id", annotationId).expect()
-            .statusCode(BAD_REQUEST).when().get(host("/videos/{videoId}/tracks/{trackId}/annotations/{id}"));
-  }
-
-  @Test
   public void testUser() throws Exception {
     JSONObject json = new JSONObject();
     json.put("channel", "33");

--- a/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/TestRestService.java
+++ b/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/TestRestService.java
@@ -38,7 +38,9 @@ import org.junit.Ignore;
 
 import java.net.URL;
 
+import javax.ws.rs.DELETE;
 import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
 
 @Path("/")
 // put @Ignore here to prevent maven surefire from complaining about missing test methods
@@ -57,6 +59,13 @@ public class TestRestService extends AbstractExtendedAnnotationsRestService {
   @Override
   protected ExtendedAnnotationService getExtendedAnnotationsService() {
     return eas;
+  }
+
+  @DELETE
+  @Path("/reset")
+  public Response reset() {
+    eas.clearDatabase();
+    return Response.noContent().build();
   }
 
   private static SecurityService getSecurityService() {


### PR DESCRIPTION
This closes #202.

Unfortunately the tests still need it for ... reasons. It should not be accessible in a production installation anymore, though. In fact, it shouldn't even be in the `.jar`. :wink: