### PR TITLE
Raise supported Opencast version

### DIFF
--- a/documentation/opencast-installation.md
+++ b/documentation/opencast-installation.md
@@ -30,10 +30,6 @@ In this manual we use `<annotationtool-dir>` for the base dir of the Annotation 
 This should build the frontend, include it into the Opencast modules and copies the JARs
 to your Opencast installation.
 
-Note that if you build with `opencast.version` set to something `>= 5`, you also have to specify
-`-Dopencast.artifactPrefix=opencast` because of the transition away from the `matterhorn` name
-between versions `4` and `5`.
-
 #### As a Karaf Feature
 
 As an alternative, the Annotation Tool is also packaged as a Karaf feature

--- a/opencast-backend/annotation-api/pom.xml
+++ b/opencast-backend/annotation-api/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>${opencast.artifactPrefix}-common</artifactId>
+      <artifactId>opencast-common</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/opencast-backend/annotation-impl/pom.xml
+++ b/opencast-backend/annotation-impl/pom.xml
@@ -23,11 +23,11 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>${opencast.artifactPrefix}-common</artifactId>
+      <artifactId>opencast-common</artifactId>
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>${opencast.artifactPrefix}-search-service-api</artifactId>
+      <artifactId>opencast-search-service-api</artifactId>
       <version>${opencast.version}</version>
     </dependency>
     <!-- Logging -->

--- a/opencast-backend/annotation-impl/src/main/resources/META-INF/persistence.xml
+++ b/opencast-backend/annotation-impl/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.1" xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence     http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
   <persistence-unit name="org.opencast.annotation.impl.persistence" transaction-type="RESOURCE_LOCAL">
     <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-    <non-jta-data-source>osgi:service/javax.sql.DataSource/(osgi.jndi.service.name=jdbc/${opencast.artifactPrefix})</non-jta-data-source>
+    <non-jta-data-source>osgi:service/javax.sql.DataSource/(osgi.jndi.service.name=jdbc/opencast)</non-jta-data-source>
     <class>org.opencast.annotation.impl.persistence.VideoDto</class>
     <class>org.opencast.annotation.impl.persistence.LabelDto</class>
     <class>org.opencast.annotation.impl.persistence.ScaleValueDto</class>

--- a/opencast-backend/annotation-tool/pom.xml
+++ b/opencast-backend/annotation-tool/pom.xml
@@ -21,7 +21,7 @@
     </dependency>
     <dependency>
       <groupId>org.opencastproject</groupId>
-      <artifactId>${opencast.artifactPrefix}-common</artifactId>
+      <artifactId>opencast-common</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.ws.rs</groupId>

--- a/opencast-backend/pom.xml
+++ b/opencast-backend/pom.xml
@@ -27,7 +27,7 @@
     <dependencies>
       <dependency>
         <groupId>org.opencastproject</groupId>
-        <artifactId>${opencast.artifactPrefix}-common</artifactId>
+        <artifactId>opencast-common</artifactId>
         <version>${opencast.version}</version>
         <scope>provided</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <jackson.version>2.7.0</jackson.version>
     <opencast.version>[2.3,)</opencast.version>
     <opencast.artifactPrefix>matterhorn</opencast.artifactPrefix>
+    <opencast.version>[6.0,)</opencast.version>
   </properties>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,6 @@
     <pax.web.version>4.3.0</pax.web.version>
     <cxf.version>3.1.7</cxf.version>
     <jackson.version>2.7.0</jackson.version>
-    <opencast.version>[2.3,)</opencast.version>
-    <opencast.artifactPrefix>matterhorn</opencast.artifactPrefix>
     <opencast.version>[6.0,)</opencast.version>
   </properties>
 


### PR DESCRIPTION
We should talk about the exact scheme of Opencast versions releases of this tool should support, but what seems very clear to me is that that scheme does not start at `2.3` anymore. And it probably should not start at `< 5.0`, either, so that we can finally get rid of the `artifactPrefix` option.