### PR TITLE
New config profile for use ExtApi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ Makefile
 /frontend/doc
 
 .flattened-pom.xml
+
+#Ignore VScode files
+*.vscode

--- a/documentation/build-frontend.md
+++ b/documentation/build-frontend.md
@@ -20,9 +20,11 @@ Now you will need to initalize your NPM repository:
 You have now several options to build and deploy the webapp:
 
 * `demo` mode on a local webserver
-* `integration` to update the webapp within the Opencast backend
+* `integration` to update the webapp within the Opencast backend.
+* `integration_extapi` Changes the api endpoint to use to `api/events`.
+* `integrationminified` Integration, but minified the JS files for a faster load.
 * `build` to build the webapp and put in the the _target_ directory.
-* `dev` to start a webserver with grunt to test the current webapp
+* `dev` to start a webserver with grunt to test the current webapp.
 
 ## Building __demo__
 

--- a/documentation/opencast-installation.md
+++ b/documentation/opencast-installation.md
@@ -30,11 +30,17 @@ In this manual we use `<annotationtool-dir>` for the base dir of the Annotation 
 This should build the frontend, include it into the Opencast modules and copies the JARs
 to your Opencast installation.
 
-Note that if you are building against an Opencast version prior to 7,
-you currently need to skip the tests due to an incompatibility
+Note that **if you are building against an Opencast version prior to 7,**
+**you currently need to skip the tests** due to an incompatibility
 between Opencast 6 and 7.
 You can do this by passing the additional option `-Dmaven.test.skip`
 to Maven in the command above.
+
+#### Use the External API
+The annotation tool is made to use the search endpoint by default, if you want to build the Annotation 
+tool to work with the External API instead of the search endpoint use the flag `-Denvironment=ExtApi`
+
+If you have a multicluster deployment, remember that the External API is only available on the admin node.
 
 #### As a Karaf Feature
 
@@ -121,6 +127,7 @@ Within the `etc/workflows/partial-publish` you need to add this operation to the
       exception-handler-workflow="partial-error"
       description="Publish to preview publication channel">
       <configurations>
