### PR TITLE
Simplify the POM structure

### DIFF
--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencast</groupId>
     <artifactId>annotation</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>${version}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>

--- a/opencast-backend/annotation-api/pom.xml
+++ b/opencast-backend/annotation-api/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.opencast.annotation</groupId>
     <artifactId>opencast-backend</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>${version}</version>
   </parent>
   <properties>
     <checkstyle.skip>true</checkstyle.skip>

--- a/opencast-backend/annotation-impl/pom.xml
+++ b/opencast-backend/annotation-impl/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.opencast.annotation</groupId>
     <artifactId>opencast-backend</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>${version}</version>
   </parent>
   <properties>
     <checkstyle.skip>true</checkstyle.skip>

--- a/opencast-backend/annotation-tool/pom.xml
+++ b/opencast-backend/annotation-tool/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.opencast.annotation</groupId>
     <artifactId>opencast-backend</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>${version}</version>
   </parent>
   <properties>
     <checkstyle.skip>true</checkstyle.skip>

--- a/opencast-backend/karaf-feature/pom.xml
+++ b/opencast-backend/karaf-feature/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencast.annotation</groupId>
     <artifactId>opencast-backend</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>${version}</version>
   </parent>
   <artifactId>karaf-feature</artifactId>
   <packaging>feature</packaging>

--- a/opencast-backend/pom.xml
+++ b/opencast-backend/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.opencast</groupId>
     <artifactId>annotation</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>${version}</version>
   </parent>
   <groupId>org.opencast.annotation</groupId>
   <artifactId>opencast-backend</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencast</groupId>
   <artifactId>annotation</artifactId>
-  <version>1.1-SNAPSHOT</version>
+  <version>${version}</version>
   <packaging>pom</packaging>
 
   <name>opencast-annotation</name>
@@ -14,6 +14,7 @@
   <inceptionYear>2017</inceptionYear>
 
   <properties>
+    <version>1.1-SNAPSHOT</version>
     <checkstyle.skip>false</checkstyle.skip>
     <jmeter.home>${project.build.directory}/jakarta-jmeter-${jmeter.version}</jmeter.home>
     <joda-time.version>2.9.4</joda-time.version>


### PR DESCRIPTION
Modern versions of Maven allow us to specify the version of the parent
using a property from said parent.