### PR TITLE
HLS Opencast integration mimetype fix

### DIFF
--- a/frontend/build/profiles/integration/annotation-tool-configuration.js
+++ b/frontend/build/profiles/integration/annotation-tool-configuration.js
@@ -311,7 +311,7 @@ define(["jquery",
                 mediaPackage.then(function (mediaPackage) {
                     var videos = util.array(mediaPackage.media.track)
                         .filter(_.compose(
-                            RegExp.prototype.test.bind(/video\/.*/),
+                            RegExp.prototype.test.bind(/application\/.*|video\/.*/),
                             _.property("mimetype")
                         ));
                     videos.sort(


### PR DESCRIPTION
HLS uses the mimetype application/x-mpegURL instead of video/*.  The annotation tool when is integrated with opencast makes a check of the mimetypes.


This patch allows the AT to load this type of media when comes from the mediapackage