+        <configuration key="source-flavors">dublincore/*,security/*</configuration>
         <configuration key="source-tags">preview</configuration>
         <configuration key="channel-id">annotation</configuration>
         <configuration key="url-pattern">http://localhost:8080/annotation-tool/index.html?id=${event_id}</configuration>

--- a/frontend/Gruntfile.js
+++ b/frontend/Gruntfile.js
@@ -37,6 +37,11 @@ module.exports = function (grunt) {
                 config  : 'build/profiles/integration/annotation-tool-configuration.js'
             },
 
+            integration_extapi: {
+                target  : '../opencast-backend/annotation-tool/src/main/resources/ui/',
+                config  : 'build/profiles/integration_ExtApi/annotation-tool-configuration.js'
+            },
+
             local: {
                 target : '<%= webServerDir %>',
                 config : 'build/profiles/local/annotation-tool-configuration.js'
@@ -246,6 +251,14 @@ module.exports = function (grunt) {
                     dest: '<%= currentProfile.target %>'
                 }]
             },
+            'integration_extapi': {
+                files: [{
+                    flatten: false,
+                    expand: true,
+                    src: ['js/**/*', 'img/**/*', 'style/**/*.svg', 'style/**/*.png', 'style/**/*.css', 'tests/**/*'],
+                    dest: '<%= currentProfile.target %>'
+                }]
+            },
             // ... the index locally
             'index': {
                 options: {
@@ -430,12 +443,22 @@ module.exports = function (grunt) {
      ==================================================*/
 
     // Default task
+<<<<<<< HEAD
     grunt.registerTask('default', ['amdcheck', 'jshint:all', 'less', 'copy:local-all', 'copy:local-index']);
     grunt.registerTask('baseDEV', ['handlebars:all', 'less', 'copy:all', 'processhtml:index', 'copy:less', 'copy:config', 'copy:locales', 'concurrent:dev']);
     grunt.registerTask('baseDEMO', ['amdcheck', 'mkdir:demo', 'handlebars:all', 'less', 'copy:demo', 'processhtml:index', 'copy:config', 'copy:locales']);
     grunt.registerTask('baseBUILD', ['amdcheck', 'jsdoc', 'handlebars:temp', 'less', 'copy:build', 'processhtml:index', 'copy:config-build', 'copy:locales', 'copy:temp', 'requirejs', 'uglify']);
     grunt.registerTask('baseINTEGRATION', ['amdcheck', 'handlebars:all', 'less', 'copy:integration', 'processhtml:index', 'copy:config', 'copy:locales']);
     grunt.registerTask('baseINTEGRATIONMINIFIED', ['amdcheck', 'handlebars:temp', 'less', 'copy:integration', 'processhtml:index', 'copy:config-build', 'copy:locales', 'copy:temp', 'requirejs', 'uglify']);
+=======
+    grunt.registerTask('default', ['jshint:all', 'less', 'copy:local-all', 'copy:local-index']);
+    grunt.registerTask('baseDEV', ['handlebars:all', 'less', 'copy:all', 'processhtml:dev', 'copy:less', 'copy:config', 'copy:locales', 'concurrent:dev']);
+    grunt.registerTask('baseDEMO', ['mkdir:demo', 'handlebars:all', 'less', 'copy:demo', 'processhtml:dev', 'copy:config', 'copy:locales']);
+    grunt.registerTask('baseBUILD', ['jsdoc', 'handlebars:temp', 'less', 'copy:build', 'processhtml:build', 'copy:config-build', 'copy:locales', 'copy:temp', 'requirejs', 'uglify']);
+    grunt.registerTask('baseINTEGRATION', ['handlebars:all', 'less', 'copy:integration', 'processhtml:dev', 'copy:config', 'copy:locales']);
+    grunt.registerTask('baseINTEGRATION_EXTAPI', ['handlebars:all', 'less', 'copy:integration_extapi', 'processhtml:dev', 'copy:config', 'copy:locales']);
+    grunt.registerTask('baseINTEGRATIONMINIFIED', ['handlebars:temp', 'less', 'copy:integration', 'processhtml:build', 'copy:config-build', 'copy:locales', 'copy:temp', 'requirejs', 'uglify']);
+>>>>>>> - New config profile called integration_ExtApi
 
     grunt.registerTaskWithProfile = function (name, description, profile) {
         grunt.registerTask(name, description, function () {
@@ -458,6 +481,7 @@ module.exports = function (grunt) {
     grunt.registerTaskWithProfile('build', 'Build task', 'build');
     grunt.registerTaskWithProfile('demo', 'Generate build for demo', 'demo');
     grunt.registerTaskWithProfile('integration', 'Deploy webapp in Opencast backend', 'integration');
+    grunt.registerTaskWithProfile('integration_extapi', 'Deploy webapp in Opencast backend', 'integration_extapi');
     grunt.registerTaskWithProfile('integrationminified', 'Deploy webapp in Opencast backend as minified version', 'integration');
     grunt.registerTaskWithProfile('dev', 'Development workflow');
 

--- a/frontend/Gruntfile.js
+++ b/frontend/Gruntfile.js
@@ -443,22 +443,13 @@ module.exports = function (grunt) {
      ==================================================*/
 
     // Default task
-<<<<<<< HEAD
     grunt.registerTask('default', ['amdcheck', 'jshint:all', 'less', 'copy:local-all', 'copy:local-index']);
     grunt.registerTask('baseDEV', ['handlebars:all', 'less', 'copy:all', 'processhtml:index', 'copy:less', 'copy:config', 'copy:locales', 'concurrent:dev']);
     grunt.registerTask('baseDEMO', ['amdcheck', 'mkdir:demo', 'handlebars:all', 'less', 'copy:demo', 'processhtml:index', 'copy:config', 'copy:locales']);
     grunt.registerTask('baseBUILD', ['amdcheck', 'jsdoc', 'handlebars:temp', 'less', 'copy:build', 'processhtml:index', 'copy:config-build', 'copy:locales', 'copy:temp', 'requirejs', 'uglify']);
-    grunt.registerTask('baseINTEGRATION', ['amdcheck', 'handlebars:all', 'less', 'copy:integration', 'processhtml:index', 'copy:config', 'copy:locales']);
+    grunt.registerTask('baseINTEGRATION', ['amdcheck', 'handlebars:all', 'less', 'copy:integration', 'processhtml:index', 'copy:config', 'copy:locales']);    
+    grunt.registerTask('baseINTEGRATION_EXTAPI', ['amdcheck', 'handlebars:all', 'less', 'copy:integration_extapi', 'processhtml:index', 'copy:config', 'copy:locales']);
     grunt.registerTask('baseINTEGRATIONMINIFIED', ['amdcheck', 'handlebars:temp', 'less', 'copy:integration', 'processhtml:index', 'copy:config-build', 'copy:locales', 'copy:temp', 'requirejs', 'uglify']);
-=======
-    grunt.registerTask('default', ['jshint:all', 'less', 'copy:local-all', 'copy:local-index']);
-    grunt.registerTask('baseDEV', ['handlebars:all', 'less', 'copy:all', 'processhtml:dev', 'copy:less', 'copy:config', 'copy:locales', 'concurrent:dev']);
-    grunt.registerTask('baseDEMO', ['mkdir:demo', 'handlebars:all', 'less', 'copy:demo', 'processhtml:dev', 'copy:config', 'copy:locales']);
-    grunt.registerTask('baseBUILD', ['jsdoc', 'handlebars:temp', 'less', 'copy:build', 'processhtml:build', 'copy:config-build', 'copy:locales', 'copy:temp', 'requirejs', 'uglify']);
-    grunt.registerTask('baseINTEGRATION', ['handlebars:all', 'less', 'copy:integration', 'processhtml:dev', 'copy:config', 'copy:locales']);
-    grunt.registerTask('baseINTEGRATION_EXTAPI', ['handlebars:all', 'less', 'copy:integration_extapi', 'processhtml:dev', 'copy:config', 'copy:locales']);
-    grunt.registerTask('baseINTEGRATIONMINIFIED', ['handlebars:temp', 'less', 'copy:integration', 'processhtml:build', 'copy:config-build', 'copy:locales', 'copy:temp', 'requirejs', 'uglify']);
->>>>>>> - New config profile called integration_ExtApi
 
     grunt.registerTaskWithProfile = function (name, description, profile) {
         grunt.registerTask(name, description, function () {

--- a/frontend/build/profiles/integration_ExtApi/annotation-tool-configuration.js
+++ b/frontend/build/profiles/integration_ExtApi/annotation-tool-configuration.js
@@ -1,0 +1,346 @@
+/**
+ *  Copyright 2012, Entwine GmbH, Switzerland
+ *  Licensed under the Educational Community License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.osedu.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an "AS IS"
+ *  BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ *  or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ *
+ */
+
+/**
+ * Module containing the tool configuration
+ * @module annotation-tool-configuration
+ */
+define(["jquery",
+        "underscore",
+        "backbone",
+        "util",
+        "models/user",
+        "roles",
+        "player_adapter_HTML5",
+        "localstorage"
+        // Add the files (PlayerAdapter, ...) required for your configuration here
+        ],
+
+    function ($, _, Backbone, util, User, ROLES, HTML5PlayerAdapter) {
+
+        "use strict";
+
+        var backboneSync = Backbone.sync;
+
+        /**
+         * Synchronize models with an annotation tool backend
+         */
+        Backbone.sync = function (method, model, options) {
+
+            // The backend expects `application/x-www-form-urlencoded data
+            // with anything nested deeper than one level transformed to a JSON string
+            options.processData = true;
+
+            options.data = options.attrs || model.toJSON(options);
+
+            // Some models (marked with `mPOST`) need to always be `PUT`, i.e. never be `POST`ed
+            if (model.noPOST && method === "create") {
+                method = "update";
+            }
+
+            options.beforeSend = function () {
+                this.url = "../../extended-annotations" + this.url;
+            };
+
+            return backboneSync.call(this, method, model, options);
+        };
+
+        // Initiate loading the video metadata from Opencast
+        var mediaPackageId = util.queryParameters.id;
+        $.support.cors = true;
+
+        // Loads data from the external API.
+        // For next update: Add an error handling procedure in case this fail.
+        var apiOut = $.ajax({
+            url: "/api/events/"+ mediaPackageId,
+            data: "withpublications=true",
+            crossDomain: true,
+            datatype: "json"
+        }).then(function(data){
+            return data;
+        });
+
+        var mediaPackage = apiOut.then(function (result) {
+            var arrayResult = result.publications.find(x=>x.channel === "CUSTOM_CHANNEL");
+            arrayResult ? arrayResult : arrayResult = result.publications.find(x=>x.channel === "annotation");
+            return arrayResult
+        });
+
+        // Get user data from Opencast
+        var user = $.ajax({
+            url: "/info/me.json",
+            dataType: "json"
+        });
+        // Find out which roles should have admin rights
+        var adminRoles = mediaPackage.then(function (mediaPackage) {
+            // First we need to find the proper XACML file
+            var attachments = util.array(mediaPackage.attachments);
+            var selectedXACML = function () {
+                var seriesXACML;
+                for (var i = 0; i < attachments.length; i++) {
+                    var attachment = attachments[i];
+                    if (attachment.flavor === "security/xacml+episode") {
+                        // Immediately return an XACML belonging to this specific episode
+                        return attachment;
+                    }
+                    if (attachment.flavor === "security/xacml+series") {
+                        // Remember any series XACML on the way,
+                        //   so we can return that as a fallback
+                        seriesXACML = attachment;
+                    }
+                }
+                return seriesXACML;
+            }();
+            // TODO What if nothing was found?!
+            return $.ajax({
+                url: selectedXACML.url,
+                crossDomain: true,
+                dataType: "xml"
+            });
+        }).then(function (xacmlData) {
+            // Then we need to extract the appropriate rules
+            return $(xacmlData).find("Rule").filter(function (index, rule) {
+                return $(rule).find("Action AttributeValue").text() === "annotate-admin";
+            }).map(function (index, rule) {
+                return $(rule).find("Condition AttributeValue").text();
+            }).toArray();
+        });
+
+        /**
+         * Annotations tool configuration object
+         * @alias module:annotation-tool-configuration.Configuration
+         */
+        var Configuration = {
+            /**
+             * The minmal duration used for annotation representation on timeline
+             * @alias module:annotation-tool-configuration.Configuration.MINIMAL_DURATION
+             * @memberOf module:annotation-tool-configuration.Configuration
+             * @type {Object}
+             */
+            MINIMAL_DURATION: 5,
+
+            /**
+             * Define the number of categories per tab in the annotate box.
+             * The bigger this number, the thinner the columns for the categories.
+             * @alias module:annotation-tool-configuration.Configuration.CATEGORIES_PER_TAB
+             * @memberOf module:annotation-tool-configuration.Configuration
+             * @type {Number}
+             */
+            CATEGORIES_PER_TAB: 7,
+
+            /**
+             * The maximal number of tracks visible in the timeline at the same time
+             * @type {Number}
+             */
+            MAX_VISIBLE_TRACKS: 0,
+
+            /**
+             * Define if the localStorage should be used or not
+             * @alias module:annotation-tool-configuration.Configuration.localStorage
+             * @type {boolean}
+             * @readOnly
+             */
+            localStorage: false,
+
+            /**
+             * Offer the user a spreadsheet version of the annotations for download.
+             * @alias module:annotation-tool-configuration.Configuration.export
+             * @param {Video} video The video to export
+             * @param {Track[]} tracks The tracks to include in the export
+             * @param {Category[]} categories The tracks to include in the export
+             */
+            export: function (video, tracks, categories) {
+                window.location.href = "../extended-annotations/videos/" + video.id + "/export.csv?" +
+                    _.map(tracks, function (track) {
+                        return "track=" + track.id;
+                    }).join("&") +
+                    "&" +
+                    _.map(categories, function (category) {
+                        return "category=" + category.id;
+                    }).join("&") +
+                    "freetext=" + this.freeTextVisible;
+            },
+
+            tracksToImport: undefined,
+
+            /**
+             * Define if the structured annotations are or not enabled
+             * @alias module:annotation-tool-configuration.Configuration.isStructuredAnnotationEnabled
+             * @return {boolean} True if this feature is enabled
+             */
+            isStructuredAnnotationEnabled: function () {
+                return true;
+            },
+
+            /**
+             * Define if the private-only mode is enabled
+             * @alias module:annotation-tool-configuration.Configuration.isPrivateOnly
+             * @type {boolean}
+             */
+            isPrivateOnly: false,
+
+            /**
+             * Define if the free text annotations are or not enabled
+             * @alias module:annotation-tool-configuration.Configuration.isFreeTextEnabled
+             * @return {boolean} True if this feature is enabled
+             */
+            isFreeTextEnabled: function () {
+                return true;
+            },
+
+            /**
+             * Get the current video id (video_extid)
+             * @alias module:annotation-tool-configuration.Configuration.getVideoExtId
+             * @return {Promise.<string>} video external id
+             */
+            getVideoExtId: function () {
+                return $.when(mediaPackageId);
+            },
+
+            /**
+             * Returns the time interval between each timeupdate event to take into account.
+             * It can improve a bit the performance if the amount of annotations is important.
+             * @alias module:annotation-tool-configuration.Configuration.getTimeupdateIntervalForTimeline
+             * @return {number} The interval
+             */
+            getTimeupdateIntervalForTimeline: function () {
+                // TODO Check if this function should be linear
+                return Math.max(500, this.getAnnotations().length * 3);
+
+            },
+
+            /**
+             * Sets the behavior of the timeline. Enable it to follow the playhead.
+             * @alias module:annotation-tool-configuration.Configuration.timelineFollowPlayhead
+             * @type {Boolean}
+             */
+            timelineFollowPlayhead: true,
+
+            /**
+             * Get the external parameters related to video. The supported parameters are now the following:
+             *     - title: The title of the video
+             *     - src_owner: The owner of the video in the system
+             *     - src_creation_date: The date of the course, when the video itself was created.
+             * @alias module:annotation-tool-configuration.Configuration.getVideoParameters
+             * @example
+             * {
+             *     video_extid: 123, // Same as the value returned by getVideoExtId
+             *     title: "Math lesson 4", // The title of the video
+             *     src_owner: "Professor X", // The owner of the video in the system
+             *     src_creation_date: "12-12-1023" // The date of the course, when the video itself was created.
+             * }
+             * @return {Object} The literal object containing all the parameters described in the example.
+             */
+            getVideoParameters: function () {
+                return apiOut.then(function (result) {
+                    return {
+                        title: result.title,
+                        src_owner: result.creator,
+                        src_creaton_date: result.created
+                    };
+                });
+            },
+
+            /**
+             * Maps a list of roles of the external user to a corresponding user role
+             * @alias module:annotation-tool-configuration.Configuration.getUserRoleFromExt
+             * @param {string[]} roles The roles of the external user
+             * @return {Promise.<ROLE>} The corresponding user role in the annotations tool
+             */
+            getUserRoleFromExt: function (roles) {
+                return adminRoles.then(function (adminRoles) {
+                    if (_.some(adminRoles.concat(['ROLE_ADMIN']), function (adminRole) {
+                        return _.contains(roles, adminRole);
+                    })) {
+                        return ROLES.ADMINISTRATOR;
+                    } else {
+                        return ROLES.USER;
+                    }
+                });
+            },
+
+            /**
+             * Authenticate the user
+             * @alias module:annotation-tool-configuration.Configuration.authenticate
+             */
+            authenticate: function () {
+                user.then(function (userData) {
+                    return $.when(userData.user, this.getUserRoleFromExt(userData.roles));
+                }.bind(this)).then(function (user, role) {
+                    this.user = new User({
+                        user_extid: user.username,
+                        nickname: user.username,
+                        email: user.email,
+                        role: role
+                    });
+                    return this.user.save();
+                }.bind(this)).then(function () {
+                    this.trigger(this.EVENTS.USER_LOGGED);
+                }.bind(this));
+            },
+
+            /**
+             * Log out the current user
+             * @alias module:annotation-tool-configuration.Configuration.logout
+             */
+            logout: function () {
+                window.location = "/j_spring_security_logout";
+            },
+
+            /**
+             * Function to load the video
+             * @alias module:annotation-tool-configuration.Configuration.loadVideo
+             * @param {HTMLElement} container The container to create the video player in
+             */
+            loadVideo: function (container) {
+                mediaPackage.then(function (mediaPackage) {
+                    var videos = mediaPackage.media
+                        .filter(_.compose(
+                            RegExp.prototype.test.bind(/application\/.*|video\/.*/),
+                            _.property("mediatype")
+                        ));
+                    videos.sort(
+                        util.lexicographic(
+                            util.firstWith(_.compose(
+                                RegExp.prototype.test.bind(/presenter\/.*/),
+                                _.property("flavor")
+                            )),
+                            util.firstWith(_.compose(
+                                RegExp.prototype.test.bind(/presentation\/.*/),
+                                _.property("flavor")
+                            ))
+                        )
+                    );
+
+                    var videoElement = document.createElement("video");
+                    container.appendChild(videoElement);
+                    this.playerAdapter = new HTML5PlayerAdapter(
+                        videoElement,
+                        videos.map(function (track) {
+                            return {
+                                src: track.url,
+                                type: track.mediatype
+                            };
+                        })
+                    );
+                    this.trigger(this.EVENTS.VIDEO_LOADED);
+                }.bind(this));
+            }
+        };
+
+        return Configuration;
+    }
+);

--- a/frontend/build/profiles/integration_ExtApi/annotation-tool-configuration.js
+++ b/frontend/build/profiles/integration_ExtApi/annotation-tool-configuration.js
@@ -79,6 +79,12 @@ define(["jquery",
             return arrayResult
         });
 
+        var mediaPackageVideo = apiOut.then(function (result) {
+            var arrayResult = result.publications.find(x=>x.channel === "CUSTOM_CHANNEL");
+            arrayResult ? arrayResult : arrayResult = result.publications.find(x=>x.channel === "engage-player");
+            return arrayResult
+        });
+
         // Get user data from Opencast
         var user = $.ajax({
             url: "/info/me.json",
@@ -306,14 +312,14 @@ define(["jquery",
              * @param {HTMLElement} container The container to create the video player in
              */
             loadVideo: function (container) {
-                mediaPackage.then(function (mediaPackage) {
-                    var videos = mediaPackage.media
+                mediaPackageVideo.then(function (mediaPackageVideo) {
+                    var videos = mediaPackageVideo.media
                         .filter(_.compose(
                             RegExp.prototype.test.bind(/application\/.*|video\/.*/),
                             _.property("mediatype")
                         ));
                     videos.sort(
-                        util.lexicographic(
+                        util.lexicographic([
                             util.firstWith(_.compose(
                                 RegExp.prototype.test.bind(/presenter\/.*/),
                                 _.property("flavor")
@@ -322,7 +328,7 @@ define(["jquery",
                                 RegExp.prototype.test.bind(/presentation\/.*/),
                                 _.property("flavor")
                             ))
-                        )
+                        ])
                     );
 
                     var videoElement = document.createElement("video");

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1274,7 +1274,7 @@
       "dependencies": {
         "combined-stream": {
           "version": "1.0.6",
-          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "dev": true,
           "optional": true,
@@ -1545,7 +1545,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1607,7 +1607,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1655,7 +1655,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1703,7 +1703,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -2697,7 +2697,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -1,8 +1,5 @@
-<project
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
->
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -19,43 +16,102 @@
     <checkstyle.skip>true</checkstyle.skip>
   </properties>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>com.github.eirslett</groupId>
-        <artifactId>frontend-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>install node and npm</id>
-            <goals>
-              <goal>install-node-and-npm</goal>
-            </goals>
-            <configuration>
-              <nodeVersion>v8.15.0</nodeVersion>
-            </configuration>
-          </execution>
+  <profiles>
+    <profile>
+      <activation>
+        <property>
+          <name>environment</name>
+          <value>integration</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>install node and npm</id>
+                <goals>
+                  <goal>install-node-and-npm</goal>
+                </goals>
+                <configuration>
+                  <nodeVersion>v8.15.0</nodeVersion>
+                </configuration>
+              </execution>
 
-          <execution>
-            <id>npm install</id>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-            <configuration>
-              <arguments>install --engine-strict</arguments>
-            </configuration>
-          </execution>
-          <execution>
-            <id>grunt build</id>
-            <goals>
-              <goal>grunt</goal>
-            </goals>
+              <execution>
+                <id>npm install</id>
+                <goals>
+                  <goal>npm</goal>
+                </goals>
+                <configuration>
+                  <arguments>install --engine-strict</arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>grunt build</id>
+                <goals>
+                  <goal>grunt</goal>
+                </goals>
 
-            <configuration>
-              <arguments>integration</arguments>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+                <configuration>
+                  <arguments>integration</arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>extapi</id>
+      <activation>
+        <property>
+          <name>environment</name>
+          <value>ExtApi</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>install node and npm</id>
+                <goals>
+                  <goal>install-node-and-npm</goal>
+                </goals>
+                <configuration>
+                  <nodeVersion>v8.15.0</nodeVersion>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>npm install</id>
+                <goals>
+                  <goal>npm</goal>
+                </goals>
+                <configuration>
+                  <arguments>install --engine-strict</arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>grunt build</id>
+                <goals>
+                  <goal>grunt</goal>
+                </goals>
+
+                <configuration>
+                  <arguments>integration_extapi</arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/opencastCfg/listproviders/acl.additional.actions.properties
+++ b/opencastCfg/listproviders/acl.additional.actions.properties
@@ -1,0 +1,12 @@
+list.name=ACL.ACTIONS
+# This list provider allows you to configure custom actions that can be added
+# to ACLs. The default actions are read and write.
+
+# The pattern for adding them is
+# UI_LABEL=actionId
+
+# For example to set a custom action of type annotate with a label in the UI of Annotate.
+# Annotate=annotate
+
+Annotate=annotate
+Manage\ annotations=annotate-admin

--- a/opencastCfg/listproviders/publication.channels.properties
+++ b/opencastCfg/listproviders/publication.channels.properties
@@ -1,0 +1,45 @@
+list.name=PUBLICATION.CHANNELS
+
+# This list provider allows you to configure the look of the publications shown in event details of the admin ui. The
+# entries are configured with a channelid=record pair. Records are json records which can have the following fields:
+#
+# - "label" to configure which text is displayed for the publication channel's name. This can be a plain text or a
+#   translation key.
+# - "icon" to configure which icon is displayed for the entry. This can be an URL
+#   (e.g. http://hostname/path/to/image.png) or a path to a resource on the webserver
+#   (e.g. ./img/video.png or ../staticfiles/file-id)
+# - "description" to configure which explanatory text is displayed for the entry. This can be a plain text or a
+#   translation key.
+# - "hide" to configure whether the entry is shown or not. If you set this to true, the entry is hidden. This is a
+#   boolean value.
+# - "order" to configure in which order the entries are displayed. This is a number and the entries are sorted ascending
+#   by their "order" value.
+#
+# All these fields can also be omitted. When a field is not specified, a default value is used, i.e. default icons,
+# default label, no description, not hidden, order bigger than 999.
+#
+# For example to just set a custom icon for engage publications you could set:
+# engage-player={"icon": "./img/engage_2x.png"}
+#
+# The key has to be a channel id. To find the channel id, you can take a look at the corresponding workflow. For example
+# if you had the workflow:
+# <operation
+#   id="publish-configure"
+# ...
+#   <configurations>
+# ...
+#     <configuration key="channel-id">api</configuration>
+# ...
+#   </configurations>
+# </operation>
+# The channel id would be "api"
+#
+# Here is a full example:
+# api={"label":"EVENTS.EVENTS.DETAILS.PUBLICATIONS.EXTERNAL_API", "icon": "./img/video_2x.png", "description":"lorem ipsum", "hide": false, "order":1}
+
+api={"label":"EVENTS.EVENTS.DETAILS.PUBLICATIONS.EXTERNAL_API", "order":1}
+oaipmh-default={"label":"Default OAI-PMH Repository", "order":2}
+engage-player={"icon":"img/engage_2x.png", "order":3}
+youtube={"icon":"img/youtube_2x.png", "order":4}
+engage-player={"icon":"img/engage_2x.png", "order":5}
+annotation={"label":"Annotation-tool", "order":6}

--- a/opencastCfg/org.apache.felix.fileinstall-deploy.cfg
+++ b/opencastCfg/org.apache.felix.fileinstall-deploy.cfg
@@ -1,0 +1,25 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+felix.fileinstall.dir           = ${karaf.base}/deploy
+felix.fileinstall.tmpdir        = ${karaf.data}/generated-bundles
+felix.fileinstall.poll          = 30000
+felix.fileinstall.start.level   = 80
+felix.fileinstall.active.level  = 80
+felix.fileinstall.log.level     = 3

--- a/opencastCfg/workflows/partial-publish.xml
+++ b/opencastCfg/workflows/partial-publish.xml
@@ -1,0 +1,572 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition xmlns="http://workflow.opencastproject.org">
+
+  <id>partial-publish</id>
+  <title>Publish the recording</title>
+  <tags/>
+  <description/>
+
+  <configuration_panel/>
+
+  <operations>
+
+    <operation
+        id="analyze-tracks"
+        exception-handler-workflow="partial-error"
+        description="Analyze tracks in media package a set control variables">
+      <configurations>
+        <configuration key="source-flavor">*/work</configuration>
+      </configurations>
+    </operation>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Cut the video according the SMIL file                             -->
+    <!--                                                                   -->
+    <!-- Perform cutting according to the edit decision list.              -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <operation id="editor"
+      exception-handler-workflow="partial-error"
+      description="Cut the recording according to the edit decision list">
+      <configurations>
+        <configuration key="source-flavors">*/work</configuration>
+        <configuration key="smil-flavors">smil/cutting</configuration>
+        <configuration key="target-smil-flavor">smil/publish</configuration>
+        <configuration key="target-flavor-subtype">trimmed</configuration>
+        <configuration key="interactive">false</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Tag any optionally uploaded assets -->
+    <operation
+      id="tag"
+      if="${downloadSourceflavorsExist}"
+      exception-handler-workflow="partial-error"
+      description="Tagging uploaded assets for distribution">
+      <configurations>
+        <configuration key="source-flavors">${download-source-flavors}</configuration>
+        <configuration key="target-tags">+engage-download</configuration>
+      </configurations>
+    </operation>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Extract preview images                                            -->
+    <!--                                                                   -->
+    <!-- From the edited recording, take preview images for the player,    -->
+    <!-- search results etc.                                               -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <!-- Encode to engage search result thumbnails -->
+
+    <operation
+      id="image"
+      if="NOT (${uploadedSearchPreview}) AND ${thumbnailType}==0 AND ${presenter_work_video}"
+      exception-handler-workflow="partial-error"
+      description="Creating search result default thumbnails">
+      <configurations>
+        <configuration key="source-flavor">presenter/work</configuration>
+        <configuration key="target-flavor">presenter/search+preview</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="encoding-profile">search-cover.http</configuration>
+        <configuration key="time">${thumbnailPosition}</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="image"
+      if="NOT (${uploadedSearchPreview}) AND ${thumbnailType}==0 AND (${presentation_work_video} AND NOT (${presenter_work_video}))"
+      exception-handler-workflow="partial-error"
+      description="Creating search result default thumbnails">
+      <configurations>
+        <configuration key="source-flavor">presentation/work</configuration>
+        <configuration key="target-flavor">presentation/search+preview</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="encoding-profile">search-cover.http</configuration>
+        <configuration key="time">${thumbnailPosition}</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="image"
+      if="NOT (${uploadedSearchPreview}) AND ${thumbnailType}==2"
+      exception-handler-workflow="partial-error"
+      description="Creating search result thumbnail from saved position">
+      <configurations>
+        <configuration key="source-flavor">${thumbnailTrack}/work</configuration>
+        <configuration key="target-flavor">*/search+preview</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="encoding-profile">search-cover.http</configuration>
+        <configuration key="time">${thumbnailPosition}</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="image-convert"
+      if="NOT (${uploadedSearchPreview}) AND ${thumbnailType}==1 AND ${presenter_work_video}"
+      exception-handler-workflow="partial-error"
+      description="Convert uploaded thumbnail to search result thumbnail (presenter track)">
+      <configurations>
+        <configuration key="source-flavors">thumbnail/source</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="target-flavor">presenter/search+preview</configuration>
+        <configuration key="encoding-profiles">search-cover.http.downscale</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="image-convert"
+      if="NOT (${uploadedSearchPreview}) AND ${thumbnailType}==1 AND ${presentation_work_video}"
+      exception-handler-workflow="partial-error"
+      description="Convert uploaded thumbnail to search result thumbnail (presentation track)">
+      <configurations>
+        <configuration key="source-flavors">thumbnail/source</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="target-flavor">presentation/search+preview</configuration>
+        <configuration key="encoding-profiles">search-cover.http.downscale</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Encode to engage player preview images -->
+
+    <operation
+      id="image"
+      exception-handler-workflow="partial-error"
+      description="Creating player preview image">
+      <configurations>
+        <configuration key="source-flavor">*/trimmed</configuration>
+        <configuration key="source-tags"></configuration>
+        <configuration key="target-flavor">*/player+preview</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="encoding-profile">player-preview.http</configuration>
+        <configuration key="time">1</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Encode to feed cover images -->
+
+    <operation
+      id="image"
+      exception-handler-workflow="partial-error"
+      description="Creating feed cover image">
+      <configurations>
+        <configuration key="source-flavor">*/trimmed</configuration>
+        <configuration key="source-tags"></configuration>
+        <configuration key="target-flavor">*/feed+preview</configuration>
+        <configuration key="target-tags">atom,rss</configuration>
+        <configuration key="encoding-profile">feed-cover.http</configuration>
+        <configuration key="time">1</configuration>
+      </configurations>
+    </operation>
+
+
+    <!-- Create a cover image with the default template -->
+
+    <operation
+      id="tag"
+      description="Removing unneeded presenter-cover from download publication">
+      <configurations>
+        <configuration key="source-flavors">presenter/player+preview</configuration>
+        <configuration key="target-tags">-engage-download</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="image"
+      exception-handler-workflow="partial-error"
+      description="Creating player preview image">
+      <configurations>
+        <configuration key="source-flavor">presenter/trimmed</configuration>
+        <configuration key="source-tags"></configuration>
+        <configuration key="target-flavor">presenter/coverbackground</configuration>
+        <configuration key="encoding-profile">player-preview.http</configuration>
+        <configuration key="time">1</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="cover-image"
+      fail-on-error="true"
+      exception-handler-workflow="partial-error"
+      description="Create a cover image">
+      <configurations>
+        <configuration key="stylesheet">file://${karaf.etc}/branding/coverimage.xsl</configuration>
+        <configuration key="width">1920</configuration>
+        <configuration key="height">1080</configuration>
+        <configuration key="posterimage-flavor">presenter/coverbackground</configuration>
+        <configuration key="target-flavor">presenter/player+preview</configuration>
+        <configuration key="target-tags">archive, engage-download</configuration>
+     </configurations>
+    </operation>
+
+    <!-- Generate timeline preview images -->
+
+    <operation
+      id="timelinepreviews"
+      fail-on-error="false"
+      exception-handler-workflow="error"
+      description="Creating timeline preview images">
+      <configurations>
+        <configuration key="source-flavor">*/trimmed</configuration>
+        <configuration key="target-flavor">*/timeline+preview</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="image-count">100</configuration>
+      </configurations>
+    </operation>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Apply the branding artifacts                                      -->
+    <!--                                                                   -->
+    <!-- Add trailer and bumper to the recording prior to publication.     -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <!-- Apply the theme to the mediapackage -->
+
+    <operation
+      id="theme"
+      exception-handler-workflow="partial-error"
+      description="Apply the theme">
+      <configurations>
+        <configuration key="bumper-flavor">branding/bumper</configuration>
+        <configuration key="bumper-tags">archive</configuration>
+        <configuration key="trailer-flavor">branding/trailer</configuration>
+        <configuration key="trailer-tags">archive</configuration>
+        <configuration key="title-slide-flavor">branding/titleslide</configuration>
+        <configuration key="title-slide-tags">archive</configuration>
+        <configuration key="watermark-flavor">branding/watermark</configuration>
+        <configuration key="watermark-tags">archive</configuration>
+        <configuration key="watermark-layout">theme_watermark_layout</configuration>
+        <configuration key="watermark-layout-variable">theme_watermark_layout_variable</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Inspect the media from the theme -->
+
+    <operation
+      id="inspect"
+      exception-handler-workflow="partial-error"
+      description="Inspecting audio and video streams">
+      <configurations>
+        <configuration key="overwrite">false</configuration>
+        <configuration key="accept-no-media">false</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Create a title slide video if theme has active title slide -->
+    <operation
+      id="include"
+      description="Prepare title slide video"
+      if="${theme_title_slide_active}">
+      <configurations>
+        <configuration key="workflow-id">partial-title-slide</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Render watermarks into video tracks -->
+    <operation
+      id="include"
+      description="Render watermarks into video tracks"
+      if="${theme_watermark_active}">
+      <configurations>
+        <configuration key="workflow-id">partial-watermark</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Tag the dublin core catalogs created during trim operation for archival and publication -->
+
+    <operation
+      id="tag"
+      description="Tagging presenter track as input for next operation"
+      if="NOT (${theme_watermark_active})">
+      <configurations>
+        <configuration key="source-flavors">presenter/trimmed</configuration>
+        <configuration key="target-flavor">presenter/branded</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="tag"
+      description="Tagging presentation track as input for next operation"
+      if="NOT (${theme_watermark_active})">
+      <configurations>
+        <configuration key="source-flavors">presentation/trimmed</configuration>
+        <configuration key="target-flavor">presentation/branded</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Add bumper and trailer part to the presenter track -->
+
+    <operation
+      id="concat"
+      exception-handler-workflow="partial-error"
+      description="Concatenate presenter track with intro, title slide and outro videos">
+      <configurations>
+        <configuration key="source-flavor-part-0">branding/bumper</configuration>
+        <configuration key="source-flavor-part-0-mandatory">${theme_bumper_active}</configuration>
+        <configuration key="source-flavor-part-1">branding/titleslide+video</configuration>
+        <configuration key="source-flavor-part-1-mandatory">${theme_title_slide_active}</configuration>
+        <configuration key="source-flavor-part-2">presenter/branded</configuration>
+        <configuration key="source-flavor-part-2-mandatory">true</configuration>
+        <configuration key="source-flavor-part-3">branding/trailer</configuration>
+        <configuration key="source-flavor-part-3-mandatory">${theme_trailer_active}</configuration>
+        <configuration key="target-flavor">presenter/themed</configuration>
+        <configuration key="encoding-profile">concat.work</configuration>
+        <configuration key="output-resolution">part-2</configuration>
+        <configuration key="output-framerate">part-2</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Add bumper and trailer part to the presentation track -->
+
+    <operation
+      id="concat"
+      exception-handler-workflow="partial-error"
+      description="Concatenate presentation track with intro, title slide and outro videos">
+      <configurations>
+        <configuration key="source-flavor-part-0">branding/bumper</configuration>
+        <configuration key="source-flavor-part-0-mandatory">${theme_bumper_active}</configuration>
+        <configuration key="source-flavor-part-1">branding/titleslide+video</configuration>
+        <configuration key="source-flavor-part-1-mandatory">${theme_title_slide_active}</configuration>
+        <configuration key="source-flavor-part-2">presentation/branded</configuration>
+        <configuration key="source-flavor-part-2-mandatory">true</configuration>
+        <configuration key="source-flavor-part-3">branding/trailer</configuration>
+        <configuration key="source-flavor-part-3-mandatory">${theme_trailer_active}</configuration>
+        <configuration key="target-flavor">presentation/themed</configuration>
+        <configuration key="encoding-profile">concat.work</configuration>
+        <configuration key="output-resolution">part-2</configuration>
+        <configuration key="output-framerate">part-2</configuration>
+      </configurations>
+    </operation>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Encode for publication to Engage                                  -->
+    <!--                                                                   -->
+    <!-- Encode audio and video formats to the distribution formats that   -->
+    <!-- are required by the Engage publication channel.                   -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <!-- Encode presenter (camera) to Engage player format -->
+    <operation
+      if="${flagQuality360p}"
+      id="compose"
+      exception-handler-workflow="partial-error"
+      description="Encoding 360p video to MP4 download">
+      <configurations>
+        <configuration key="source-flavor">*/themed</configuration>
+        <configuration key="target-flavor">*/delivery</configuration>
+        <configuration key="target-tags">engage-download,engage-streaming,360p-quality</configuration>
+        <configuration key="encoding-profile">adaptive-360p.http</configuration>
+      </configurations>
+    </operation>
+    <operation
+      if="${flagQuality480p}"
+      id="compose"
+      exception-handler-workflow="partial-error"
+      description="Encoding 480p video to MP4 download">
+      <configurations>
+        <configuration key="source-flavor">*/themed</configuration>
+        <configuration key="target-flavor">*/delivery</configuration>
+        <configuration key="target-tags">engage-download,engage-streaming,480p-quality</configuration>
+        <configuration key="encoding-profile">adaptive-480p.http</configuration>
+      </configurations>
+    </operation>
+    <operation
+      if="${flagQuality720p}"
+      id="compose"
+      exception-handler-workflow="partial-error"
+      description="Encoding 720p video to MP4 download">
+      <configurations>
+        <configuration key="source-flavor">*/themed</configuration>
+        <configuration key="target-flavor">*/delivery</configuration>
+        <configuration key="target-tags">engage-download,engage-streaming,720p-quality</configuration>
+        <configuration key="encoding-profile">adaptive-720p.http</configuration>
+      </configurations>
+    </operation>
+    <operation
+      if="${flagQuality1080p}"
+      id="compose"
+      exception-handler-workflow="partial-error"
+      description="Encoding 1080p video to MP4 download">
+      <configurations>
+        <configuration key="source-flavor">*/themed</configuration>
+        <configuration key="target-flavor">*/delivery</configuration>
+        <configuration key="target-tags">engage-download,engage-streaming,1080p-quality</configuration>
+        <configuration key="encoding-profile">adaptive-1080p.http</configuration>
+      </configurations>
+    </operation>
+    <operation
+      if="${flagQuality2160p}"
+      id="compose"
+      exception-handler-workflow="partial-error"
+      description="Encoding 2160p video to MP4 download">
+      <configurations>
+        <configuration key="source-flavor">*/themed</configuration>
+        <configuration key="target-flavor">*/delivery</configuration>
+        <configuration key="target-tags">engage-download,engage-streaming,2160p-quality</configuration>
+        <configuration key="encoding-profile">adaptive-2160p.http</configuration>
+      </configurations>
+    </operation>
+    <operation
+      id="composite"
+      description="Create YouTube compatible output"
+      if="${publishToYouTube}"
+      fail-on-error="true"
+      exception-handler-workflow="partial-error">
+      <configurations>
+        <configuration key="source-flavor-lower">presentation/themed</configuration>
+        <configuration key="source-flavor-upper">presenter/themed</configuration>
+        <configuration key="encoding-profile">mp4-preview.dual.http</configuration>
+        <configuration key="target-flavor">composite/delivery</configuration>
+        <configuration key="target-tags">youtube</configuration>
+        <configuration key="output-resolution">1280x800</configuration>
+        <configuration key="output-background">0x000000FF</configuration>
+        <configuration key="layout">preview</configuration>
+        <configuration key="layout-preview">
+          {"horizontalCoverage":0.5,"anchorOffset":{"referring":{"left":1.0,"top":0.0},"reference":{"left":1.0,"top":0.0},"offset":{"x":0,"y":0}}};
+          {"horizontalCoverage":0.5,"anchorOffset":{"referring":{"left":0.0,"top":0.0},"reference":{"left":0.0,"top":0.0},"offset":{"x":0,"y":0}}};
+        </configuration>
+      </configurations>
+    </operation>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Segment video streams and extract metadata                        -->
+    <!--                                                                   -->
+    <!-- Apply the video segmentation algorithm to the presentation tracks -->
+    <!-- and extract segment preview images and metadata.                  -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <!-- Run the videosegmentation -->
+
+    <operation
+      id="segment-video"
+      fail-on-error="false"
+      description="Detecting slide transitions in presentation track">
+      <configurations>
+        <configuration key="source-flavor">presentation/themed</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Generate segment preview images -->
+
+    <operation
+      id="segmentpreviews"
+      fail-on-error="false"
+      description="Creating preview images for presentation segments">
+      <configurations>
+        <configuration key="source-flavor">presentation/themed</configuration>
+        <configuration key="target-flavor">presentation/segment+preview</configuration>
+        <configuration key="reference-flavor">presentation/delivery</configuration>
+        <configuration key="reference-tags">engage-download</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+        <configuration key="encoding-profile">player-slides.http</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Extract text form slide preview images -->
+
+    <operation
+      id="extract-text"
+      fail-on-error="false"
+      description="Extracting text from presentation segments">
+      <configurations>
+        <configuration key="source-flavor">presentation/themed</configuration>
+        <configuration key="target-tags">engage-download</configuration>
+      </configurations>
+    </operation>
+
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- Publish to publication channels                                   -->
+    <!--                                                                   -->
+    <!-- Send the encoded material along with the metadata to the          -->
+    <!-- publication channels.                                             -->
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <!-- Publish to engage player -->
+
+    <operation
+      id="publish-engage"
+      if="${publishToEngage}"
+      max-attempts="2"
+      exception-handler-workflow="partial-error"
+      description="Publishing to Opencast Media Module">
+      <configurations>
+        <configuration key="download-source-flavors">dublincore/*,security/*</configuration>
+        <configuration key="download-source-tags">engage-download,atom,rss,mobile</configuration>
+        <configuration key="streaming-source-tags">engage-streaming</configuration>
+        <configuration key="check-availability">true</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="publish-configure"
+      exception-handler-workflow="partial-error"
+      description="To annotation tool">
+      <configurations>
+        <configuration key="source-tags">engage-download, engage-streaming</configuration>
+        <configuration key="channel-id">annotation</configuration>
+        <configuration key="url-pattern">http://localhost:8080/annotation-tool/index.html?id=${event_id}</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="publish-aws"
+      if="${publishToAws}"
+      max-attempts="2"
+      exception-handler-workflow="partial-error"
+      description="Publishing to Amazon Web Services">
+      <configurations>
+        <configuration key="download-source-flavors">dublincore/*,security/*</configuration>
+        <configuration key="download-source-tags">engage-download,atom,rss,mobile</configuration>
+        <configuration key="streaming-source-tags">engage-streaming</configuration>
+        <configuration key="strategy">merge</configuration>
+        <configuration key="check-availability">true</configuration>
+      </configurations>
+    </operation>
+
+    <operation
+      id="publish-configure"
+      if="${publishToApi}"
+      exception-handler-workflow="partial-error"
+      description="Publish to external api publication channel">
+      <configurations>
+        <configuration key="channel-id">api</configuration>
+        <configuration key="mimetype">application/json</configuration>
+        <configuration key="source-tags">engage-download,engage-streaming</configuration>
+        <configuration key="url-pattern">http://localhost:8080/api/events/${event_id}</configuration>
+        <configuration key="with-published-elements">false</configuration>
+        <configuration key="check-availability">true</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Publish to OAI-PMH -->
+
+    <operation
+      id="publish-oaipmh"
+      if="${publishToOaiPmh}"
+      exception-handler-workflow="partial-error"
+      description="Publish to OAI-PMH Default Repository">
+      <configurations>
+        <configuration key="download-flavors">dublincore/*,security/*</configuration>
+        <configuration key="download-tags">engage-download,atom,rss</configuration>
+        <configuration key="streaming-tags">engage-streaming</configuration>
+        <configuration key="check-availability">true</configuration>
+        <configuration key="repository">default</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Publish to YouTube -->
+
+    <operation
+      id="publish-youtube"
+      if="${publishToYouTube}"
+      max-attempts="2"
+      exception-handler-workflow="partial-error"
+      description="Publishing to YouTube">
+      <configurations>
+        <configuration key="source-tags">youtube</configuration>
+      </configurations>
+    </operation>
+
+  </operations>
+
+</definition>


### PR DESCRIPTION
This PR adds a new config file that allows the annotation tool to work with the external api instead of the search index.

- To work the user who logs to the Opencast system has to have the permission to access to the external API.
- In the workflows is required to attach the XACML files to the channel, if not, the annotation tool will fail in loading.



Also Added configuration files and workflows from the default installation of opencast to ease the default setup when testing