### PR TITLE
Correctly initialize template layout settings

### DIFF
--- a/frontend/js/views/main.js
+++ b/frontend/js/views/main.js
@@ -328,7 +328,7 @@ define(["jquery",
                 visitComponents(layout, function (component) {
                     component.title = i18next.t("views." + component.componentName);
                 });
-                _.extend(layout.settings, {
+                layout.settings = _.extend(layout.settings || {}, {
                     showPopoutIcon: false,
                     showMaximiseIcon: false,
                     selectionEnabled: true


### PR DESCRIPTION
When loading a layout from a template,
it does not have a `settings` key,
so extending it has no effect.

This results in the maximize and pop-out icons being shown
when you load a predefined view,
although these should be hidden,
since we currently don't support these GoldenLayout features,
unfortunately. :(