### PR TITLE
Add ability to toggle free text annotations

### DIFF
--- a/frontend/build/profiles/integration/annotation-tool-configuration.js
+++ b/frontend/build/profiles/integration/annotation-tool-configuration.js
@@ -172,7 +172,8 @@ define(["jquery",
                     "&" +
                     _.map(categories, function (category) {
                         return "category=" + category.id;
-                    }).join("&");
+                    }).join("&") +
+                    "freetext=" + this.freeTextVisible;
             },
 
             tracksToImport: undefined,

--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -167,6 +167,8 @@ define(["jquery",
 
                 this.tracksOrder = [];
 
+                this.freeTextVisible = true;
+
                 this.colorsManager = new ColorsManager();
 
                 this.once(this.EVENTS.USER_LOGGED, function () {
@@ -545,6 +547,15 @@ define(["jquery",
             orderTracks: function (order) {
                 this.tracksOrder = order;
                 this.trigger("order", order);
+            },
+
+            /**
+             * Shows or hides the free text annotations
+             * @alias annotationTool.toggleFreeTextAnnotations
+             */
+            toggleFreeTextAnnotations: function () {
+                this.freeTextVisible = !this.freeTextVisible;
+                this.trigger("togglefreetext");
             },
 
             /**

--- a/frontend/js/views/annotate.js
+++ b/frontend/js/views/annotate.js
@@ -26,6 +26,7 @@
  * @requires collections-categories
  * @requires templates/annotate
  * @requires templates/annotate-tab-title
+ * @requires templates/annotate-toggle-free-text-button
  * @requires ROLES
  * @requires ACCESS
  * @requires handlebars
@@ -41,12 +42,13 @@ define(["jquery",
         "views/annotate-tab",
         "templates/annotate",
         "templates/annotate-tab-title",
+        "templates/annotate-toggle-free-text-button",
         "roles",
         "access",
         "backbone",
         "handlebarsHelpers"],
 
-    function ($, _, i18next, PlayerAdapter, Annotation, Annotations, Categories, AnnotateTab, template, TabsButtonTemplate, ROLES, ACCESS, Backbone) {
+    function ($, _, i18next, PlayerAdapter, Annotation, Annotations, Categories, AnnotateTab, template, TabsButtonTemplate, toggleFreeTextButtonTemplate, ROLES, ACCESS, Backbone) {
 
         "use strict";
 
@@ -102,7 +104,8 @@ define(["jquery",
                 "keydown #new-annotation": "onFocusIn",
                 "focusout #new-annotation": "onFocusOut",
                 "click #label-tabs-buttons a": "showTab",
-                "click #editSwitch": "onSwitchEditModus"
+                "click #editSwitch": "onSwitchEditModus",
+                "click #toggle-free-text button": "toggleFreeTextAnnotations",
             },
 
             /**
@@ -168,6 +171,12 @@ define(["jquery",
                 this.continueVideo = false;
 
                 this.$el.html(template());
+
+                this.$el.find("#toggle-free-text").html(
+                    toggleFreeTextButtonTemplate({
+                        freeTextVisible: annotationTool.freeTextVisible
+                    })
+                );
 
                 // New annotation input
                 this.input = this.$el.find("#new-annotation");
@@ -394,6 +403,20 @@ define(["jquery",
             toggleStructuredAnnotations: function () {
                 this.layout.categories = !this.layout.categories;
                 this.categoriesElement.toggle();
+            },
+
+            /**
+             * Shows or hides the free text annotations
+             * @alias module:views-annotate.Annotate#toggleFreeTextAnnotations
+             */
+            toggleFreeTextAnnotations: function () {
+                annotationTool.toggleFreeTextAnnotations();
+
+                this.$el.find("#toggle-free-text").html(
+                    toggleFreeTextButtonTemplate({
+                        freeTextVisible: annotationTool.freeTextVisible
+                    })
+                );
             },
 
             /**

--- a/frontend/js/views/annotate.js
+++ b/frontend/js/views/annotate.js
@@ -161,7 +161,7 @@ define(["jquery",
                             "checkToContinueVideo",
                             "switchEditModus",
                             "keydownOnAnnotate",
-                            "toggleFreeTextAnnotations",
+                            "toggleFreeTextAnnotationPane",
                             "toggleStructuredAnnotations");
 
                 // Parameter for stop on write
@@ -379,9 +379,9 @@ define(["jquery",
 
             /**
              * Toggle layout for free text annotation only
-             * @alias module:views-annotate.Annotate#toggleFreeTextAnnotations
+             * @alias module:views-annotate.Annotate#toggleFreeTextAnnotationPane
              */
-            toggleFreeTextAnnotations: function () {
+            toggleFreeTextAnnotationPane: function () {
                 this.layout.freeText = !this.layout.freeText;
                 // TODO You might have to adapt this as well
                 this.freeTextElement.toggle();

--- a/frontend/js/views/list.js
+++ b/frontend/js/views/list.js
@@ -118,6 +118,8 @@ define(["jquery",
 
                 this.listenTo(annotationTool.video.get("categories"), "change:visible", this.render);
 
+                this.listenTo(annotationTool, "togglefreetext", this.render);
+
                 this.autoExpand = options.autoExpand;
                 annotationTool.addTimeupdateListener(this.potentiallyOpenCurrentItems, 900);
 
@@ -420,6 +422,7 @@ define(["jquery",
                 _.each(this.annotationViews, function (annView) {
                     var category = annView.model.category();
                     if (category && !category.get("visible")) return;
+                    if (!category && !annotationTool.freeTextVisible) return;
                     $listContainer.append(annView.$el);
                 });
 

--- a/frontend/js/views/main.js
+++ b/frontend/js/views/main.js
@@ -673,7 +673,7 @@ define(["jquery",
              */
             toggleFreeTextAnnotations: function () {
                 $("#opt-annotate-text").toggleClass("checked");
-                this.views.annotate.toggleFreeTextAnnotations();
+                this.views.annotate.toggleFreeTextAnnotationPane();
             },
 
             /**

--- a/frontend/js/views/print.js
+++ b/frontend/js/views/print.js
@@ -77,7 +77,7 @@ define(["underscore", "backbone", "templates/print", "handlebarsHelpers"], funct
                 .flatten()
                 .filter(function (annotation) {
                     var category = annotation.category();
-                    if (!category) return true;
+                    if (!category) return annotationTool.freeTextVisible;
                     return category.get("visible");
                 });
 

--- a/frontend/locales/de/translation.json
+++ b/frontend/locales/de/translation.json
@@ -47,6 +47,8 @@
     "upload categories": "Kategorien hochladen",
     "hide category": "Kategorie verstecken",
     "show category": "Kategorie anzeigen"
+    "show free text": "Freitextannotationen anzeigen",
+    "hide free text": "Freitextannotationen ausblenden"
   },
   "annotation": {
     "author": "Erstellt von",

--- a/frontend/locales/en/translation.json
+++ b/frontend/locales/en/translation.json
@@ -46,7 +46,9 @@
     "select track prompt": "Select a track to start annotating",
     "upload categories": "Upload categories",
     "hide category": "Hide category",
-    "show category": "Show category"
+    "show category": "Show category",
+    "show free text": "Show free text annotations",
+    "hide free text": "Hide free text annotations"
   },
   "annotation": {
     "author": "Created by",

--- a/frontend/style/annotations/base_layout.less
+++ b/frontend/style/annotations/base_layout.less
@@ -65,7 +65,6 @@ body {
 
         .nav > li > button {
             padding: 0 0 0 1em;
-            line-height: @line-height;
 
             &:hover {
                 cursor: pointer;

--- a/frontend/style/annotations/base_style.less
+++ b/frontend/style/annotations/base_style.less
@@ -68,6 +68,13 @@ body {
     width: 21px;
 }
 
+.icon-dark-grey, .icon-grey, .icon-white {
+    &.icon-eye-open, &.icon-eye-close {
+        height: 15px;
+        width: 23px;
+    }
+}
+
 [class^="icon-likert"], [class*=" icon-likert"] {
     width: 18px;
     height: 18px;

--- a/frontend/templates/annotate-toggle-free-text-button.tmpl
+++ b/frontend/templates/annotate-toggle-free-text-button.tmpl
@@ -1,0 +1,9 @@
+<button class="btn-nav" type="button">
+    {{#if freeTextVisible}}
+        {{t "annotate.hide free text"}}
+        <i class="icon-white icon-eye-open" title="{{t "annotate.hide freetext"}}"></i>
+    {{else}}
+        {{t "annotate.show free text"}}
+        <i class="icon-white icon-eye-close" title="{{t "annotate.show freetext"}}"></i>
+    {{/if}}
+</button>

--- a/frontend/templates/annotate.tmpl
+++ b/frontend/templates/annotate.tmpl
@@ -8,6 +8,9 @@
                     <span class="content">{{t "annotate.no selected track"}}</span>
                 </span>
             </span>
+            <ul class="nav pull-right">
+                <li id="toggle-free-text"></li>
+            </ul>
         </div>
     </div>
 

--- a/frontend/templates/annotate.tmpl
+++ b/frontend/templates/annotate.tmpl
@@ -2,12 +2,12 @@
 
     <div class="navbar navbar-inverse">
         <div class="navbar-inner">
-            <div class="container">
+            <span>
                 <span class="window-title">{{t "annotate on"}}</span>
                 <span class='currentTrack'>
                     <span class="content">{{t "annotate.no selected track"}}</span>
                 </span>
-            </div>
+            </span>
         </div>
     </div>
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/VideoEndpoint.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/VideoEndpoint.java
@@ -960,14 +960,15 @@ public class VideoEndpoint {
   @GET
   @Path("/export.csv")
   public Response getExportStatistics(@QueryParam("track") final List<Long> tracks,
-          @QueryParam("category") final List<Long> categories) throws IOException {
+          @QueryParam("category") final List<Long> categories,
+          @QueryParam("freetext") final Boolean freeText) throws IOException {
     Response.ResponseBuilder response = Response.ok(new StreamingOutput() {
 
       public void write(OutputStream os) throws IOException, WebApplicationException {
         CSVWriter writer = null;
         try {
           writer = new CSVWriter(new OutputStreamWriter(os));
-          writeExport(writer, tracks, categories);
+          writeExport(writer, tracks, categories, freeText);
           writer.close();
         } finally {
           IOUtils.closeQuietly(os);
@@ -980,7 +981,8 @@ public class VideoEndpoint {
     return response.build();
   }
 
-  private void writeExport(CSVWriter writer, List<Long> tracksToExport, List<Long> categoriesToExport) {
+  private void writeExport(CSVWriter writer, List<Long> tracksToExport, List<Long> categoriesToExport,
+          boolean freeText) {
     // Write headers
     List<String> header = new ArrayList<>();
     header.add("ID");
@@ -1020,6 +1022,8 @@ public class VideoEndpoint {
           });
           if (label.isSome()) {
             if (!categoriesToExport.contains(label.get().getCategoryId())) continue;
+          } else {
+            if (!freeText) continue;
           }
 
           List<String> line = new ArrayList<>();


### PR DESCRIPTION
This PR adds a button to the annotate panel which shows or hides free text annotations

* in the list view,
* in the timeline,
* in the printout
* and in the CSV export.

I hope I didn't forget anything. :smile: 