### PR TITLE
Implement shortcuts for the first 9 categories/labels/scale values

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -106,6 +106,7 @@
       <div class="modal" id="scale-editor" style="display:none"></div>
       <div class="modal" id="alert" style="display:none"></div>
       <div class="modal" id="tracks-selection" style="display:none"></div>
+      <div tabindex="-1" id="annotation-shortcut-focus"></div>
     </div>
     <div id="print-view"></div>
   </body>

--- a/frontend/js/views/main.js
+++ b/frontend/js/views/main.js
@@ -77,6 +77,9 @@ define(["jquery",
 
         var goldenLayout;
 
+        var annotationShortcutState;
+        var annotationShortcutTimer;
+
         /**
          * @constructor
          * @see {@link http://www.backbonejs.org/#View}
@@ -115,7 +118,9 @@ define(["jquery",
                 "click .opt-tracks-select": "tracksSelection",
                 "click #opt-auto-expand": "toggleAutoExpand",
                 "click .opt-view": "toggleView",
-                "click .opt-template": "loadTemplate"
+                "click .opt-template": "loadTemplate",
+                "keyup": "handleAnnotationShortcut",
+                "blur #annotation-shortcut-focus": "interruptAnnotationShortcut"
             },
 
             /**
@@ -130,6 +135,7 @@ define(["jquery",
                                 "print",
                                 "ready",
                                 "setupKeyboardShortcuts",
+                                "interruptAnnotationShortcut",
                                 "tracksSelection",
                                 "setLoadingProgress");
 
@@ -559,6 +565,83 @@ define(["jquery",
                     event.preventDefault();
                     addComment();
                 });
+
+                this.interruptAnnotationShortcut();
+            },
+
+            /**
+             * Handle numeric key sequences to easily insert structured annotations.
+             * Pressing a numeric key selects first the corresponding category,
+             * then the label, and then -- if necessary -- a scale value.
+             * The sequence is interrupted by pressing any other key,
+             * or changing the input focus in any way.
+             * @alias module:views-main.MainView#handleAnnotationShortcut
+             */
+            handleAnnotationShortcut: function (event) {
+                if (
+                    ["input", "textarea"].includes(event.target.tagName.toLowerCase())
+                        || !event.key.match(/^[1-9]$/)
+                ) {
+                    this.interruptAnnotationShortcut();
+                    return;
+                }
+
+                this.$el.find("#annotation-shortcut-focus")[0].focus();
+
+                var selectedEntity = Number(event.key) - 1;
+
+                // Note that this might fail horribly when the entities change in between keys of the sequence
+
+
+                if (!annotationShortcutState.category) {
+                    annotationShortcutState.category = annotationTool.video.get("categories").at(selectedEntity);
+                    if (!annotationShortcutState.category) {
+                        this.interruptAnnotationShortcut();
+                        return;
+                    }
+                    var scaleId = annotationShortcutState.category.get("scale_id");
+                    if (!scaleId) {
+                        var scale = annotationShortcutState.category.get("scale");
+                        if (scale) {
+                            scaleId = scale.id;
+                        }
+                    }
+                    annotationShortcutState.scale = annotationTool.video.get("scales").get(scaleId);
+                } else if (!annotationShortcutState.label) {
+                    annotationShortcutState.label = annotationShortcutState.category.get("labels").at(selectedEntity);
+                    if (!annotationShortcutState.label) {
+                        this.interruptAnnotationShortcut();
+                        return;
+                    }
+                    annotationShortcutState.params.label = annotationShortcutState.label;
+                    annotationShortcutState.params.text = annotationShortcutState.label.get("value");
+                } else {
+                    var scaleValue = annotationShortcutState.scale.get("scaleValues").at(selectedEntity);
+                    if (!scaleValue) {
+                        this.interruptAnnotationShortcut();
+                        return;
+                    }
+                    annotationShortcutState.params.scalevalue = scaleValue;
+                }
+
+                if (scaleValue || annotationShortcutState.label && !annotationShortcutState.scale) {
+                    var annotation = annotationTool.createAnnotation(annotationShortcutState.params);
+                    annotationTool.setSelection([annotation], true);
+                    this.interruptAnnotationShortcut();
+                } else {
+                    clearTimeout(annotationShortcutTimer);
+                    annotationShortcutTimer = setTimeout(this.interruptAnnotationShortcut, 3000);
+                }
+            },
+
+            /**
+             * Interrupt an in-process annotation key combination
+             * @alias module:views-main.MainView#interruptAnnotationShortcut
+             */
+            interruptAnnotationShortcut: function () {
+                annotationShortcutState = { params: {} };
+                clearTimeout(annotationShortcutTimer);
+                annotationShortcutTimer = null;
             },
 
             /**


### PR DESCRIPTION
This should close #7.

Entering a numeric key first selects the corresponding category, and then the label. If the category has a scale associated with it, a further numeric keypress is expected to select the scale value. Otherwise, or after that, an annotation with the appropriate values is inserted, as if the corresponding item in the structured annotations panel was pressed.

If any non-numeric key is pressed during such a sequence, it is interrupted. When a sequences is initiated, an invisible `div` gets the input focus, and if that is lost, the sequence is interrupted. This should happen whenever you click anywhere in between key strokes, for example. This happens mainly to prevent the user from changing the categories/labels/scales/scale values in between key strokes of a shortcut sequence.

And it is a terrible hack, but implementing it cleanly would require a lot more effort, and would either force large scale refactorings, or many more smaller hacks distributed over the whole code base.