### PR TITLE
Use proper quotation marks in translations

### DIFF
--- a/frontend/locales/de/translation.json
+++ b/frontend/locales/de/translation.json
@@ -39,7 +39,7 @@
     "new label placeholder": "Wert des Kennzeichens …",
     "new": {
       "placeholder": "Freitextannotation schreiben ($t(annotate.new.title))",
-      "title": "\"Shift + Return\" drücken, um eine neue Zeile einzufügen."
+      "title": "„Shift + Return“ drücken, um eine neue Zeile einzufügen."
     },
     "no selected track": "Keine Spur ausgewählt",
     "pause while editing": "Video während des Schreibens anhalten",
@@ -97,7 +97,7 @@
     "cancel": "$t(common actions.cancel)",
     "delete": "$t(common actions.delete)",
     "title": "Löschen",
-    "warning": "Wollen Sie $t(models.genitive, {'context': {{context}} }) \"{{content}}\" wirklich löschen?"
+    "warning": "Wollen Sie $t(models.genitive, {'context': {{context}} }) „{{content}}“ wirklich löschen?"
   },
   "description": "Werkzeug zur Videoannotation",
   "list annotation": {

--- a/frontend/locales/en/translation.json
+++ b/frontend/locales/en/translation.json
@@ -97,7 +97,7 @@
     "cancel": "$t(common actions.cancel)",
     "delete": "$t(common actions.delete)",
     "title": "Delete",
-      "warning": "Do you really want to delete the {{context}} \"{{content}}\"?"
+    "warning": "Do you really want to delete the {{context}} \"{{content}}\"?"
   },
   "description": "Video annotation tool",
   "list annotation": {

--- a/frontend/locales/en/translation.json
+++ b/frontend/locales/en/translation.json
@@ -38,7 +38,7 @@
     "new category name": "NEW CATEGORY",
     "new label placeholder": "Label value …",
     "new": {
-      "placeholder": "Write a free text annotation. $t(annotate.new.title)",
+      "placeholder": "Write a free text annotation. ($t(annotate.new.title))",
       "title": "Use “ shift + return” keys to create a new line."
     },
     "no selected track": "No tracak selected",

--- a/frontend/locales/en/translation.json
+++ b/frontend/locales/en/translation.json
@@ -39,7 +39,7 @@
     "new label placeholder": "Label value …",
     "new": {
       "placeholder": "Write a free text annotation. $t(annotate.new.title)",
-      "title": "Use \"shift + return\" keys to create a new line."
+      "title": "Use “ shift + return” keys to create a new line."
     },
     "no selected track": "No tracak selected",
     "pause while editing": "Pause video during writing",
@@ -97,7 +97,7 @@
     "cancel": "$t(common actions.cancel)",
     "delete": "$t(common actions.delete)",
     "title": "Delete",
-    "warning": "Do you really want to delete the {{context}} \"{{content}}\"?"
+    "warning": "Do you really want to delete the {{context}} “ {{content}}”?"
   },
   "description": "Video annotation tool",
   "list annotation": {


### PR DESCRIPTION
SWITCH noticed some incomplete strings in the UI:

![image](https://user-images.githubusercontent.com/123272/66316862-b368fd80-e918-11e9-8000-79cd1079c744.png)

This is because the corresponding translation strings contained literal `"` characters, and our Handlebars translation helper (intentionally!) does not escape these strings.

See also #256.

The solution is of course to use sexy unicode quotation marks. :smirk: 