### PR TITLE
Fix Project Versions

### DIFF
--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencast</groupId>
     <artifactId>annotation</artifactId>
-    <version>${version}</version>
+    <version>3-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <properties>

--- a/opencast-backend/annotation-api/pom.xml
+++ b/opencast-backend/annotation-api/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.opencast.annotation</groupId>
     <artifactId>opencast-backend</artifactId>
-    <version>${version}</version>
+    <version>3-SNAPSHOT</version>
   </parent>
   <properties>
     <checkstyle.skip>true</checkstyle.skip>

--- a/opencast-backend/annotation-impl/pom.xml
+++ b/opencast-backend/annotation-impl/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.opencast.annotation</groupId>
     <artifactId>opencast-backend</artifactId>
-    <version>${version}</version>
+    <version>3-SNAPSHOT</version>
   </parent>
   <properties>
     <checkstyle.skip>true</checkstyle.skip>

--- a/opencast-backend/annotation-tool/pom.xml
+++ b/opencast-backend/annotation-tool/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.opencast.annotation</groupId>
     <artifactId>opencast-backend</artifactId>
-    <version>${version}</version>
+    <version>3-SNAPSHOT</version>
   </parent>
   <properties>
     <checkstyle.skip>true</checkstyle.skip>

--- a/opencast-backend/karaf-feature/pom.xml
+++ b/opencast-backend/karaf-feature/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.opencast.annotation</groupId>
     <artifactId>opencast-backend</artifactId>
-    <version>${version}</version>
+    <version>3-SNAPSHOT</version>
   </parent>
   <artifactId>karaf-feature</artifactId>
   <packaging>feature</packaging>

--- a/opencast-backend/pom.xml
+++ b/opencast-backend/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.opencast</groupId>
     <artifactId>annotation</artifactId>
-    <version>${version}</version>
+    <version>3-SNAPSHOT</version>
   </parent>
   <groupId>org.opencast.annotation</groupId>
   <artifactId>opencast-backend</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.opencast</groupId>
   <artifactId>annotation</artifactId>
-  <version>${version}</version>
+  <version>3-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>opencast-annotation</name>
@@ -14,7 +14,6 @@
   <inceptionYear>2017</inceptionYear>
 
   <properties>
-    <version>3-SNAPSHOT</version>
     <checkstyle.skip>false</checkstyle.skip>
     <jmeter.home>${project.build.directory}/jakarta-jmeter-${jmeter.version}</jmeter.home>
     <joda-time.version>2.9.4</joda-time.version>


### PR DESCRIPTION
Building this project, Maven loudly complains about malformed `pom.xml`
files due to the usage of a `version` property for the bundle versions:

```
% mvn clean install                                                                                                                                                                     (git)-[develop] [0]
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.opencast:annotation-tool-frontend:jar:3-SNAPSHOT
[WARNING] 'version' contains an expression but should be a constant. @ org.opencast:annotation:${version}, /home/lars/dev/annotation-tool/pom.xml, line 8, column 12
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.opencast:annotation:pom:3-SNAPSHOT
[WARNING] 'version' contains an expression but should be a constant. @ org.opencast:annotation:${version}, /home/lars/dev/annotation-tool/pom.xml, line 8, column 12
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```

This already leads to errors if you try building a sub-project:

```
% cd opencast-backend
% mvn clean install
...
[INFO] BUILD FAILURE
...
[ERROR] Failed to execute goal on project opencast-annotation-tool:
Could not resolve dependencies for project
org.opencast:opencast-annotation-tool:bundle:3-SNAPSHOT: Failed to
collect dependencies at
org.opencast:annotation-tool-frontend:jar:3-SNAPSHOT: Failed to read
artifact descriptor for
org.opencast:annotation-tool-frontend:jar:3-SNAPSHOT: Failure to find
org.opencast:annotation:pom:${version} in
https://nexus.opencast.org/nexus/content/groups/public was cached in the
local repository, resolution will not be reattempted until the update
interval of opencast-osna has elapsed or updates are forced -> [Help 1]
```

The property is meant to easily update the version. The same can also be
achieved in a well defined way using the versions-maven-plugin:

    mvn versions:set -DnewVersion=4-SNAPSHOT versions:commit

For more options, take a look at the plugin's documentation:

- http://www.mojohaus.org/versions-maven-plugin/