### PR TITLE
Refactoring in preparation of the vis-timeline migration

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -3,6 +3,11 @@
          (eval . (progn
                    (c-set-offset 'arglist-cont-nonempty 8)
                    (require 'grep)
-                   (add-to-list (make-local-variable 'grep-find-ignored-directories)
-                                "node_modules")))))
+                   (make-local-variable 'grep-find-ignored-directories)
+                   (dolist (dir '("node_modules"
+                                  "frontend/js/libs"
+                                  "frontend/www"
+                                  "target"
+                                  "opencast-backend/annotation-tool/src/main/resources/ui"))
+                     (add-to-list 'grep-find-ignored-directories dir))))))
  (js2-mode . ((js2-basic-offset . 4))))

--- a/frontend/build/profiles/integration/annotation-tool-configuration.js
+++ b/frontend/build/profiles/integration/annotation-tool-configuration.js
@@ -167,8 +167,6 @@ define(["jquery",
                     parameters;
             },
 
-            tracksToImport: undefined,
-
             /**
              * Define if the structured annotations are or not enabled
              * @alias module:annotation-tool-configuration.Configuration.isStructuredAnnotationEnabled

--- a/frontend/build/profiles/local/annotation-tool-configuration.js
+++ b/frontend/build/profiles/local/annotation-tool-configuration.js
@@ -75,12 +75,6 @@ define(["jquery",
             localStorage: true,
 
             /**
-             * Array of tracks to import by default
-             * @type {?object[]}
-             */
-            tracksToImport: undefined,
-
-            /**
              * Define if the structured annotations are or not enabled
              * @alias module:annotation-tool-configuration.Configuration.isStructuredAnnotationEnabled
              * @return {boolean} True if this feature is enabled

--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -336,7 +336,7 @@ define(["jquery",
              * Add a timeupdate listener with the given interval
              * @alias   annotationTool.addTimeupdateListener
              * @param {Object} callback the listener callback
-             * @param {Number} (interval) the interval between each timeupdate event
+             * @param {Number} interval the interval between each timeupdate event
              */
             addTimeupdateListener: function (callback, interval) {
                 var timeupdateEvent = this.EVENTS.TIMEUPDATE;

--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -544,27 +544,15 @@ define(["jquery",
              * @return {Object} The created annotation
              */
             createAnnotation: function (params) {
-                if (!params.created_by && this.user) {
-                    params.created_by = this.user.id;
-                }
-                if (!params.time) {
-                    var time = Math.round(this.playerAdapter.getCurrentTime());
-                    if (!_.isNumber(time) || time < 0) {
-                        return undefined;
-                    }
-                    params.start = time;
-                }
-
-                var options = {};
-                if (!this.localStorage) {
-                    options.wait = true;
-                }
-
-                // The loop controller can constrain annotations to the current loop using this.
-                // @see module:views-loop.Loop#toggleConstrainAnnotations
-                _.extend(params, this.annotationConstraints);
-
-                var annotation = this.selectedTrack.get("annotations").create(params, options);
+                var annotation = this.selectedTrack.get("annotations")
+                    .create(_.extend(
+                        params,
+                        { start: Math.round(this.playerAdapter.getCurrentTime()) },
+                        // The loop controller can constrain annotations
+                        // to the current loop using this.
+                        // @see module:views-loop.Loop#toggleConstrainAnnotations
+                        this.annotationConstraints
+                    ), { wait: true });
                 this.activeAnnotation = annotation;
                 return annotation;
             },

--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -274,24 +274,6 @@ define(["jquery",
             },
 
             /**
-             * Transform time in seconds (i.e. 12.344) into a well formated time (01:12:04)
-             * @alias   annotationTool.getWellFormatedTime
-             * @param {number} time the time in seconds
-             * @param {boolean} [noRounted] Define if the number should be rounded or if the decimal should be simply removed. Default is rounding (false).
-             */
-            getWellFormatedTime: function (time, noRounding) {
-                var twoDigit = function (number) {
-                    return (number < 10 ? "0" : "") + number;
-                },
-                    base    = (_.isUndefined(noRounding) || !noRounding) ? Math.round(time) : Math.floor(time),
-                    seconds = base % 60,
-                    minutes = ((base - seconds) / 60) % 60,
-                    hours   = (base - seconds - minutes * 60) / 3600;
-
-                return twoDigit(hours) + ":" + twoDigit(minutes) + ":" + twoDigit(seconds);
-            },
-
-            /**
              * Listen and retrigger timeupdate event from player adapter events with added intervals
              * @alias   annotationTool.onTimeUpdate
              */

--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -124,7 +124,6 @@ define(["jquery",
                 _.bindAll(this,
                           "updateSelectionOnTimeUpdate",
                           "createAnnotation",
-                          "deleteAnnotation",
                           "getAnnotation",
                           "getSelection",
                           "getTrack",
@@ -746,34 +745,6 @@ define(["jquery",
                         });
                     }
                 });
-            },
-
-            //////////////
-            // DELETERs //
-            //////////////
-
-            /**
-             * Delete the annotation with the given id with the track with the given track id
-             * @alias annotationTool.deleteAnnotation
-             * @param {Integer} annotationId The id of the annotation to delete
-             * @param {Integer} trackId Id of the track containing the annotation
-             */
-            deleteAnnotation: function (annotationId, trackId) {
-                if (typeof trackId === "undefined") {
-                    this.video.get("tracks").each(function (track) {
-                        if (track.get("annotations").get(annotationId)) {
-                            trackId = track.get("id");
-                        }
-                    });
-                }
-
-                var annotation = this.video.getAnnotation(annotationId, trackId);
-                if (annotation) {
-                    this.deleteOperation.start(
-                        annotation,
-                        this.deleteOperation.targetTypes.ANNOTATION
-                    );
-                }
             },
 
             /**

--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -131,7 +131,6 @@ define(["jquery",
                           "getTracks",
                           "getSelectedTrack",
                           "fetchData",
-                          "importTracks",
                           "importCategories",
                           "hasSelection",
                           "onDestroyRemoveSelection",
@@ -171,43 +170,6 @@ define(["jquery",
                 this.once(this.EVENTS.MODELS_INITIALIZED, function () {
                     this.views.main = new MainView();
                 }, this);
-
-                var importTracks = function () {
-
-                    var updateTracksOrder = _.bind(function (tracks) {
-                        this.tracksOrder = _.chain(tracks.getVisibleTracks())
-                            .map("id")
-                            .sortBy(function (trackId) {
-                                return _.indexOf(this.tracksOrder, trackId);
-                            }, this).value();
-                    }, this);
-                    this.listenTo(this.video, "change:tracks", updateTracksOrder);
-                    updateTracksOrder(this.getTracks());
-
-                    var trackImported = false;
-
-                    if (!_.isUndefined(this.tracksToImport)) {
-                        if (this.playerAdapter.getStatus() === PlayerAdapter.STATUS.PAUSED) {
-                            this.importTracks(this.tracksToImport());
-                            trackImported = true;
-                        } else {
-                            $(this.playerAdapter).one(
-                                PlayerAdapter.EVENTS.READY + " " + PlayerAdapter.EVENTS.PAUSE,
-                                _.bind(function () {
-                                    if (trackImported) {
-                                        return;
-                                    }
-
-                                    this.importTracks(this.tracksToImport());
-                                    trackImported = true;
-                                }, this)
-                            );
-                        }
-                    }
-                };
-                importTracks = _.after(2, importTracks, this);
-                this.once(this.EVENTS.MODELS_INITIALIZED, importTracks);
-                this.once(this.EVENTS.VIDEO_LOADED, importTracks);
 
                 this.once(this.EVENTS.VIDEO_LOADED, function () {
 
@@ -733,25 +695,6 @@ define(["jquery",
             ////////////////
             // IMPORTERs  //
             ////////////////
-
-            /**
-             * Import the given tracks in the tool
-             * @alias annotationTool.importTracks
-             * @param {PlainObject} tracks Object containing the tracks in the tool
-             */
-            importTracks: function (tracks) {
-                _.each(tracks, function (track) {
-                    this.setLoadingProgress(
-                        this.loadingPercent,
-                        i18next.t("startup.importing track", { track: track.name })
-                    );
-                    if (_.isUndefined(this.getTrack(track.id))) {
-                        this.video.get("tracks").create(track);
-                    } else {
-                        console.info("Can not import track %s: A track with this ID already exist.", track.id);
-                    }
-                }, this);
-            },
 
             /**
              * Import the given categories in the tool

--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -42,12 +42,12 @@ define(["jquery",
         var annotationTool = window.annotationTool = _.extend({}, Backbone.Events, {
 
             EVENTS: {
-                ANNOTATION_SELECTION : "at:annotation-selection",
-                ANNOTATE_TOGGLE_EDIT : "at:annotate-switch-edit-modus",
-                MODELS_INITIALIZED   : "at:models-initialized",
-                TIMEUPDATE           : "at:timeupdate",
-                USER_LOGGED          : "at:logged",
-                VIDEO_LOADED         : "at:video-loaded"
+                ANNOTATION_SELECTION: "at:annotation-selection",
+                ANNOTATE_TOGGLE_EDIT: "at:annotate-switch-edit-modus",
+                MODELS_INITIALIZED: "at:models-initialized",
+                TIMEUPDATE: "at:timeupdate",
+                USER_LOGGED: "at:logged",
+                VIDEO_LOADED: "at:video-loaded"
             },
 
             timeupdateIntervals: [],
@@ -834,9 +834,6 @@ define(["jquery",
              * @param {Integer} trackId Id of the track containing the annotation
              */
             deleteAnnotation: function (annotationId, trackId) {
-                var annotation,
-                    self = this;
-
                 if (typeof trackId === "undefined") {
                     this.video.get("tracks").each(function (track) {
                         if (track.get("annotations").get(annotationId)) {
@@ -845,12 +842,12 @@ define(["jquery",
                     });
                 }
 
-                annotation = self.video.getAnnotation(annotationId, trackId);
-
+                var annotation = this.video.getAnnotation(annotationId, trackId);
                 if (annotation) {
-                    self.deleteOperation.start(annotation, self.deleteOperation.targetTypes.ANNOTATION);
-                } else {
-                    console.warn("Not able to find annotation %i on track %i", annotationId, trackId);
+                    this.deleteOperation.start(
+                        annotation,
+                        this.deleteOperation.targetTypes.ANNOTATION
+                    );
                 }
             },
 

--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -759,7 +759,7 @@ define(["jquery",
                     concludeInitialization = _.bind(function () {
 
                         // At least one private track should exist, we select the first one
-                        var selectedTrack = tracks.getMine()[0];
+                        var selectedTrack = tracks.where({ isMine: true })[0];
 
                         if (!selectedTrack.get("id")) {
                             selectedTrack.on("ready", concludeInitialization, this);
@@ -778,11 +778,7 @@ define(["jquery",
 
                         tracks = this.video.get("tracks");
 
-                        if (this.localStorage) {
-                            tracks = tracks.getTracksForLocalStorage();
-                        }
-
-                        if (tracks.getMine().length === 0) {
+                        if (!tracks.where({ isMine: true }).length) {
                             tracks.create({
                                 name: i18next.t("default track.name", {
                                     nickname: this.user.get("nickname")

--- a/frontend/js/collections/categories.js
+++ b/frontend/js/collections/categories.js
@@ -72,24 +72,6 @@ define(["underscore",
                 } else {
                     return null;
                 }
-            },
-
-            /**
-             * Get the categories created by the current user
-             * @alias module:collections-categories.Categories#getMine
-             * @return {array} Array containing the list of categories created by the current user
-             */
-            getMine: function () {
-                return this.where({ isMine: true });
-            },
-
-            /**
-             * Get the categories visible by everyone
-             * @alias module:collections-categories.Categories#getPublic
-             * @return {array} Array containing the list of categories visible by everyone
-             */
-            getPublic: function () {
-                return this.where({ isPublic: true });
             }
         });
 

--- a/frontend/js/collections/tracks.js
+++ b/frontend/js/collections/tracks.js
@@ -63,8 +63,8 @@ define(["underscore",
             /**
              * Parse the given data
              * @alias module:collections-tracks.Tracks#parse
-             * @param  {object} data Object or array containing the data to parse.
-             * @return {object}      the part of the given data related to the tracks
+             * @param {object} data object or array containing the data to parse.
+             * @return {object} the part of the given data related to the tracks
              */
             parse: function (data) {
                 if (data.tracks && _.isArray(data.tracks)) {
@@ -82,7 +82,7 @@ define(["underscore",
              * @return {array} Array containing the list of tracks created by the current user
              */
             getMine: function () {
-                return this.where({isMine: true});
+                return this.where({ isMine: true });
             },
 
             /**
@@ -91,7 +91,7 @@ define(["underscore",
              * @return {array} Array containing the list of the visible tracks
              */
             getTracksForLocalStorage: function () {
-                return this.remove(this.where({isMine: false, access: 0}));
+                return this.remove(this.where({ isMine: false, access: 0 }));
             },
 
             /**
@@ -106,8 +106,8 @@ define(["underscore",
 
             /**
              * Displays the given tracks and hide the current displayed tracks.
-             * @param  {array} tracks an array containing the tracks to display
-             * @param  {boolean} keepPrevious should previously visible tracks stay visible?
+             * @param {array} tracks an array containing the tracks to display
+             * @param {boolean} keepPrevious should previously visible tracks stay visible?
              */
             showTracks: function (tracks, keepPrevious) {
                 var selectedTrack = annotationTool.selectedTrack;
@@ -142,7 +142,7 @@ define(["underscore",
             /**
              * Get the url for this collection
              * @alias module:collections-tracks.Tracks#url
-             * @return {String} The url of this collection
+             * @return {String} the url of this collection
              */
             url: function () {
                 return _.result(this.video, "url") + "/tracks";

--- a/frontend/js/collections/tracks.js
+++ b/frontend/js/collections/tracks.js
@@ -37,7 +37,7 @@ define(["underscore",
 
             /**
              * Model of the instances contained in this collection
-             * @alias module:collections-tracks.Tracks#initialize
+             * @alias module:collections-tracks.Tracks#model
              */
             model: Track,
 

--- a/frontend/js/collections/tracks.js
+++ b/frontend/js/collections/tracks.js
@@ -56,7 +56,7 @@ define(["underscore",
                     this.showTracks([track], true);
 
                     // Select the new track
-                    annotationTool.selectedTrack = track;
+                    annotationTool.selectTrack(track);
                 });
             },
 

--- a/frontend/js/handlebarsHelpers.js
+++ b/frontend/js/handlebarsHelpers.js
@@ -23,23 +23,12 @@ define(["handlebars", "underscore", "i18next", "util"], function (Handlebars, _,
     });
 
     /**
-     * Handlebars helper to display the annotation start time
+     * Handlebars helper to display a point in time on the timeline
      * @alias module:Handlebars#time
-     * @param {number} start The start time
+     * @param {number} start The time to format in seconds
      * @return {string} The formated time
      */
     Handlebars.registerHelper("time", util.formatTime);
-
-    /**
-     * Handlebars helper to display the annotation end time
-     * @alias module:Handlebars#end
-     * @param  {number} start The start time
-     * @param  {number} duration The annotation duration
-     * @return {string}      The formated time
-     */
-    Handlebars.registerHelper("end", function (start, duration) {
-        return util.formatTime(start + (duration || 0));
-    });
 
     /**
      * Handlebars helper to get user nickname

--- a/frontend/js/handlebarsHelpers.js
+++ b/frontend/js/handlebarsHelpers.js
@@ -23,20 +23,20 @@ define(["handlebars", "underscore", "i18next", "util"], function (Handlebars, _,
     });
 
     /**
-     * Handlebars helper to secure the text field
+     * Handlebars helper to display the annotation start time
      * @alias module:Handlebars#time
-     * @param  {double} start The start time
-     * @return {string}      The formated time
+     * @param {number} start The start time
+     * @return {string} The formated time
      */
     Handlebars.registerHelper("time", function (start) {
         return annotationTool.getWellFormatedTime(start);
     });
 
     /**
-     * Handlebars helper to display the annotation duration
+     * Handlebars helper to display the annotation end time
      * @alias module:Handlebars#end
-     * @param  {double} start The start time
-     * @param  {double} duration The annotation duration
+     * @param  {number} start The start time
+     * @param  {number} duration The annotation duration
      * @return {string}      The formated time
      */
     Handlebars.registerHelper("end", function (start, duration) {
@@ -46,7 +46,7 @@ define(["handlebars", "underscore", "i18next", "util"], function (Handlebars, _,
     /**
      * Handlebars helper to get user nickname
      * @alias module:Handlebars#nickname
-     * @param  {User | integer} user The user object or its id
+     * @param {User | number} user The user object or its id
      * @return {string} The user nickname
      */
     Handlebars.registerHelper("nickname", function (user) {
@@ -61,7 +61,7 @@ define(["handlebars", "underscore", "i18next", "util"], function (Handlebars, _,
      * Handlebars helper to format a date to the configured format
      * @alias module:Handlebars#formatDate
      * @param  {date} date The date to format
-     * @return {string}      The formated date
+     * @return {string} The formated date
      */
     Handlebars.registerHelper("formatDate", function (date) {
         return util.formatDate(date);

--- a/frontend/js/handlebarsHelpers.js
+++ b/frontend/js/handlebarsHelpers.js
@@ -28,9 +28,7 @@ define(["handlebars", "underscore", "i18next", "util"], function (Handlebars, _,
      * @param {number} start The start time
      * @return {string} The formated time
      */
-    Handlebars.registerHelper("time", function (start) {
-        return util.formatTime(start);
-    });
+    Handlebars.registerHelper("time", util.formatTime);
 
     /**
      * Handlebars helper to display the annotation end time
@@ -50,7 +48,7 @@ define(["handlebars", "underscore", "i18next", "util"], function (Handlebars, _,
      * @return {string} The user nickname
      */
     Handlebars.registerHelper("nickname", function (user) {
-        if (!_.isObject(user)) {
+        if (_.isNumber(user)) {
             return annotationTool.users.get(user).get("nickname");
         } else {
             return user.nickname;
@@ -63,9 +61,7 @@ define(["handlebars", "underscore", "i18next", "util"], function (Handlebars, _,
      * @param  {date} date The date to format
      * @return {string} The formated date
      */
-    Handlebars.registerHelper("formatDate", function (date) {
-        return util.formatDate(date);
-    });
+    Handlebars.registerHelper("formatDate", util.formatDate);
 
     /**
      * Translate a string using `i18next`

--- a/frontend/js/handlebarsHelpers.js
+++ b/frontend/js/handlebarsHelpers.js
@@ -88,14 +88,5 @@ define(["handlebars", "underscore", "i18next", "util"], function (Handlebars, _,
         );
     });
 
-    /**
-     * Concatenate strings and possibly variables.
-     * Mainly used for nesting helpers.
-     * @alias module:Handlebars#concat
-     */
-    Handlebars.registerHelper("concat", function () {
-        return Array.prototype.slice.call(arguments, 0, -1).join('');
-    });
-
     return Handlebars;
 });

--- a/frontend/js/handlebarsHelpers.js
+++ b/frontend/js/handlebarsHelpers.js
@@ -29,7 +29,7 @@ define(["handlebars", "underscore", "i18next", "util"], function (Handlebars, _,
      * @return {string} The formated time
      */
     Handlebars.registerHelper("time", function (start) {
-        return annotationTool.getWellFormatedTime(start);
+        return util.formatTime(start);
     });
 
     /**
@@ -40,7 +40,7 @@ define(["handlebars", "underscore", "i18next", "util"], function (Handlebars, _,
      * @return {string}      The formated time
      */
     Handlebars.registerHelper("end", function (start, duration) {
-        return annotationTool.getWellFormatedTime(start + (duration || 0.0));
+        return util.formatTime(start + (duration || 0));
     });
 
     /**

--- a/frontend/js/models/annotation.js
+++ b/frontend/js/models/annotation.js
@@ -43,7 +43,7 @@ define(["underscore",
              * @static
              */
             defaults: {
-                start   : 0,
+                start: 0,
                 duration: 0
             },
 

--- a/frontend/js/models/category.js
+++ b/frontend/js/models/category.js
@@ -139,7 +139,7 @@ define(["underscore",
 
                 if (attr.labels) {
                     attr.labels.each(function (value) {
-                        var parseValue = value.parse({category: this.toJSON()});
+                        var parseValue = value.parse({ category: this.toJSON() });
 
                         if (parseValue.category) {
                             parseValue = parseValue.category;

--- a/frontend/js/models/resource.js
+++ b/frontend/js/models/resource.js
@@ -123,11 +123,11 @@ var Resource = Backbone.Model.extend({
     /**
      * Parse the attribute list passed to the model
      * @alias module:models-resource.Resource#parse
-     * @param  {object} data Object literal containing the model attribute to parse.
+     * @param {object} data Object literal containing the model attribute to parse.
      * @param {function} callback Callback function that parses and potentially modifies <tt>data</tt>
      *   It does not need to worry about whether a POJO or a Backbone model was passed
      *   and it does not have to return anything. It works directly on the passed hash
-     * @return {object}  The object literal with the list of parsed model attribute.
+     * @return {object} The object literal with the list of parsed model attribute.
      */
     parse: function (data, callback) {
         var annotationTool = window.annotationTool || {};

--- a/frontend/js/models/track.js
+++ b/frontend/js/models/track.js
@@ -18,26 +18,30 @@
  * A module representing the track model
  * @module models-track
  */
-define(["underscore",
-        "collections/annotations",
-        "access",
-        "models/resource"],
+define([
+    "underscore",
+    "collections/annotations",
+    "access",
+    "models/resource"
+], function (
+    _,
+    Annotations,
+    ACCESS,
+    Resource
+) {
 
-    function (_, Annotations, ACCESS, Resource) {
+    "use strict";
 
-        "use strict";
-
-        /**
-         * @constructor
-         * @see {@link http://www.backbonejs.org/#Model}
-         * @augments module:Backbone.Model
-         * @memberOf module:models-track
-         * @alias module:models-track.Track
-         */
-        var Track = Resource.extend(
-            /** @lends module:models-track~Track.prototype */
-            {
-
+    /**
+     * @constructor
+     * @see {@link http://www.backbonejs.org/#Model}
+     * @augments module:Backbone.Model
+     * @memberOf module:models-track
+     * @alias module:models-track.Track
+     */
+    var Track = Resource.extend(
+        /** @lends module:models-track~Track.prototype */
+        {
             /**
              * Default models value
              * @alias module:models-scalevalue.Scalevalue#defaults
@@ -55,8 +59,8 @@ define(["underscore",
              */
             initialize: function (attr) {
                 _.bindAll(this,
-                        "getAnnotation",
-                        "fetchAnnotations");
+                          "getAnnotation",
+                          "fetchAnnotations");
 
                 if (!attr || _.isUndefined(attr.name)) {
                     throw "'name' attribute is required";
@@ -152,11 +156,11 @@ define(["underscore",
                 CREATED_BY          : "created_by",
                 CREATED_BY_NICKNAME : "created_by_nickname"
             }
-        });
+        }
+    );
 
-        /**
-         * @exports Track
-         */
-        return Track;
-    }
-);
+    /**
+     * @exports Track
+     */
+    return Track;
+});

--- a/frontend/js/models/user.js
+++ b/frontend/js/models/user.js
@@ -86,6 +86,13 @@ define(["roles",
                 }
 
                 return undefined;
+            },
+
+            /**
+             * @return {boolean} Whether or not this user is an admin
+             */
+            isAdmin: function () {
+                return this.get("role") === ROLES.ADMINISTRATOR;
             }
         });
         return User;

--- a/frontend/js/util.js
+++ b/frontend/js/util.js
@@ -21,6 +21,14 @@ define([
     moment
 ) { "use strict";
 
+function zeroPad(n) {
+    if (n < 10) {
+        return "0" + n;
+    } else {
+        return n;
+    }
+}
+
 /**
  * A module containing helper functions needed in many different places
  * @exports util
@@ -55,6 +63,25 @@ var util = {
      */
     secondsFromDate: function (d) {
         return d.getTime() / 1000;
+    },
+
+    /**
+     * @param time {number} A point in time,
+     *     defined by the number of seconds between it and the epoch.
+     * @return {string} A string representing <code>time</code>
+     *     in the format <code>h:mm:ss</code>,
+     *     where <code>h</code>, <code>mm</code> and <code>ss</code>
+     *     are the hours, minutes, and seconds, respectively,
+     *     since the epoch.
+     *     The minutes and seconds are zero-padded to two places.
+     */
+    formatTime: function (time) {
+        time = Math.floor(time);
+        var seconds = time % 60;
+        time = Math.floor(time / 60);
+        var minutes = time % 60;
+        var hours = Math.floor(time / 60);
+        return hours + ":" + zeroPad(minutes) + ":" + zeroPad(seconds);
     },
 
     /**

--- a/frontend/js/util.js
+++ b/frontend/js/util.js
@@ -35,6 +35,24 @@ function zeroPad(n) {
  */
 var util = {
     /**
+     * Some side effect on a thing.
+     * The return value of this function is not used.
+     * @callback effect
+     * @param o The object to effect
+     */
+
+    /**
+     * Function to execute some side effect on a thing in the context of an expression.
+     * @param o The object to effect
+     * @param {effect} f The side effect to execute
+     * @return <code>o</code>
+     */
+    inspect: function (o, f) {
+        f(o);
+        return o;
+    },
+
+    /**
      * Check whether two closed intervals overlap.
      * Nothe that the <code>start</code> and <code>end</code> properties of the given objects
      * all have to be comparable with one another.

--- a/frontend/js/util.js
+++ b/frontend/js/util.js
@@ -42,6 +42,22 @@ var util = {
     },
 
     /**
+     * @param {number} n
+     * @return {Date} The date <code>n</code> seconds after the epoch
+     */
+    dateFromSeconds: function (n) {
+        return new Date(n * 1000);
+    },
+
+    /**
+     * @param {Date} d
+     * @return {number} The number of seconds between <code>d</code> and the epoch
+     */
+    secondsFromDate: function (d) {
+        return d.getTime() / 1000;
+    },
+
+    /**
      * Tries to parse many different things to a date.
      * @param value A thing hopefully representing a date
      * @return {Date|undefined} <code>value</code> interpreted as a <code>Date</code>

--- a/frontend/js/views/annotate-category.js
+++ b/frontend/js/views/annotate-category.js
@@ -396,7 +396,7 @@ define(["jquery",
                     labelView.remove();
                 });
                 $(window).off(".annotate-category");
-                Backbone.View.prototype.remove.call(this);
+                Backbone.View.prototype.remove.apply(this, arguments);
             }
         });
 

--- a/frontend/js/views/annotate-tab.js
+++ b/frontend/js/views/annotate-tab.js
@@ -579,7 +579,7 @@ define(["jquery",
                 _.each(this.categoryViews, function (categoryView) {
                     categoryView.remove();
                 });
-                Backbone.View.prototype.remove.call(this);
+                Backbone.View.prototype.remove.apply(this, arguments);
             }
         });
 

--- a/frontend/js/views/comment.js
+++ b/frontend/js/views/comment.js
@@ -222,7 +222,7 @@ define(["underscore",
              */
             remove: function () {
                 this.replyContainer.remove();
-                Backbone.View.prototype.remove.call(this);
+                Backbone.View.prototype.remove.apply(this, arguments);
             }
         });
         return CommentView;

--- a/frontend/js/views/comments-container.js
+++ b/frontend/js/views/comments-container.js
@@ -246,7 +246,7 @@ define(["underscore",
                 _.each(this.commentViews, function (commentView) {
                     commentView.remove();
                 });
-                Backbone.View.prototype.remove.call(this);
+                Backbone.View.prototype.remove.apply(this, arguments);
             }
         }, {
             /**

--- a/frontend/js/views/list-annotation.js
+++ b/frontend/js/views/list-annotation.js
@@ -580,7 +580,7 @@ define(["jquery",
              */
             remove: function () {
                 this.commentContainer.remove();
-                Backbone.View.prototype.remove.call(this);
+                Backbone.View.prototype.remove.apply(this, arguments);
             }
         }, {
 

--- a/frontend/js/views/list-annotation.js
+++ b/frontend/js/views/list-annotation.js
@@ -85,7 +85,7 @@ define(["jquery",
 
                 this.model = attr.annotation;
 
-                this.id = this.model.get("id");
+                this.$el.attr("id", this.model.id);
 
                 this.commentContainer = new CommentsContainer({
                     collection: this.model.get("comments")
@@ -390,9 +390,7 @@ define(["jquery",
                 modelJSON.numberOfComments = this.model.get("comments").countCommentsAndReplies();
                 modelJSON.state = this.getState().id;
 
-                this.$el.html($(this.currentState.render(modelJSON)));
-
-                this.$el.attr("id", this.id);
+                this.$el.html(this.currentState.render(modelJSON));
 
                 if (!_.isUndefined(modelJSON.label) && !_.isNull(modelJSON.label)) {
                     title = modelJSON.label.abbreviation + " - " + modelJSON.label.value;

--- a/frontend/js/views/list-annotation.js
+++ b/frontend/js/views/list-annotation.js
@@ -389,6 +389,7 @@ define(["jquery",
 
                 modelJSON.numberOfComments = this.model.get("comments").countCommentsAndReplies();
                 modelJSON.state = this.getState().id;
+                modelJSON.end = modelJSON.start + modelJSON.duration;
 
                 this.$el.html(this.currentState.render(modelJSON));
 

--- a/frontend/js/views/list.js
+++ b/frontend/js/views/list.js
@@ -446,7 +446,7 @@ define(["underscore",
                 _.each(this.annotationViews, function (annotationView) {
                     annotationView.remove();
                 });
-                Backbone.View.prototype.remove.call(this);
+                Backbone.View.prototype.remove.apply(this, arguments);
             }
         });
 

--- a/frontend/js/views/loop.js
+++ b/frontend/js/views/loop.js
@@ -18,6 +18,7 @@
  * @module views-loop
  */
 define([
+    "util",
     "jquery",
     "i18next",
     "player-adapter",
@@ -27,6 +28,7 @@ define([
     "slider",
     "handlebarsHelpers"
 ], function (
+    util,
     $,
     i18next,
     PlayerAdapter,
@@ -164,8 +166,8 @@ var LoopView = Backbone.View.extend({
         function addTimelineItem(loop, isCurrent) {
             var boundaries = loops[loop];
             timeline.addItem("loop-" + loop, {
-                start: timeline.getFormatedDate(boundaries.start),
-                end: timeline.getFormatedDate(boundaries.end),
+                start: util.dateFromSeconds(boundaries.start),
+                end: util.dateFromSeconds(boundaries.end),
                 group: "<div class=\"loop-group\">Loops",
                 content: timelineItemTemplate({
                     current: isCurrent,

--- a/frontend/js/views/main.js
+++ b/frontend/js/views/main.js
@@ -588,10 +588,11 @@ define(["jquery",
              * @alias module:views-main.MainView#handleAnnotationShortcut
              */
             handleAnnotationShortcut: function (event) {
-                if (
+                if ((
                     ["input", "textarea"].includes(event.target.tagName.toLowerCase())
-                        || !event.key.match(/^[1-9]$/)
-                ) {
+                ) || (
+                    !event.key.match(/^[1-9]$/)
+                )) {
                     this.interruptAnnotationShortcut();
                     return;
                 }

--- a/frontend/js/views/main.js
+++ b/frontend/js/views/main.js
@@ -130,8 +130,6 @@ define(["jquery",
 
                 annotationTool.scaleEditor = new ScaleEditorView();
 
-                this.listenTo(annotationTool, "deleteAnnotation", annotationTool.deleteAnnotation);
-
                 $(window).on("keydown", _.bind(this.onDeletePressed, this));
 
                 this.once(MainView.EVENTS.READY, function () {
@@ -799,35 +797,13 @@ define(["jquery",
                     event.preventDefault();
 
                     annotation = annotationTool.getSelection()[0];
+                    console.log(annotation.trackId);
                     if (annotation) {
-                        annotationTool.trigger("deleteAnnotation", annotation.get("id"), annotation.trackId);
+                        annotationTool.deleteOperation.start(
+                            annotation,
+                            annotationTool.deleteOperation.targetTypes.ANNOTATION
+                        );
                     }
-                }
-            },
-
-            /**
-             * Delete the annotation with the given id with the track with the given track id
-             * @alias module:views-main.MainView#deleteAnnotation
-             * @param {integer} annotationId The id of the annotation to delete
-             * @param {integer} trackId Id of the track containing the annotation
-             */
-            deleteAnnotation: function (annotationId, trackId) {
-                var annotation;
-
-                if (typeof trackId === "undefined") {
-                    annotationTool.video.get("tracks").each(function (track) {
-                        if (track.get("annotations").get(annotationId)) {
-                            trackId = track.get("id");
-                        }
-                    });
-                }
-
-                annotation = annotationTool.video.getAnnotation(annotationId, trackId);
-
-                if (annotation) {
-                    annotationTool.deleteOperation.start(annotation, annotationTool.deleteOperation.targetTypes.ANNOTATION);
-                } else {
-                    console.warn("Not able to find annotation %i on track %i", annotationId, trackId);
                 }
             },
 

--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -176,7 +176,7 @@ define([
         /**
          * Items from external sources.
          * @see module:views-loop
-         * @alias module:views-timeline.TimelineView#trackItems
+         * @alias module:views-timeline.TimelineView#extraItems
          * @type {map}
          */
         extraItems: {},
@@ -363,7 +363,7 @@ define([
         /**
          * Search for the group/track with the given name in the timeline
          * @alias module:views-timeline.TimelineView#findGroup
-         * @param {Annotation} groupName the name of the group/track to search
+         * @param {string} groupName the name of the group/track to search
          * @return {Object} The search group/track as timeline-group if found, or undefined
          */
         findGroup: function (groupName) {

--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -453,7 +453,7 @@ define([
          * @alias module:views-timeline.TimelineView#changeTitleFromCustomPlayhead
          */
         changeTitleFromCustomPlayhead: function () {
-            this.$el.find(".timeline-customtime").attr("title", annotationTool.getWellFormatedTime(this.playerAdapter.getCurrentTime()));
+            this.$el.find(".timeline-customtime").attr("title", util.formatTime(this.playerAdapter.getCurrentTime()));
         },
 
         /**
@@ -1156,7 +1156,7 @@ define([
 
             this.timeline.setCustomTime(newDate);
 
-            this.$el.find("span.time").html(annotationTool.getWellFormatedTime(currentTime, true));
+            this.$el.find("span.time").html(util.formatTime(currentTime));
 
             this.moveToCurrentTime();
         },

--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -1085,7 +1085,16 @@ define([
                                 trackId: trackId,
                                 itemContent: PlaceholderTmpl({
                                     track: trackId,
-                                    hiddenItems: spilledStack.items
+                                    hiddenItems: _.map(
+                                        spilledStack.items,
+                                        function (item) {
+                                            var annotation = item.annotation.attributes;
+                                            return _.extend({}, item, {
+                                                start: annotation.start,
+                                                end: annotation.duration && annotation.start + annotation.duration
+                                            });
+                                        }
+                                    )
                                 }),
                                 className: this.PREFIX_STACKING_CLASS + 2,
                                 editable: false

--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -235,7 +235,7 @@ define([
             this.endDate = util.dateFromSeconds(this.playerAdapter.getDuration());
 
             // Options for the links timeline
-            this.options = {
+            var options = {
                 width            : "100%",
                 height           : "auto",
                 style            : "box",
@@ -270,7 +270,7 @@ define([
             this.$timeline = this.$el.find("#timeline");
             this.timeline = new links.Timeline(this.$timeline[0]);
             // Draw the timeline initially, so that it's HTML elements are available for attaching listeners, etc.
-            this.timeline.draw([], this.options);
+            this.timeline.draw([], options);
 
             // Ensure that the timeline is redraw on window resize
             $(window).resize(this.onWindowResize);

--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -17,1700 +17,1711 @@
  * A module representing the timeline view
  * @module views-timeline
  */
-define(["util",
-        "jquery",
-        "underscore",
-        "i18next",
-        "player-adapter",
-        "models/track",
-        "templates/timeline",
-        "templates/timeline-group",
-        "templates/timeline-item",
-        "templates/timeline-placeholder",
-        "templates/timeline-modal-group",
-        "access",
-        "backbone",
-        "timeline",
-        "bootstrap",
-        "handlebarsHelpers"
-    ],
+define([
+    "util",
+    "jquery",
+    "underscore",
+    "i18next",
+    "player-adapter",
+    "models/track",
+    "templates/timeline",
+    "templates/timeline-group",
+    "templates/timeline-item",
+    "templates/timeline-placeholder",
+    "templates/timeline-modal-group",
+    "access",
+    "backbone",
+    "timeline",
+    "bootstrap",
+    "handlebarsHelpers"
+], function (
+    util,
+    $,
+    _,
+    i18next,
+    PlayerAdapter,
+    Track,
+    template,
+    GroupTmpl,
+    ItemTmpl,
+    PlaceholderTmpl,
+    ModalGroupTmpl,
+    ACCESS,
+    Backbone,
+    links
+) {
+    "use strict";
 
-       function (util, $, _, i18next, PlayerAdapter, Track, template, GroupTmpl,
-            ItemTmpl, PlaceholderTmpl, ModalGroupTmpl, ACCESS, Backbone, links) {
+    function normalizeAccess(access) {
+        return ACCESS[access.replace(/-/g, "_").toUpperCase()];
+    }
 
-        "use strict";
+    function accessIdentifier(access) {
+        return _.findKey(ACCESS, function (value) {
+            return value === access;
+        }).replace(/_/g, "-").toLowerCase();
+    }
 
-        function normalizeAccess(access) {
-            return ACCESS[access.replace(/-/g, "_").toUpperCase()];
-        }
-
-        function accessIdentifier(access) {
-            return _.findKey(ACCESS, function (value) {
-                return value === access;
-            }).replace(/_/g, "-").toLowerCase();
-        }
+    /**
+     * @constructor
+     * @see {@link http://www.backbonejs.org/#View}
+     * @augments module:Backbone.View
+     * @memberOf module:views-timeline
+     * @alias module:views-timeline.TimelineView
+     */
+    var Timeline = Backbone.View.extend({
+        /**
+         * Group template
+         * @alias module:views-timeline.TimelineView#groupTemplate
+         * @type {HandlebarsTemplate}
+         */
+        groupTemplate: GroupTmpl,
 
         /**
-         * @constructor
-         * @see {@link http://www.backbonejs.org/#View}
-         * @augments module:Backbone.View
-         * @memberOf module:views-timeline
-         * @alias module:views-timeline.TimelineView
+         * Item template
+         * @alias module:views-timeline.TimelineView#itemTemplate
+         * @type {HandlebarsTemplate}
          */
-        var Timeline = Backbone.View.extend({
-            /**
-             * Group template
-             * @alias module:views-timeline.TimelineView#groupTemplate
-             * @type {HandlebarsTemplate}
-             */
-            groupTemplate: GroupTmpl,
+        itemTemplate: ItemTmpl,
 
-            /**
-             * Item template
-             * @alias module:views-timeline.TimelineView#itemTemplate
-             * @type {HandlebarsTemplate}
-             */
-            itemTemplate: ItemTmpl,
+        /**
+         * Modal template for groups
+         * @alias module:views-timeline.TimelineView#modalGroupTemplate
+         * @type {HandlebarsTemplate}
+         */
+        modalGroupTemplate: ModalGroupTmpl,
 
-            /**
-             * Modal template for groups
-             * @alias module:views-timeline.TimelineView#modalGroupTemplate
-             * @type {HandlebarsTemplate}
-             */
-            modalGroupTemplate: ModalGroupTmpl,
+        /**
+         * Events to handle by the timeline view
+         * @alias module:views-timeline.TimelineView#event
+         * @type {map}
+         */
+        events: {
+            "click #add-track": "initTrackModal",
+            "click .timeline-group": "onSelectTrack",
+            "dblclick .timeline-group": "onUpdateTrack",
+            "click .update": "onUpdateTrack",
+            "click .delete": "onDeleteTrack",
+            "click .visibility": "onChangeTrackVisibility",
+            "click #reset-zoom": "onTimelineResetZoom",
+            "click #zoom-in": "zoomIn",
+            "click #zoom-out": "zoomOut",
+            "click #move-right": "moveRight",
+            "click #move-left": "moveLeft",
+            "click .toggle-expansion": "toggleTrackExpansion",
+            "click .timeline-placeholder": "expandTrack",
+            "click .timeline-item.selectable": "selectAnnotation"
+        },
 
-            /**
-             * Events to handle by the timeline view
-             * @alias module:views-timeline.TimelineView#event
-             * @type {map}
-             */
-            events: {
-                "click #add-track": "initTrackModal",
-                "click .timeline-group": "onSelectTrack",
-                "dblclick .timeline-group": "onUpdateTrack",
-                "click .update": "onUpdateTrack",
-                "click .delete": "onDeleteTrack",
-                "click .visibility": "onChangeTrackVisibility",
-                "click #reset-zoom": "onTimelineResetZoom",
-                "click #zoom-in": "zoomIn",
-                "click #zoom-out": "zoomOut",
-                "click #move-right": "moveRight",
-                "click #move-left": "moveLeft",
-                "click .toggle-expansion": "toggleTrackExpansion",
-                "click .timeline-placeholder": "expandTrack",
-                "click .timeline-item.selectable": "selectAnnotation"
-            },
+        /**
+         * Template for void item content
+         * @alias module:views-timeline.TimelineView#VOID_ITEM_TMPL
+         * @type {string}
+         * @constant
+         */
+        VOID_ITEM_TMPL: "<div style=\"display:none\"></div>",
 
-            /**
-             * Template for void item content
-             * @alias module:views-timeline.TimelineView#VOID_ITEM_TMPL
-             * @type {string}
-             * @constant
-             */
-            VOID_ITEM_TMPL: "<div style=\"display:none\"></div>",
+        /**
+         * Void track paramters
+         * @alias module:views-timeline.TimelineView#VOID_TRACK
+         * @type {Object}
+         * @constant
+         */
+        VOID_TRACK: {
+            isMine: true,
+            id: "empty-timeline",
+            name: i18next.t("timeline.no track available.short"),
+            description: i18next.t("timeline.no track available.long"),
+            empty: true
+        },
 
-            /**
-             * Void track paramters
-             * @alias module:views-timeline.TimelineView#VOID_TRACK
-             * @type {Object}
-             * @constant
-             */
-            VOID_TRACK: {
-                isMine      : true,
-                id          : "empty-timeline",
-                name        : i18next.t("timeline.no track available.short"),
-                description : i18next.t("timeline.no track available.long"),
-                empty       : true
-            },
+        /**
+         * Default duration for annotation
+         * @alias module:views-timeline.TimelineView#DEFAULT_DURATION
+         * @type {Integer}
+         * @constant
+         */
+        DEFAULT_DURATION: 1,
 
-            /**
-             * Default duration for annotation
-             * @alias module:views-timeline.TimelineView#DEFAULT_DURATION
-             * @type {Integer}
-             * @constant
-             */
-            DEFAULT_DURATION: 1,
+        /**
+         * Class prefix for stack level
+         * @alias module:views-timeline.TimelineView#PREFIX_STACKING_CLASS
+         * @type {string}
+         * @constant
+         */
+        PREFIX_STACKING_CLASS: "stack-level-",
 
-            /**
-             * Class prefix for stack level
-             * @alias module:views-timeline.TimelineView#PREFIX_STACKING_CLASS
-             * @type {string}
-             * @constant
-             */
-            PREFIX_STACKING_CLASS: "stack-level-",
+        /**
+         * Class for item selected on timeline
+         * @alias module:views-timeline.TimelineView#ITEM_SELECTED_CLASS
+         * @type {string}
+         * @constant
+         */
+        ITEM_SELECTED_CLASS: "timeline-event-selected",
 
-            /**
-             * Class for item selected on timeline
-             * @alias module:views-timeline.TimelineView#ITEM_SELECTED_CLASS
-             * @type {string}
-             * @constant
-             */
-            ITEM_SELECTED_CLASS: "timeline-event-selected",
+        /**
+         * Map containing all the items
+         * @alias module:views-timeline.TimelineView#annotationItems
+         * @type {map}
+         */
+        annotationItems: {},
 
-            /**
-             * Map containing all the items
-             * @alias module:views-timeline.TimelineView#annotationItems
-             * @type {map}
-             */
-            annotationItems: {},
+        /**
+         * Placeholder items to keep tracks visible even when there is no annotation item in them
+         * @alias module:views-timeline.TimelineView#trackItems
+         * @type {map}
+         */
+        trackItems: {},
 
-            /**
-             * Placeholder items to keep tracks visible even when there is no annotation item in them
-             * @alias module:views-timeline.TimelineView#trackItems
-             * @type {map}
-             */
-            trackItems: {},
+        /**
+         * Items from external sources.
+         * @see module:views-loop
+         * @alias module:views-timeline.TimelineView#trackItems
+         * @type {map}
+         */
+        extraItems: {},
 
-            /**
-             * Items from external sources.
-             * @see module:views-loop
-             * @alias module:views-timeline.TimelineView#trackItems
-             * @type {map}
-             */
-            extraItems: {},
+        /**
+         * Cache for the timeline items after some preprocessing indexed by track id
+         * @alias module:views-timeline.TimelineView#preprocessedItems
+         * @type {map}
+         * @see preprocessTrack
+         */
+        preprocessedItems: {},
 
-            /**
-             * Cache for the timeline items after some preprocessing indexed by track id
-             * @alias module:views-timeline.TimelineView#preprocessedItems
-             * @type {map}
-             * @see preprocessTrack
-             */
-            preprocessedItems: {},
+        /**
+         * Array containing only the items displayed in the timeline
+         * @alias module:views-timeline.TimelineView#filteredItems
+         * @type {array}
+         */
+        filteredItems: [],
 
-            /**
-             * Array containing only the items displayed in the timeline
-             * @alias module:views-timeline.TimelineView#filteredItems
-             * @type {array}
-             */
-            filteredItems: [],
+        /**
+         * Set of currently expanded tracks, i.e. tracks that show all their items without preprocessing.
+         * @alias module:views-timeline.TimelineView#trackExpanded
+         * @type {object}
+         * @see preprocessTrack
+         */
+        trackExpanded: {},
 
-            /**
-             * Set of currently expanded tracks, i.e. tracks that show all their items without preprocessing.
-             * @alias module:views-timeline.TimelineView#trackExpanded
-             * @type {object}
-             * @see preprocessTrack
-             */
-            trackExpanded: {},
+        /**
+         * Constructor
+         * @alias module:views-timeline.TimelineView#initialize
+         * @param {PlainObject} attr Object literal containing the view initialization attributes.
+         */
+        initialize: function (attr) {
+            _.bindAll(this,
+                      "addTrack",
+                      "addTracksList",
+                      "createTrack",
+                      "changeTitleFromCustomPlayhead",
+                      "onDeleteTrack",
+                      "markTrackSelected",
+                      "onSelectionUpdate",
+                      "onPlayerTimeUpdate",
+                      "onTimelineMoved",
+                      "onTimelineItemChanged",
+                      "onTimelineItemDeleted",
+                      "isAnnotationSelectedonTimeline",
+                      "onTimelineItemAdded",
+                      "onAnnotationDestroyed",
+                      "generateVoidItem",
+                      "generateItem",
+                      "changeItem",
+                      "changeTrack",
+                      "getFormatedDate",
+                      "getSelectedItemAndAnnotation",
+                      "getTrack",
+                      "onWindowResize",
+                      "onTimelineResetZoom",
+                      "initTrackModal",
+                      "updateDraggingCtrl",
+                      "moveToCurrentTime",
+                      "moveRight",
+                      "moveLeft",
+                      "zoomIn",
+                      "zoomOut",
+                      "timerangeChange",
+                      "repaintCustomTime",
+                      "redraw",
+                      "updateHeader");
 
-            /**
-             * Constructor
-             * @alias module:views-timeline.TimelineView#initialize
-             * @param {PlainObject} attr Object literal containing the view initialization attributes.
-             */
-            initialize: function (attr) {
-                _.bindAll(this,
-                    "addTrack",
-                    "addTracksList",
-                    "createTrack",
-                    "changeTitleFromCustomPlayhead",
-                    "onDeleteTrack",
-                    "markTrackSelected",
-                    "onSelectionUpdate",
-                    "onPlayerTimeUpdate",
-                    "onTimelineMoved",
-                    "onTimelineItemChanged",
-                    "onTimelineItemDeleted",
-                    "isAnnotationSelectedonTimeline",
-                    "onTimelineItemAdded",
-                    "onAnnotationDestroyed",
-                    "generateVoidItem",
-                    "generateItem",
-                    "changeItem",
-                    "changeTrack",
-                    "getFormatedDate",
-                    "getSelectedItemAndAnnotation",
-                    "getTrack",
-                    "onWindowResize",
-                    "onTimelineResetZoom",
-                    "initTrackModal",
-                    "updateDraggingCtrl",
-                    "moveToCurrentTime",
-                    "moveRight",
-                    "moveLeft",
-                    "zoomIn",
-                    "zoomOut",
-                    "timerangeChange",
-                    "repaintCustomTime",
-                    "redraw",
-                    "updateHeader");
+            this.playerAdapter = attr.playerAdapter;
 
-                this.playerAdapter = attr.playerAdapter;
+            this.$el.html(template());
 
-                this.$el.html(template());
+            // Type use for delete operation
+            this.typeForDeleteAnnotation = annotationTool.deleteOperation.targetTypes.ANNOTATION;
+            this.typeForDeleteTrack = annotationTool.deleteOperation.targetTypes.TRACK;
 
-                // Type use for delete operation
-                this.typeForDeleteAnnotation = annotationTool.deleteOperation.targetTypes.ANNOTATION;
-                this.typeForDeleteTrack = annotationTool.deleteOperation.targetTypes.TRACK;
+            this.startDate = this.getFormatedDate(0);
+            this.endDate = this.getFormatedDate(this.playerAdapter.getDuration());
 
-                this.startDate = this.getFormatedDate(0);
-                this.endDate = this.getFormatedDate(this.playerAdapter.getDuration());
+            // Options for the links timeline
+            this.options = {
+                width            : "100%",
+                height           : "auto",
+                style            : "box",
+                //scale          : links.Timeline.StepDate.SCALE.SECOND,
+                //step           : 30,
+                showButtonNew    : false,
+                editable         : true,
+                start            : this.startDate,
+                end              : this.endDate,
+                min              : this.startDate,
+                max              : this.endDate,
+                intervalMin      : 5000,
+                showCustomTime   : true,
+                showNavigation   : false,
+                showMajorLabels  : false,
+                snapEvents       : false,
+                stackEvents      : true,
+                axisOnTop        : true,
+                groupsWidth      : "150px",
+                animate          : true,
+                animateZoom      : true,
+                // cluster       : true,
+                eventMarginAxis  : 0,
+                eventMargin      : 0,
+                dragAreaWidth    : 5,
+                groupsChangeable : true
+            };
 
-                // Options for the links timeline
-                this.options = {
-                    width            : "100%",
-                    height           : "auto",
-                    style            : "box",
-                    //scale          : links.Timeline.StepDate.SCALE.SECOND,
-                    //step           : 30,
-                    showButtonNew    : false,
-                    editable         : true,
-                    start            : this.startDate,
-                    end              : this.endDate,
-                    min              : this.startDate,
-                    max              : this.endDate,
-                    intervalMin      : 5000,
-                    showCustomTime   : true,
-                    showNavigation   : false,
-                    showMajorLabels  : false,
-                    snapEvents       : false,
-                    stackEvents      : true,
-                    axisOnTop        : true,
-                    groupsWidth      : "150px",
-                    animate          : true,
-                    animateZoom      : true,
-                    // cluster       : true,
-                    eventMarginAxis  : 0,
-                    eventMargin      : 0,
-                    dragAreaWidth    : 5,
-                    groupsChangeable : true
-                };
+            this.groupModals = {};
 
-                this.groupModals = {};
+            this.$navbar = this.$el.find(".navbar");
 
-                this.$navbar = this.$el.find(".navbar");
+            // Create the timeline
+            this.$timeline = this.$el.find("#timeline");
+            this.timeline = new links.Timeline(this.$timeline[0]);
+            // Draw the timeline initially, so that it's HTML elements are available for attaching listeners, etc.
+            this.timeline.draw([], this.options);
 
-                // Create the timeline
-                this.$timeline = this.$el.find("#timeline");
-                this.timeline = new links.Timeline(this.$timeline[0]);
-                // Draw the timeline initially, so that it's HTML elements are available for attaching listeners, etc.
-                this.timeline.draw([], this.options);
+            // Ensure that the timeline is redraw on window resize
+            $(window).resize(this.onWindowResize);
 
-                // Ensure that the timeline is redraw on window resize
-                $(window).resize(this.onWindowResize);
+            annotationTool.addTimeupdateListener(this.onPlayerTimeUpdate, 1);
 
-                annotationTool.addTimeupdateListener(this.onPlayerTimeUpdate, 1);
-
-                this.$el.find(".timeline-frame > div:first-child").on("click", function (event) {
-                    if ($(event.target).find(".timeline-event").length > 0) {
-                        annotationTool.setSelection([]);
-                    }
-                });
-
-                links.events.addListener(this.timeline, "timechanged", this.onTimelineMoved);
-                links.events.addListener(this.timeline, "timechange", this.onTimelineMoved);
-                links.events.addListener(this.timeline, "change", this.onTimelineItemChanged);
-                links.events.addListener(this.timeline, "delete", this.onTimelineItemDeleted);
-                links.events.addListener(this.timeline, "add", this.onTimelineItemAdded);
-                links.events.addListener(this.timeline, "rangechange", this.timerangeChange);
-
-                this.tracks = annotationTool.video.get("tracks");
-                this.listenTo(this.tracks, "select", this.markTrackSelected);
-                this.listenTo(this.tracks, "visibility", this.addTracksList);
-                this.listenTo(this.tracks, "change", this.changeTrack);
-                this.listenTo(annotationTool, annotationTool.EVENTS.ANNOTATION_SELECTION, this.onSelectionUpdate);
-
-                this.listenTo(annotationTool.video.get("categories"), "change:visible", this.update);
-                this.listenTo(annotationTool, "togglefreetext", this.update);
-
-                this.addTracksList(this.tracks.getVisibleTracks());
-                this.timeline.setCustomTime(this.startDate);
-
-                // Overwrite the redraw method
-                this.timeline.repaintCustomTime = this.repaintCustomTime;
-                this.timeline.redraw = this.redraw;
-
-                // Add findGroup method to the timeline if missing
-                if (!this.timeline.findGroup) {
-                    this.timeline.findGroup = this.findGroup;
-                    _.bindAll(this.timeline, "findGroup");
+            this.$el.find(".timeline-frame > div:first-child").on("click", function (event) {
+                if ($(event.target).find(".timeline-event").length > 0) {
+                    annotationTool.setSelection([]);
                 }
+            });
 
-                this.$el.find(".timeline-frame > div")[0].addEventListener("mousewheel", function (event) {
-                    event.stopPropagation();
-                }, true);
+            links.events.addListener(this.timeline, "timechanged", this.onTimelineMoved);
+            links.events.addListener(this.timeline, "timechange", this.onTimelineMoved);
+            links.events.addListener(this.timeline, "change", this.onTimelineItemChanged);
+            links.events.addListener(this.timeline, "delete", this.onTimelineItemDeleted);
+            links.events.addListener(this.timeline, "add", this.onTimelineItemAdded);
+            links.events.addListener(this.timeline, "rangechange", this.timerangeChange);
 
-                this.listenTo(annotationTool, "order", this.update);
+            this.tracks = annotationTool.video.get("tracks");
+            this.listenTo(this.tracks, "select", this.markTrackSelected);
+            this.listenTo(this.tracks, "visibility", this.addTracksList);
+            this.listenTo(this.tracks, "change", this.changeTrack);
+            this.listenTo(annotationTool, annotationTool.EVENTS.ANNOTATION_SELECTION, this.onSelectionUpdate);
 
-                this.timerangeChange();
-                this.$timeline.scroll(this.updateHeader);
-                this.onPlayerTimeUpdate();
-            },
+            this.listenTo(annotationTool.video.get("categories"), "change:visible", this.update);
+            this.listenTo(annotationTool, "togglefreetext", this.update);
 
-            /**
-             * Update the timeline view.
-             * This recalculates the grouping and stacking for all tracks
-             * and then redraws everything. Call this if something affecting
-             * the visibility/existence of annotations in every track.
-             * @alias module:views-timeline.TimelineView#update
-             */
-            update: function () {
-                this.preprocessAllTracks();
-                this.redraw();
-            },
+            this.addTracksList(this.tracks.getVisibleTracks());
+            this.timeline.setCustomTime(this.startDate);
 
-            /**
-             * Search for the group/track with the given name in the timeline
-             * @alias module:views-timeline.TimelineView#findGroup
-             * @param {Annotation} groupName the name of the group/track to search
-             * @return {Object} The search group/track as timeline-group if found, or undefined
-             */
-            findGroup: function (groupName) {
-                return _.find(this.groups, function (group) {
-                    return $(group.content).find("div.content").text().toUpperCase() === groupName.toUpperCase();
-                });
-            },
+            // Overwrite the redraw method
+            this.timeline.repaintCustomTime = this.repaintCustomTime;
+            this.timeline.redraw = this.redraw;
 
-            /**
-             * Add an annotation to the timeline
-             * @alias module:views-timeline.TimelineView#redraw
-             */
-            redraw: function () {
-                var timedItems = _.chain(this.preprocessedItems)
-                    .values()
-                    .flatten()
-                    .value()
-                    .concat(_.values(this.extraItems));
+            // Add findGroup method to the timeline if missing
+            if (!this.timeline.findGroup) {
+                this.timeline.findGroup = this.findGroup;
+                _.bindAll(this.timeline, "findGroup");
+            }
 
-                var visibleRange = this.timeline.getVisibleChartRange();
-                var startTime = visibleRange.start;
-                var endTime = visibleRange.end;
-                var filteredItems = _.filter(timedItems, function (item) {
-                    return startTime <= item.end && item.start <= endTime;
-                });
+            this.$el.find(".timeline-frame > div")[0].addEventListener("mousewheel", function (event) {
+                event.stopPropagation();
+            }, true);
 
-                if (_.keys(this.trackItems).length === 0) {
-                    filteredItems = [{
-                        trackId: this.VOID_TRACK.id,
-                        isMine: this.VOID_TRACK.isMine,
-                        isPublic: true,
-                        start: this.startDate - 5000,
-                        end: this.startDate - 4500,
-                        content: this.VOID_ITEM_TMPL,
-                        group: this.groupTemplate(this.VOID_TRACK)
-                    }];
-                }
+            this.listenTo(annotationTool, "order", this.update);
 
-                // We save the actually displayed items here to access them later, for example in `onSelectionUpdate`
-                this.filteredItems = filteredItems.concat(_.values(this.trackItems));
+            this.timerangeChange();
+            this.$timeline.scroll(this.updateHeader);
+            this.onPlayerTimeUpdate();
+        },
 
-                this.$el.find("[data-toggle='popover']").popover("destroy");
-                this.$el.find("[data-toggle='tooltip']").tooltip("destroy");
+        /**
+         * Update the timeline view.
+         * This recalculates the grouping and stacking for all tracks
+         * and then redraws everything. Call this if something affecting
+         * the visibility/existence of annotations in every track.
+         * @alias module:views-timeline.TimelineView#update
+         */
+        update: function () {
+            this.preprocessAllTracks();
+            this.redraw();
+        },
 
-                this.timeline.draw(this.filteredItems);
+        /**
+         * Search for the group/track with the given name in the timeline
+         * @alias module:views-timeline.TimelineView#findGroup
+         * @param {Annotation} groupName the name of the group/track to search
+         * @return {Object} The search group/track as timeline-group if found, or undefined
+         */
+        findGroup: function (groupName) {
+            return _.find(this.groups, function (group) {
+                return $(group.content).find("div.content").text().toUpperCase() === groupName.toUpperCase();
+            });
+        },
 
-                this.$el.find("[data-toggle='popover']").popover({ container: "body", html: true });
-                this.$el.find("[data-toggle='tooltip']").tooltip({ html: true });
+        /**
+         * Add an annotation to the timeline
+         * @alias module:views-timeline.TimelineView#redraw
+         */
+        redraw: function () {
+            var timedItems = _.chain(this.preprocessedItems)
+                .values()
+                .flatten()
+                .value()
+                .concat(_.values(this.extraItems));
 
-                // Restore the selections and co.
-                if (annotationTool.hasSelection()) {
-                    this.onSelectionUpdate(annotationTool.getSelection());
-                    this.updateDraggingCtrl();
-                }
-                this.markTrackSelected(annotationTool.selectedTrack);
+            var visibleRange = this.timeline.getVisibleChartRange();
+            var startTime = visibleRange.start;
+            var endTime = visibleRange.end;
+            var filteredItems = _.filter(timedItems, function (item) {
+                return startTime <= item.end && item.start <= endTime;
+            });
 
-                this.$el.find(".timeline-groups-text").width(this.$el.width());
-            },
-
-            /**
-             * Update the timerange filter with the timerange
-             * @alias module:views-timeline.TimelineView#timerangeChange
-             */
-            timerangeChange: function () {
-                this.redraw();
-            },
-
-            /**
-             * Update the position of the timeline header on scroll
-             * @alias module:views-timeline.TimelineView#updateHeader
-             */
-            updateHeader: function () {
-                var self = this;
-
-                $("div.timeline-frame > div:first-child > div:first-child").css({
-                    "margin-top": self.$timeline.scrollTop() - 2
-                });
-            },
-
-            /**
-             * Repaint the custom playhead
-             * @alias module:views-timeline.TimelineView#repaintCustomTime
-             */
-            repaintCustomTime: function () {
-                links.Timeline.prototype.repaintCustomTime.call(this.timeline);
-                this.changeTitleFromCustomPlayhead();
-            },
-
-            /**
-             * Change the title from the custome Playhead with a better time format
-             * @alias module:views-timeline.TimelineView#changeTitleFromCustomPlayhead
-             */
-            changeTitleFromCustomPlayhead: function () {
-                this.$el.find(".timeline-customtime").attr("title", annotationTool.getWellFormatedTime(this.playerAdapter.getCurrentTime()));
-            },
-
-            /**
-             * Move the current range to the left
-             * @alias module:views-timeline.TimelineView#moveLeft
-             * @param  {Event} event Event object
-             */
-            moveLeft: function (event) {
-                links.Timeline.preventDefault(event);
-                links.Timeline.stopPropagation(event);
-                this.timeline.move(-0.2);
-                this.timeline.trigger("rangechange");
-                this.timeline.trigger("rangechanged");
-            },
-
-            /**
-             * [moveRight description]
-             * @alias module:views-timeline.TimelineView#Right
-             * @param  {Event} event Event object
-             */
-            moveRight: function (event) {
-                links.Timeline.preventDefault(event);
-                links.Timeline.stopPropagation(event);
-                this.timeline.move(0.2);
-                this.timeline.trigger("rangechange");
-                this.timeline.trigger("rangechanged");
-            },
-
-            /**
-             * Move the current position of the player
-             * @alias module:views-timeline.TimelineView#moveToCurrentTime
-             */
-            moveToCurrentTime: function () {
-                var currentChartRange = this.timeline.getVisibleChartRange(),
-                    start             = this.getTimeInSeconds(currentChartRange.start),
-                    end               = this.getTimeInSeconds(currentChartRange.end),
-                    size              = end - start,
-                    currentTime       = this.playerAdapter.getCurrentTime(),
-                    videoDuration     = this.playerAdapter.getDuration(),
-                    marge             = size / 20,
-                    startInSecond;
-
-                if (annotationTool.timelineFollowPlayhead) {
-                    if ((currentTime - size / 2) < 0) {
-                        start = this.getFormatedDate(0);
-                        end = this.getFormatedDate(size);
-                    } else if ((currentTime + size / 2) > videoDuration) {
-                        start = this.getFormatedDate(videoDuration - size);
-                        end = this.getFormatedDate(videoDuration);
-                    } else {
-                        start = this.getFormatedDate(currentTime - size / 2);
-                        end = this.getFormatedDate(currentTime + size / 2);
-                    }
-                } else {
-                    if (((currentTime + marge) >= end && end != videoDuration) || (currentTime > end || currentTime < start)) {
-                        startInSecond = Math.max(currentTime - marge, 0);
-                        start = this.getFormatedDate(startInSecond);
-                        end = this.getFormatedDate(Math.min(startInSecond + size, videoDuration));
-                    } else {
-                        start = this.getFormatedDate(start);
-                        end = this.getFormatedDate(end);
-                    }
-                }
-
-
-
-                if (currentChartRange.start.getTime() != start.getTime() || currentChartRange.end.getTime() !== end.getTime()) {
-                    this.timeline.setVisibleChartRange(start, end);
-                }
-            },
-
-            /**
-             * Zoom in
-             * @alias module:views-timeline.TimelineView#zoomIn
-             * @param  {Event} event Event object
-             */
-            zoomIn: function (event) {
-                links.Timeline.preventDefault(event);
-                links.Timeline.stopPropagation(event);
-                this.timeline.zoom(0.4, this.timeline.getCustomTime());
-                this.timeline.trigger("rangechange");
-                this.timeline.trigger("rangechanged");
-            },
-
-            /**
-             * Zoom out
-             * @alias module:views-timeline.TimelineView#zoomOut
-             * @param  {Event} event Event object
-             */
-            zoomOut: function (event) {
-                links.Timeline.preventDefault(event);
-                links.Timeline.stopPropagation(event);
-                this.timeline.zoom(-0.4, this.timeline.getCustomTime());
-                this.timeline.trigger("rangechange");
-                this.timeline.trigger("rangechanged");
-            },
-
-            /**
-             * Add a new item to the timeline
-             * @param {string}  id           The id of the item
-             * @param {object}  item         The object representing the item
-             * @alias module:views-timeline.TimelineView#addItem
-             */
-            addItem: function (id, item) {
-                item.group = "<!-- extra -->" + item.group;
-                this.extraItems[id] = item;
-            },
-
-            /**
-             * Remove the timeline item with the given id
-             * @param  {string} id The id of the item to remove
-             * @alias module:views-timeline.TimelineView#removeItem
-             */
-            removeItem: function (id) {
-                delete this.extraItems[id];
-            },
-
-            /**
-             * Add an annotation to the timeline
-             * @alias module:views-timeline.TimelineView#addAnnotation
-             * @param {Annotation} annotation the annotation to add.
-             * @param {Track} track  the track where the annotation must be added
-             * @param {Boolean} [isList]  define if the insertion is part of a list, Default is false
-             */
-            addAnnotation: function (annotation, track, isList) {
-                // Wait that the id has be set to the model before to add it
-                if (_.isUndefined(annotation.get("id"))) {
-                    annotation.once("ready", function () {
-                        this.addAnnotation(annotation, track, isList);
-                    }, this);
-                    return;
-                }
-
-                if (annotation.get("oldId") && this.ignoreAdd === annotation.get("oldId")) {
-                    delete this.ignoreAdd;
-                    return;
-                }
-
-                this.annotationItems[annotation.id] = this.generateItem(annotation, track);
-
-                if (!isList) {
-                    this.preprocessTrack(track.id);
-                    this.redraw();
-                    this.onPlayerTimeUpdate();
-                }
-
-                annotation.on("destroy", this.onAnnotationDestroyed, this);
-            },
-
-            /**
-             * Add a track to the timeline
-             * @alias module:views-timeline.TimelineView#addTrack
-             * @param {Track} track The track to add to the timline
-             */
-            addTrack: function (track) {
-                var annotations,
-                    proxyToAddAnnotation = function (annotation) {
-                        this.addAnnotation(annotation, track, false);
-                    },
-                    annotationWithList = function (annotation) {
-                        this.addAnnotation(annotation, track, true);
-                    };
-
-                // If track has not id, we save it to have an id
-                if (!track.id) {
-                    track.on("ready", this.addTrack, this);
-                    return;
-                }
-
-                // Add void item
-                this.trackItems[track.id] = this.generateVoidItem(track);
-
-                annotations = track.get("annotations");
-                annotations.each(annotationWithList, this);
-                annotations.on("add", proxyToAddAnnotation, this);
-                annotations.on("change", this.changeItem, this);
-
-                this.preprocessTrack(track.id);
-                this.redraw();
-            },
-
-            /**
-             * Add a list of tracks, creating a view for each of them
-             * @alias module:views-timeline.TimelineView#addTracksList
-             * @param {Array | List} tracks The list of tracks to add
-             */
-            addTracksList: function (tracks) {
-                this.trackItems = {};
-                this.annotationItems = {};
-                this.preprocessedItems = {};
-                if (tracks.length === 0) {
-                    //this.preprocessAllTracks();
-                    this.redraw();
-                } else {
-                    _.each(tracks, this.addTrack, this);
-                }
-            },
-
-            /**
-             * Render the timeline group header for a track.
-             * @alias module:views-timeline.TimelineView#renderTrack
-             * @param {Track} track The track to render
-             * @return {String} The rendered track group header
-             */
-            renderTrack: function (track) {
-                var trackAttributes = _.clone(track.attributes);
-                trackAttributes.expanded = this.trackExpanded[track.id];
-                if (trackAttributes.access || trackAttributes.access === 0) {
-                    trackAttributes.access = accessIdentifier(trackAttributes.access);
-                }
-                return this.groupTemplate(trackAttributes);
-            },
-
-            /**
-             * Get a void timeline item for the given track
-             * @alias module:views-timeline.TimelineView#generateVoidItem
-             * @param {Track} track Given track owning the void item
-             * @return {Object} the generated timeline item
-             */
-            generateVoidItem: function (track) {
-                return {
-                    model: track,
-                    trackId: track.id,
-                    isMine: track.get("isMine"),
-                    isPublic: track.get("isPublic"),
-                    voidItem: true,
+            if (_.keys(this.trackItems).length === 0) {
+                filteredItems = [{
+                    trackId: this.VOID_TRACK.id,
+                    isMine: this.VOID_TRACK.isMine,
+                    isPublic: true,
                     start: this.startDate - 5000,
                     end: this.startDate - 4500,
                     content: this.VOID_ITEM_TMPL,
-                    groupContent: this.renderTrack(track)
-                };
-            },
+                    group: this.groupTemplate(this.VOID_TRACK)
+                }];
+            }
 
-            /**
-             * Get an timeline item from the given annotation
-             * @alias module:views-timeline.TimelineView#generateItem
-             * @param {Annotation} annotation The source annotation for the item
-             * @param {Track} track Track where the annotation is saved
-             * @return {Object} the generated timeline item
-             */
-            generateItem: function (annotation, track) {
-                var videoDuration = this.playerAdapter.getDuration(),
-                    annotationJSON,
-                    startTime,
-                    endTime,
-                    start,
-                    end;
+            // We save the actually displayed items here to access them later, for example in `onSelectionUpdate`
+            this.filteredItems = filteredItems.concat(_.values(this.trackItems));
 
-                annotationJSON = annotation.toJSON();
-                annotationJSON.track = track.id;
-                annotationJSON.text = annotation.get("text");
+            this.$el.find("[data-toggle='popover']").popover("destroy");
+            this.$el.find("[data-toggle='tooltip']").tooltip("destroy");
 
-                if (annotationJSON.label && annotationJSON.label.category && annotationJSON.label.category.settings) {
-                    annotationJSON.category = annotationJSON.label.category;
+            this.timeline.draw(this.filteredItems);
+
+            this.$el.find("[data-toggle='popover']").popover({ container: "body", html: true });
+            this.$el.find("[data-toggle='tooltip']").tooltip({ html: true });
+
+            // Restore the selections and co.
+            if (annotationTool.hasSelection()) {
+                this.onSelectionUpdate(annotationTool.getSelection());
+                this.updateDraggingCtrl();
+            }
+            this.markTrackSelected(annotationTool.selectedTrack);
+
+            this.$el.find(".timeline-groups-text").width(this.$el.width());
+        },
+
+        /**
+         * Update the timerange filter with the timerange
+         * @alias module:views-timeline.TimelineView#timerangeChange
+         */
+        timerangeChange: function () {
+            this.redraw();
+        },
+
+        /**
+         * Update the position of the timeline header on scroll
+         * @alias module:views-timeline.TimelineView#updateHeader
+         */
+        updateHeader: function () {
+            var self = this;
+
+            $("div.timeline-frame > div:first-child > div:first-child").css({
+                "margin-top": self.$timeline.scrollTop() - 2
+            });
+        },
+
+        /**
+         * Repaint the custom playhead
+         * @alias module:views-timeline.TimelineView#repaintCustomTime
+         */
+        repaintCustomTime: function () {
+            links.Timeline.prototype.repaintCustomTime.call(this.timeline);
+            this.changeTitleFromCustomPlayhead();
+        },
+
+        /**
+         * Change the title from the custome Playhead with a better time format
+         * @alias module:views-timeline.TimelineView#changeTitleFromCustomPlayhead
+         */
+        changeTitleFromCustomPlayhead: function () {
+            this.$el.find(".timeline-customtime").attr("title", annotationTool.getWellFormatedTime(this.playerAdapter.getCurrentTime()));
+        },
+
+        /**
+         * Move the current range to the left
+         * @alias module:views-timeline.TimelineView#moveLeft
+         * @param  {Event} event Event object
+         */
+        moveLeft: function (event) {
+            links.Timeline.preventDefault(event);
+            links.Timeline.stopPropagation(event);
+            this.timeline.move(-0.2);
+            this.timeline.trigger("rangechange");
+            this.timeline.trigger("rangechanged");
+        },
+
+        /**
+         * [moveRight description]
+         * @alias module:views-timeline.TimelineView#Right
+         * @param  {Event} event Event object
+         */
+        moveRight: function (event) {
+            links.Timeline.preventDefault(event);
+            links.Timeline.stopPropagation(event);
+            this.timeline.move(0.2);
+            this.timeline.trigger("rangechange");
+            this.timeline.trigger("rangechanged");
+        },
+
+        /**
+         * Move the current position of the player
+         * @alias module:views-timeline.TimelineView#moveToCurrentTime
+         */
+        moveToCurrentTime: function () {
+            var currentChartRange = this.timeline.getVisibleChartRange(),
+                start             = this.getTimeInSeconds(currentChartRange.start),
+                end               = this.getTimeInSeconds(currentChartRange.end),
+                size              = end - start,
+                currentTime       = this.playerAdapter.getCurrentTime(),
+                videoDuration     = this.playerAdapter.getDuration(),
+                marge             = size / 20,
+                startInSecond;
+
+            if (annotationTool.timelineFollowPlayhead) {
+                if ((currentTime - size / 2) < 0) {
+                    start = this.getFormatedDate(0);
+                    end = this.getFormatedDate(size);
+                } else if ((currentTime + size / 2) > videoDuration) {
+                    start = this.getFormatedDate(videoDuration - size);
+                    end = this.getFormatedDate(videoDuration);
+                } else {
+                    start = this.getFormatedDate(currentTime - size / 2);
+                    end = this.getFormatedDate(currentTime + size / 2);
                 }
+            } else {
+                if (((currentTime + marge) >= end && end != videoDuration) || (currentTime > end || currentTime < start)) {
+                    startInSecond = Math.max(currentTime - marge, 0);
+                    start = this.getFormatedDate(startInSecond);
+                    end = this.getFormatedDate(Math.min(startInSecond + size, videoDuration));
+                } else {
+                    start = this.getFormatedDate(start);
+                    end = this.getFormatedDate(end);
+                }
+            }
 
-                // Calculate start/end time
-                startTime = annotation.get("start");
-                endTime = startTime + this.annotationItemDuration(annotation);
-                start = this.getFormatedDate(startTime);
-                end = this.getFormatedDate(endTime);
 
-                // If annotation is at the end of the video, we mark it for styling
-                annotationJSON.atEnd = (videoDuration - endTime) < 3;
 
-                return {
-                    model: track,
-                    annotation: annotation,
-                    id: annotation.id,
-                    trackId: track.id,
-                    isPublic: track.get("isPublic"),
-                    isMine: track.get("isMine"),
-                    editable: track.get("isMine"),
-                    start: start,
-                    end: end,
-                    itemContent: this.itemTemplate(annotationJSON),
-                    groupContent: this.renderTrack(track)
+            if (currentChartRange.start.getTime() != start.getTime() || currentChartRange.end.getTime() !== end.getTime()) {
+                this.timeline.setVisibleChartRange(start, end);
+            }
+        },
+
+        /**
+         * Zoom in
+         * @alias module:views-timeline.TimelineView#zoomIn
+         * @param  {Event} event Event object
+         */
+        zoomIn: function (event) {
+            links.Timeline.preventDefault(event);
+            links.Timeline.stopPropagation(event);
+            this.timeline.zoom(0.4, this.timeline.getCustomTime());
+            this.timeline.trigger("rangechange");
+            this.timeline.trigger("rangechanged");
+        },
+
+        /**
+         * Zoom out
+         * @alias module:views-timeline.TimelineView#zoomOut
+         * @param  {Event} event Event object
+         */
+        zoomOut: function (event) {
+            links.Timeline.preventDefault(event);
+            links.Timeline.stopPropagation(event);
+            this.timeline.zoom(-0.4, this.timeline.getCustomTime());
+            this.timeline.trigger("rangechange");
+            this.timeline.trigger("rangechanged");
+        },
+
+        /**
+         * Add a new item to the timeline
+         * @param {string}  id           The id of the item
+         * @param {object}  item         The object representing the item
+         * @alias module:views-timeline.TimelineView#addItem
+         */
+        addItem: function (id, item) {
+            item.group = "<!-- extra -->" + item.group;
+            this.extraItems[id] = item;
+        },
+
+        /**
+         * Remove the timeline item with the given id
+         * @param  {string} id The id of the item to remove
+         * @alias module:views-timeline.TimelineView#removeItem
+         */
+        removeItem: function (id) {
+            delete this.extraItems[id];
+        },
+
+        /**
+         * Add an annotation to the timeline
+         * @alias module:views-timeline.TimelineView#addAnnotation
+         * @param {Annotation} annotation the annotation to add.
+         * @param {Track} track  the track where the annotation must be added
+         * @param {Boolean} [isList]  define if the insertion is part of a list, Default is false
+         */
+        addAnnotation: function (annotation, track, isList) {
+            // Wait that the id has be set to the model before to add it
+            if (_.isUndefined(annotation.get("id"))) {
+                annotation.once("ready", function () {
+                    this.addAnnotation(annotation, track, isList);
+                }, this);
+                return;
+            }
+
+            if (annotation.get("oldId") && this.ignoreAdd === annotation.get("oldId")) {
+                delete this.ignoreAdd;
+                return;
+            }
+
+            this.annotationItems[annotation.id] = this.generateItem(annotation, track);
+
+            if (!isList) {
+                this.preprocessTrack(track.id);
+                this.redraw();
+                this.onPlayerTimeUpdate();
+            }
+
+            annotation.on("destroy", this.onAnnotationDestroyed, this);
+        },
+
+        /**
+         * Add a track to the timeline
+         * @alias module:views-timeline.TimelineView#addTrack
+         * @param {Track} track The track to add to the timline
+         */
+        addTrack: function (track) {
+            var annotations,
+                proxyToAddAnnotation = function (annotation) {
+                    this.addAnnotation(annotation, track, false);
+                },
+                annotationWithList = function (annotation) {
+                    this.addAnnotation(annotation, track, true);
                 };
-            },
 
-            /**
-             * Add a track to the timeline
-             * @alias module:views-timeline.TimelineView#createTrack
-             * @param {PlainObject} JSON object compose of a name and description properties. Example: {name: "New track", description: "A test track as example"}
-             */
-            createTrack: function (param) {
-                var track;
+            // If track has not id, we save it to have an id
+            if (!track.id) {
+                track.on("ready", this.addTrack, this);
+                return;
+            }
 
-                if (this.timeline.findGroup(param.name)) {
-                    // If group already exist, we do nothing
+            // Add void item
+            this.trackItems[track.id] = this.generateVoidItem(track);
+
+            annotations = track.get("annotations");
+            annotations.each(annotationWithList, this);
+            annotations.on("add", proxyToAddAnnotation, this);
+            annotations.on("change", this.changeItem, this);
+
+            this.preprocessTrack(track.id);
+            this.redraw();
+        },
+
+        /**
+         * Add a list of tracks, creating a view for each of them
+         * @alias module:views-timeline.TimelineView#addTracksList
+         * @param {Array | List} tracks The list of tracks to add
+         */
+        addTracksList: function (tracks) {
+            this.trackItems = {};
+            this.annotationItems = {};
+            this.preprocessedItems = {};
+            if (tracks.length === 0) {
+                //this.preprocessAllTracks();
+                this.redraw();
+            } else {
+                _.each(tracks, this.addTrack, this);
+            }
+        },
+
+        /**
+         * Render the timeline group header for a track.
+         * @alias module:views-timeline.TimelineView#renderTrack
+         * @param {Track} track The track to render
+         * @return {String} The rendered track group header
+         */
+        renderTrack: function (track) {
+            var trackAttributes = _.clone(track.attributes);
+            trackAttributes.expanded = this.trackExpanded[track.id];
+            if (trackAttributes.access || trackAttributes.access === 0) {
+                trackAttributes.access = accessIdentifier(trackAttributes.access);
+            }
+            return this.groupTemplate(trackAttributes);
+        },
+
+        /**
+         * Get a void timeline item for the given track
+         * @alias module:views-timeline.TimelineView#generateVoidItem
+         * @param {Track} track Given track owning the void item
+         * @return {Object} the generated timeline item
+         */
+        generateVoidItem: function (track) {
+            return {
+                model: track,
+                trackId: track.id,
+                isMine: track.get("isMine"),
+                isPublic: track.get("isPublic"),
+                voidItem: true,
+                start: this.startDate - 5000,
+                end: this.startDate - 4500,
+                content: this.VOID_ITEM_TMPL,
+                groupContent: this.renderTrack(track)
+            };
+        },
+
+        /**
+         * Get an timeline item from the given annotation
+         * @alias module:views-timeline.TimelineView#generateItem
+         * @param {Annotation} annotation The source annotation for the item
+         * @param {Track} track Track where the annotation is saved
+         * @return {Object} the generated timeline item
+         */
+        generateItem: function (annotation, track) {
+            var videoDuration = this.playerAdapter.getDuration(),
+                annotationJSON,
+                startTime,
+                endTime,
+                start,
+                end;
+
+            annotationJSON = annotation.toJSON();
+            annotationJSON.track = track.id;
+            annotationJSON.text = annotation.get("text");
+
+            if (annotationJSON.label && annotationJSON.label.category && annotationJSON.label.category.settings) {
+                annotationJSON.category = annotationJSON.label.category;
+            }
+
+            // Calculate start/end time
+            startTime = annotation.get("start");
+            endTime = startTime + this.annotationItemDuration(annotation);
+            start = this.getFormatedDate(startTime);
+            end = this.getFormatedDate(endTime);
+
+            // If annotation is at the end of the video, we mark it for styling
+            annotationJSON.atEnd = (videoDuration - endTime) < 3;
+
+            return {
+                model: track,
+                annotation: annotation,
+                id: annotation.id,
+                trackId: track.id,
+                isPublic: track.get("isPublic"),
+                isMine: track.get("isMine"),
+                editable: track.get("isMine"),
+                start: start,
+                end: end,
+                itemContent: this.itemTemplate(annotationJSON),
+                groupContent: this.renderTrack(track)
+            };
+        },
+
+        /**
+         * Add a track to the timeline
+         * @alias module:views-timeline.TimelineView#createTrack
+         * @param {PlainObject} JSON object compose of a name and description properties. Example: {name: "New track", description: "A test track as example"}
+         */
+        createTrack: function (param) {
+            var track;
+
+            if (this.timeline.findGroup(param.name)) {
+                // If group already exist, we do nothing
+                return;
+            }
+
+            track = this.tracks.create(param, { wait: true });
+        },
+
+        /**
+         * Initialize the creation or update of a track, and load a corresponding modal
+         * @alias module:views-timeline.TimelineView#initTrackModal
+         * @param {Event} event The event triggering this modal
+         * @param {Track} track The track to edit or <tt>undefined</tt> to create a new one
+         */
+        initTrackModal: function (event, track) {
+            var action = track ? "update" : "add";
+
+            // If the modal is already loaded and displayed, we do nothing
+            if (this.groupModals[action]) return;
+
+            var modal = this.groupModals[action] = this.$el.find("#modal-" + action + "-group");
+            modal.off();
+            modal.html(
+                this.modalGroupTemplate(_.extend(
+                    { action: action },
+                    track && track.attributes
+                ))
+            );
+
+            var dismissModal = _.bind(function () {
+                modal.modal("hide");
+                delete this.groupModals[action];
+            }, this);
+
+            var saveTrack = _.bind(function () {
+                var name = modal.find("#name").val();
+                var description = modal.find("#description").val();
+
+                if (name === "") {
+                    modal.find(".alert #content").html(i18next.t("timeline.name required"));
+                    modal.find(".alert").show();
+                    return;
+                } else if (name.search(/<\/?script>/i) >= 0 || description.search(/<\/?script>/i) >= 0) {
+                    modal.find(".alert #content").html(i18next.t("timeline.scripts not allowed"));
+                    modal.find(".alert").show();
                     return;
                 }
 
-                track = this.tracks.create(param, { wait: true });
-            },
-
-            /**
-             * Initialize the creation or update of a track, and load a corresponding modal
-             * @alias module:views-timeline.TimelineView#initTrackModal
-             * @param {Event} event The event triggering this modal
-             * @param {Track} track The track to edit or <tt>undefined</tt> to create a new one
-             */
-            initTrackModal: function (event, track) {
-                var action = track ? "update" : "add";
-
-                // If the modal is already loaded and displayed, we do nothing
-                if (this.groupModals[action]) return;
-
-                var modal = this.groupModals[action] = this.$el.find("#modal-" + action + "-group");
-                modal.off();
-                modal.html(
-                    this.modalGroupTemplate(_.extend(
-                        { action: action },
-                        track && track.attributes
-                    ))
-                );
-
-                var dismissModal = _.bind(function () {
-                    modal.modal("hide");
-                    delete this.groupModals[action];
-                }, this);
-
-                var saveTrack = _.bind(function () {
-                    var name = modal.find("#name").val();
-                    var description = modal.find("#description").val();
-
-                    if (name === "") {
-                       modal.find(".alert #content").html(i18next.t("timeline.name required"));
-                       modal.find(".alert").show();
-                       return;
-                    } else if (name.search(/<\/?script>/i) >= 0 || description.search(/<\/?script>/i) >= 0) {
-                        modal.find(".alert #content").html(i18next.t("timeline.scripts not allowed"));
-                        modal.find(".alert").show();
-                        return;
-                    }
-
-                    var access;
-                    var accessRadio = modal.find("input[name='access-radio']:checked");
-                    if (accessRadio.length > 0) {
-                        access = normalizeAccess(accessRadio.val());
-                    } else {
-                        access = ACCESS.PUBLIC;
-                    }
-
-                    var attrs = {
-                        name: name,
-                        description: description,
-                        access: access
-                    };
-                    if (track) {
-                        track.save(attrs);
-                    } else {
-                        this.createTrack(attrs);
-                    }
-
-                    dismissModal();
-                }, this);
-
-                modal.find(".submit").on("click", saveTrack);
-                modal.on("keypress", function (event) {
-                    if (event.keyCode === 13) {
-                        saveTrack();
-                    }
-                });
-
-                modal.find(".cancel").on("click", dismissModal);
-
-                modal.on("shown", function () {
-                    modal.find("#name").focus();
-                    var access = accessIdentifier(
-                        track
-                            ? track.get("access")
-                            : ACCESS.PUBLIC
-                    );
-                    modal.find("[name='access-radio'][value='" + access + "']").prop("checked", true);
-                });
-                modal.modal({
-                    show: true,
-                    backdrop: false,
-                    keyboard: true
-                });
-            },
-
-            /**
-             * Get the track corresponding to the group header, givne an element inside the latter.
-             * @alias module:views-timeline.TimelineView#getTrackFromGroupHeader
-             * @param {Element} element An element inside a group header
-             * @return {Track} The track the surrounding group header belongs to
-             */
-            getTrackFromGroupHeader: function (element) {
-                return this.tracks.get(
-                    $(element).closest(".timeline-group").data("id")
-                );
-            },
-
-            /**
-             * Initialize the update of a track, and load a corresponding modal
-             * @alias module:views-timeline.TimelineView#onUpdateTrack
-             * @param {Event} event The event that causes the expansion. Usually clicking on a placeholder item
-             */
-            onUpdateTrack: function (event) {
-                var track = this.getTrackFromGroupHeader(event.target);
-                if (!track) return;
-                this.initTrackModal(event, track);
-            },
-
-            /**
-             * Expand or collapse a track, i. e. turn on or off all clustering and aggregation.
-             * @alias module:views-timeline.TimelineView#setTrackExpanded
-             * @param {Track} track The track to expand/collapse
-             * @param {Boolean} expanded Whether or not to expand the track
-             */
-            setTrackExpanded: function (track, expanded) {
-                this.trackExpanded[track.id] = expanded;
-                this.preprocessTrack(track.id);
-                this.changeTrack(track);
-            },
-
-            /**
-             * Expand a track. See {@link module:views-timeline.TimelineView#setTrackExpanded}.
-             * @see module:views-timeline.TimelineView#setTrackExpanded
-             * @alias module:views-timeline.TimelineView#expandTrack
-             * @param {Event} event The event that causes the expansion; Usually clicking on a placeholder item
-             * @see preprocessTrack
-             */
-            expandTrack: function (event) {
-                var track = this.tracks.get($(event.target).data("track"));
-                this.setTrackExpanded(track, true);
-            },
-
-            /**
-             * Toggle a tracks expanstion status. See {@link module:views-timeline.TimelineView#setTrackExpanded}.
-             * @alias module:views-timeline.TimelineView#toggleTrack
-             * @param {Event} event The event triggering the toggle
-             * @see expandTrack
-             */
-            toggleTrackExpansion: function (event) {
-                var track = this.getTrackFromGroupHeader(event.target);
-                this.setTrackExpanded(track, !this.trackExpanded[track.id]);
-            },
-
-            /**
-             * Do some preprocessing on the timeline items in a given track.
-             * This groups items together, when there are more than the track can display
-             * and also ensures that only the longest item of any label is displayed
-             * at any given time in this situation.
-             * @alias module:views-timeline.TimelineView#preprocessTrack
-             * @param trackId The id of the track to preprocess
-             */
-            preprocessTrack: function (trackId) {
-                delete this.preprocessedItems[trackId];
-
-                var items = _.filter(this.annotationItems, function (item) {
-                    var category = item.annotation.category();
-                    if (category && !category.get("visible")) return false;
-                    if (!category && !annotationTool.freeTextVisible) return false;
-                    // Mind the lose comparison! IDs might be either strings or numbers, but we don't care here.
-                    return item.trackId == trackId;
-                });
-
-                // The height of the track in stack levels. We need (and potentially calculate) that later.
-                // For now, tracks are at least 3 stacking levels high.
-                var height = 3;
-                // A mapping from annotation id to stacking level. We will will this later
-                // and then use it to place the items on the proper height within their track.
-                var stackLevels = {};
-
-                // When there are no items in this track,
-                // there is nothing to do, so return early,
-                // so that we can assume `items` is not empty in the following code.
-                if (!items.length) {
-                    this.preprocessedItems[trackId] = [];
+                var access;
+                var accessRadio = modal.find("input[name='access-radio']:checked");
+                if (accessRadio.length > 0) {
+                    access = normalizeAccess(accessRadio.val());
                 } else {
+                    access = ACCESS.PUBLIC;
+                }
 
-                    // We sort the items by their start time.
-                    // This will come in handy multiple times in the following algorithms
-                    // and also ensures a deterministic outcome.
-                    items = _.sortBy(items, "start");
+                var attrs = {
+                    name: name,
+                    description: description,
+                    access: access
+                };
+                if (track) {
+                    track.save(attrs);
+                } else {
+                    this.createTrack(attrs);
+                }
 
-                    if (!this.trackExpanded[trackId]) {
-                        // First we will need to determine which items to display for any label that we have.
-                        // The selected items for each label will be the subset of items with that label
-                        // with the most coverage of the timeline.
-                        // To find this subset, we will use a dynamic programming approach.
-                        var labelSelection = _.chain(items)
-                            .filter(function (item) { return item.annotation.get("label"); })
-                            .groupBy(function (item) { return item.annotation.get("label").id; })
-                            .reduce(function (labelSelection, items) {
-                                // The dynamic program will output `items.len` possible solutions,
-                                // namely the disjoint subsets of annotations that have the greatest coverage
-                                // and whose last annotation is the i-th when sorted by their end time.
-                                items = _.sortBy(items, "end");
-                                var selectedAnnotations = _.chain(items)
-                                    .reduce(function (potentialSolutions, item, i) {
-                                        // In each step we want to find the best solution ending in item i.
-                                        // These are collected in `potentialSolutions`
+                dismissModal();
+            }, this);
 
-                                        // We clearly get the next one
-                                        // by combining one of the previous best solutions
-                                        // with the i-th item.
-                                        // Because of the disjunctiveness condition, though,
-                                        // not all previous solutions are viable.
-                                        var viablePreviousSolutions = _.filter(potentialSolutions, function (_, j) {
-                                            // Only those which do not overlap the current item can be considered.
-                                            return items[j].end < items[i].start;
-                                        });
-                                        var bestPreviousSolution = viablePreviousSolutions.length
-                                            ? _.max(viablePreviousSolutions, "value")
-                                            : {
-                                                value: 0,
-                                                items: []
-                                            };
-                                        potentialSolutions.push({
-                                            value: item.end - item.start + bestPreviousSolution.value,
-                                            items: bestPreviousSolution.items.concat(item)
-                                        });
-                                        return potentialSolutions;
-                                    }, [])
-                                    // The best of these partial solutions constitutes our final selection
-                                    .max("value")
-                                    .value()
-                                    .items;
+            modal.find(".submit").on("click", saveTrack);
+            modal.on("keypress", function (event) {
+                if (event.keyCode === 13) {
+                    saveTrack();
+                }
+            });
 
-                                _.each(selectedAnnotations, function (item) {
-                                    labelSelection[item.id] = true;
-                                });
+            modal.find(".cancel").on("click", dismissModal);
 
-                                return labelSelection;
-                            }, {})
-                            .value();
-                    }
+            modal.on("shown", function () {
+                modal.find("#name").focus();
+                var access = accessIdentifier(
+                    track
+                        ? track.get("access")
+                        : ACCESS.PUBLIC
+                );
+                modal.find("[name='access-radio'][value='" + access + "']").prop("checked", true);
+            });
+            modal.modal({
+                show: true,
+                backdrop: false,
+                keyboard: true
+            });
+        },
 
-                    // Now we determining the stacking level for each item,
-                    // while also noting which items are together in a stack,
-                    // i.e. a connected component of a graph where the nodes are the items
-                    // and an edge exists if the items overlap in time.
+        /**
+         * Get the track corresponding to the group header, givne an element inside the latter.
+         * @alias module:views-timeline.TimelineView#getTrackFromGroupHeader
+         * @param {Element} element An element inside a group header
+         * @return {Track} The track the surrounding group header belongs to
+         */
+        getTrackFromGroupHeader: function (element) {
+            return this.tracks.get(
+                $(element).closest(".timeline-group").data("id")
+            );
+        },
 
-                    // The latter functionality will be needed again later,
-                    // so we write a function for this.
-                    var stackItems = function (items) {
-                        if (!items.length) return [];
+        /**
+         * Initialize the update of a track, and load a corresponding modal
+         * @alias module:views-timeline.TimelineView#onUpdateTrack
+         * @param {Event} event The event that causes the expansion. Usually clicking on a placeholder item
+         */
+        onUpdateTrack: function (event) {
+            var track = this.getTrackFromGroupHeader(event.target);
+            if (!track) return;
+            this.initTrackModal(event, track);
+        },
 
-                        var firstItem = items.splice(0, 1)[0];
-                        var currentStack = {
-                            items: [firstItem],
-                            start: firstItem.start,
-                            end: firstItem.end
-                        };
-                        var stacks = [currentStack];
+        /**
+         * Expand or collapse a track, i. e. turn on or off all clustering and aggregation.
+         * @alias module:views-timeline.TimelineView#setTrackExpanded
+         * @param {Track} track The track to expand/collapse
+         * @param {Boolean} expanded Whether or not to expand the track
+         */
+        setTrackExpanded: function (track, expanded) {
+            this.trackExpanded[track.id] = expanded;
+            this.preprocessTrack(track.id);
+            this.changeTrack(track);
+        },
 
-                        _.each(items, function (item) {
-                            // If this item does not belong to the current stack anymore,
-                            // we need to start a new one.
-                            if (item.start > currentStack.end) {
-                                currentStack = {
-                                    items: [item],
-                                    start: item.start,
-                                    end: item.end
-                                };
-                                stacks.push(currentStack);
-                                return;
-                            }
+        /**
+         * Expand a track. See {@link module:views-timeline.TimelineView#setTrackExpanded}.
+         * @see module:views-timeline.TimelineView#setTrackExpanded
+         * @alias module:views-timeline.TimelineView#expandTrack
+         * @param {Event} event The event that causes the expansion; Usually clicking on a placeholder item
+         * @see preprocessTrack
+         */
+        expandTrack: function (event) {
+            var track = this.tracks.get($(event.target).data("track"));
+            this.setTrackExpanded(track, true);
+        },
 
-                            // Otherwise add the item to the current stack
-                            currentStack.end = Math.max(currentStack.end, item.end);
-                            currentStack.items.push(item);
-                        });
-                        return stacks;
-                    };
-                    var stacks = stackItems(items);
+        /**
+         * Toggle a tracks expanstion status. See {@link module:views-timeline.TimelineView#setTrackExpanded}.
+         * @alias module:views-timeline.TimelineView#toggleTrack
+         * @param {Event} event The event triggering the toggle
+         * @see expandTrack
+         */
+        toggleTrackExpansion: function (event) {
+            var track = this.getTrackFromGroupHeader(event.target);
+            this.setTrackExpanded(track, !this.trackExpanded[track.id]);
+        },
 
-                    // Now within each stack, we assign items to different levels.
-                    // We also determine the necessary height of the track on the way, when it is expanded.
-                    _.each(stacks, function (stack) {
-                        _.each(stack.items, function (item, i) {
-                            var items = stack.items;
+        /**
+         * Do some preprocessing on the timeline items in a given track.
+         * This groups items together, when there are more than the track can display
+         * and also ensures that only the longest item of any label is displayed
+         * at any given time in this situation.
+         * @alias module:views-timeline.TimelineView#preprocessTrack
+         * @param trackId The id of the track to preprocess
+         */
+        preprocessTrack: function (trackId) {
+            delete this.preprocessedItems[trackId];
 
-                            // We don't need to place labeled items that have not been selected by the first step
-                            // but if we find an item like that, we need to show a placeholder.
-                            var label = item.annotation.get("label");
-                            if (!this.trackExpanded[trackId] && label && !labelSelection[item.id]) {
-                                stack.hasHiddenItems = true;
-                                return;
-                            };
+            var items = _.filter(this.annotationItems, function (item) {
+                var category = item.annotation.category();
+                if (category && !category.get("visible")) return false;
+                if (!category && !annotationTool.freeTextVisible) return false;
+                // Mind the lose comparison! IDs might be either strings or numbers, but we don't care here.
+                return item.trackId == trackId;
+            });
 
-                            // Find the stack level of the stack where this item fits in.
-                            // We just collect all the levels that are already occupied at this time ...
-                            var usedLevels = [];
-                            var level;
-                            for (var j = 0; j < i; ++j) {
-                                level = stackLevels[items[j].id];
-                                if ((level || level === 0) && util.overlaps(item, items[j])) {
-                                    usedLevels[level] = true;
-                                }
-                            }
-                            // ... and then look for the first free one.
-                            for (level = 0; level < usedLevels.length && usedLevels[level]; ++level);
+            // The height of the track in stack levels. We need (and potentially calculate) that later.
+            // For now, tracks are at least 3 stacking levels high.
+            var height = 3;
+            // A mapping from annotation id to stacking level. We will will this later
+            // and then use it to place the items on the proper height within their track.
+            var stackLevels = {};
 
-                            if (level > 2) stack.hasHiddenItems = true;
-                            stackLevels[item.id] = level;
-                            if (this.trackExpanded[trackId] && level >= height) height = level + 1;
-                            item.className = this.PREFIX_STACKING_CLASS + level;
-                        }, this);
-                    }, this);
+            // When there are no items in this track,
+            // there is nothing to do, so return early,
+            // so that we can assume `items` is not empty in the following code.
+            if (!items.length) {
+                this.preprocessedItems[trackId] = [];
+            } else {
 
-                    // Now we just cut each stack to contain only three levels if it is not expanded
-                    this.preprocessedItems[trackId] = _.chain(stacks)
-                        .map(function (stack) {
-                            // If the track is expanded, we need to give each item a class representing the stack height,
-                            // so that the CSS can adjust the top margin.
-                            if (this.trackExpanded[trackId]) {
-                                _.each(stack.items, function (item) {
-                                    item.className += " height-" + height;
-                                });
-                                return stack.items;
-                            }
-                            if (!stack.hasHiddenItems) return stack.items;
-                            // If the stack is three levels or less, everything is fine
-                            // and we can just display all items in the stack.
-                            if (this.trackExpanded[trackId] || !stack.hasHiddenItems) return stack.items;
+                // We sort the items by their start time.
+                // This will come in handy multiple times in the following algorithms
+                // and also ensures a deterministic outcome.
+                items = _.sortBy(items, "start");
 
-                            // Otherwise we aggregate the spilled items into one or more placeholders
-                            var items = _.partition(stack.items, function (item) {
-                                return stackLevels[item.id] < 2;
+                if (!this.trackExpanded[trackId]) {
+                    // First we will need to determine which items to display for any label that we have.
+                    // The selected items for each label will be the subset of items with that label
+                    // with the most coverage of the timeline.
+                    // To find this subset, we will use a dynamic programming approach.
+                    var labelSelection = _.chain(items)
+                        .filter(function (item) { return item.annotation.get("label"); })
+                        .groupBy(function (item) { return item.annotation.get("label").id; })
+                        .reduce(function (labelSelection, items) {
+                            // The dynamic program will output `items.len` possible solutions,
+                            // namely the disjoint subsets of annotations that have the greatest coverage
+                            // and whose last annotation is the i-th when sorted by their end time.
+                            items = _.sortBy(items, "end");
+                            var selectedAnnotations = _.chain(items)
+                                .reduce(function (potentialSolutions, item, i) {
+                                    // In each step we want to find the best solution ending in item i.
+                                    // These are collected in `potentialSolutions`
+
+                                    // We clearly get the next one
+                                    // by combining one of the previous best solutions
+                                    // with the i-th item.
+                                    // Because of the disjunctiveness condition, though,
+                                    // not all previous solutions are viable.
+                                    var viablePreviousSolutions = _.filter(potentialSolutions, function (_, j) {
+                                        // Only those which do not overlap the current item can be considered.
+                                        return items[j].end < items[i].start;
+                                    });
+                                    var bestPreviousSolution = viablePreviousSolutions.length
+                                        ? _.max(viablePreviousSolutions, "value")
+                                        : {
+                                            value: 0,
+                                            items: []
+                                        };
+                                    potentialSolutions.push({
+                                        value: item.end - item.start + bestPreviousSolution.value,
+                                        items: bestPreviousSolution.items.concat(item)
+                                    });
+                                    return potentialSolutions;
+                                }, [])
+                            // The best of these partial solutions constitutes our final selection
+                                .max("value")
+                                .value()
+                                .items;
+
+                            _.each(selectedAnnotations, function (item) {
+                                labelSelection[item.id] = true;
                             });
-                            var spilled = items[1];
-                            var placeholders = _.map(stackItems(spilled), function (spilledStack) {
-                                var trackId = spilledStack.items[0].trackId;
-                                return {
-                                    isPlaceholder: true,
-                                    start: spilledStack.start,
-                                    end: spilledStack.end,
-                                    groupContent: spilledStack.items[0].groupContent,
-                                    trackId: trackId,
-                                    itemContent: PlaceholderTmpl({
-                                        track: trackId,
-                                        hiddenItems: spilledStack.items
-                                    }),
-                                    className: this.PREFIX_STACKING_CLASS + 2,
-                                    editable: false
-                                };
-                            }, this);
-                            return items[0].concat(placeholders);
-                        }, this)
-                        .flatten()
+
+                            return labelSelection;
+                        }, {})
                         .value();
                 }
 
-                _.each(this.preprocessedItems[trackId].concat(this.trackItems[trackId]), function (item) {
-                    // We need to change the group of each item to add some indicator of the height of the track
-                    // We also need to, **in front of that**, add some indicator for the track,
-                    // as to preserve the ordering.
-                    item.group = "<div style=\"height: " + height * 23 + "px;\">" + item.groupContent + "</div>";
-                    item.group = "<!-- track: " + annotationTool.tracksOrder.indexOf(trackId) + " -->" + item.group;
+                // Now we determining the stacking level for each item,
+                // while also noting which items are together in a stack,
+                // i.e. a connected component of a graph where the nodes are the items
+                // and an edge exists if the items overlap in time.
 
-                    // We also need to set the margin of all the items to shift them to their stacking level
-                    function wrap(item, level) {
-                        return "<div style=\"margin-top: " +
-                            (-51 + (height - level) * 23) +
-                            "px;\">" +
-                            item +
-                            "</div>";
-                    }
-                    if (item.isPlaceholder) {
-                        item.content = wrap(item.itemContent, 2);
-                    } else if (item.id) {
-                        item.content = wrap(item.itemContent, stackLevels[item.id]);
-                    }
-                });
-            },
+                // The latter functionality will be needed again later,
+                // so we write a function for this.
+                var stackItems = function (items) {
+                    if (!items.length) return [];
 
-            /**
-             * Do preprocessing on all tracks.
-             * @alias module:views-timeline.TimelineView#preprocessAllTracks
-             */
-            preprocessAllTracks: function () {
-                _.each(this.trackItems, function (_, trackId) {
-                    this.preprocessTrack(trackId);
-                }, this);
-            },
+                    var firstItem = items.splice(0, 1)[0];
+                    var currentStack = {
+                        items: [firstItem],
+                        start: firstItem.start,
+                        end: firstItem.end
+                    };
+                    var stacks = [currentStack];
 
-            /**
-             * Check the position for the changed item
-             * @alias module:views-timeline.TimelineView#changeItem
-             * @param {Annotation} the annotation that has been changed
-             */
-            changeItem: function (annotation) {
-                var value = this.getTimelineItemFromAnnotation(annotation);
+                    _.each(items, function (item) {
+                        // If this item does not belong to the current stack anymore,
+                        // we need to start a new one.
+                        if (item.start > currentStack.end) {
+                            currentStack = {
+                                items: [item],
+                                start: item.start,
+                                end: item.end
+                            };
+                            stacks.push(currentStack);
+                            return;
+                        }
 
-                if (!_.isUndefined(value)) {
-                    // Only update annotation view if the item has already been created
-                    this.annotationItems[annotation.id] = this.generateItem(annotation, value.model);
-                    this.preprocessTrack(value.trackId);
-                    this.redraw();
-                }
-            },
-
-            /**
-             * Listener for the player timeupdate
-             * @alias module:views-timeline.TimelineView#onPlayerTimeUpdate
-             */
-            onPlayerTimeUpdate: function () {
-                var currentTime = this.playerAdapter.getCurrentTime(),
-                    newDate = this.getFormatedDate(currentTime);
-
-                this.timeline.setCustomTime(newDate);
-
-                this.$el.find("span.time").html(annotationTool.getWellFormatedTime(currentTime, true));
-
-                this.moveToCurrentTime();
-            },
-
-            /**
-             * Mark an annotation as selected when it is clicked.
-             * @alias module:views-timeline.TimelineView#selectAnnotation
-             * @param {Event} event The event initiating the selection
-             */
-            selectAnnotation: function (event) {
-                var id = event.currentTarget.dataset["annotationid"],
-                    trackId = event.currentTarget.dataset["trackid"];
-                annotationTool.setSelectionById([{ id: id, trackId: trackId }], true, true);
-            },
-
-            /**
-             * Listener for the selection update event
-             * @alias module:views-timeline.TimelineView#onSelectionUpdate
-             * @param  {Array} selection The new array of selected item(s)
-             */
-            onSelectionUpdate: function (selection) {
-                var data = this.filteredItems;
-
-                // If no selection, we unselected elements currently selected and return
-                if (selection.length === 0) {
-                    this.timeline.unselectItem();
-                    return;
-                }
-
-                // We look for the first item in the selection, that is actually currently visible
-                var indexToSelect;
-                var alreadySelected;
-                _.find(selection, function (annotation) {
-                    if (this.isAnnotationSelectedonTimeline(annotation)) {
-                        alreadySelected = true;
-                        return true;
-                    }
-                    indexToSelect = _.findIndex(data, function (item) {
-                        return item.id === annotation.id;
+                        // Otherwise add the item to the current stack
+                        currentStack.end = Math.max(currentStack.end, item.end);
+                        currentStack.items.push(item);
                     });
-                    return indexToSelect >= 0;
+                    return stacks;
+                };
+                var stacks = stackItems(items);
+
+                // Now within each stack, we assign items to different levels.
+                // We also determine the necessary height of the track on the way, when it is expanded.
+                _.each(stacks, function (stack) {
+                    _.each(stack.items, function (item, i) {
+                        var items = stack.items;
+
+                        // We don't need to place labeled items that have not been selected by the first step
+                        // but if we find an item like that, we need to show a placeholder.
+                        var label = item.annotation.get("label");
+                        if (!this.trackExpanded[trackId] && label && !labelSelection[item.id]) {
+                            stack.hasHiddenItems = true;
+                            return;
+                        };
+
+                        // Find the stack level of the stack where this item fits in.
+                        // We just collect all the levels that are already occupied at this time ...
+                        var usedLevels = [];
+                        var level;
+                        for (var j = 0; j < i; ++j) {
+                            level = stackLevels[items[j].id];
+                            if ((level || level === 0) && util.overlaps(item, items[j])) {
+                                usedLevels[level] = true;
+                            }
+                        }
+                        // ... and then look for the first free one.
+                        for (level = 0; level < usedLevels.length && usedLevels[level]; ++level);
+
+                        if (level > 2) stack.hasHiddenItems = true;
+                        stackLevels[item.id] = level;
+                        if (this.trackExpanded[trackId] && level >= height) height = level + 1;
+                        item.className = this.PREFIX_STACKING_CLASS + level;
+                    }, this);
                 }, this);
-                if (alreadySelected) return;
-                if (indexToSelect >= 0) this.timeline.selectItem(indexToSelect, false, true);
-            },
 
-            /**
-             * Listener for the timeline timeupdate
-             * @alias module:views-timeline.TimelineView#onTimelineMoved
-             * @param {Event} event Event object
-             */
-            onTimelineMoved: function (event) {
-                var newTime = this.getTimeInSeconds(event.time),
-                    hasToPlay = (this.playerAdapter.getStatus() === PlayerAdapter.STATUS.PLAYING);
+                // Now we just cut each stack to contain only three levels if it is not expanded
+                this.preprocessedItems[trackId] = _.chain(stacks)
+                    .map(function (stack) {
+                        // If the track is expanded, we need to give each item a class representing the stack height,
+                        // so that the CSS can adjust the top margin.
+                        if (this.trackExpanded[trackId]) {
+                            _.each(stack.items, function (item) {
+                                item.className += " height-" + height;
+                            });
+                            return stack.items;
+                        }
+                        if (!stack.hasHiddenItems) return stack.items;
+                        // If the stack is three levels or less, everything is fine
+                        // and we can just display all items in the stack.
+                        if (this.trackExpanded[trackId] || !stack.hasHiddenItems) return stack.items;
 
+                        // Otherwise we aggregate the spilled items into one or more placeholders
+                        var items = _.partition(stack.items, function (item) {
+                            return stackLevels[item.id] < 2;
+                        });
+                        var spilled = items[1];
+                        var placeholders = _.map(stackItems(spilled), function (spilledStack) {
+                            var trackId = spilledStack.items[0].trackId;
+                            return {
+                                isPlaceholder: true,
+                                start: spilledStack.start,
+                                end: spilledStack.end,
+                                groupContent: spilledStack.items[0].groupContent,
+                                trackId: trackId,
+                                itemContent: PlaceholderTmpl({
+                                    track: trackId,
+                                    hiddenItems: spilledStack.items
+                                }),
+                                className: this.PREFIX_STACKING_CLASS + 2,
+                                editable: false
+                            };
+                        }, this);
+                        return items[0].concat(placeholders);
+                    }, this)
+                    .flatten()
+                    .value();
+            }
 
-                if (hasToPlay) {
-                    this.playerAdapter.pause();
+            _.each(this.preprocessedItems[trackId].concat(this.trackItems[trackId]), function (item) {
+                // We need to change the group of each item to add some indicator of the height of the track
+                // We also need to, **in front of that**, add some indicator for the track,
+                // as to preserve the ordering.
+                item.group = "<div style=\"height: " + height * 23 + "px;\">" + item.groupContent + "</div>";
+                item.group = "<!-- track: " + annotationTool.tracksOrder.indexOf(trackId) + " -->" + item.group;
+
+                // We also need to set the margin of all the items to shift them to their stacking level
+                function wrap(item, level) {
+                    return "<div style=\"margin-top: " +
+                        (-51 + (height - level) * 23) +
+                        "px;\">" +
+                        item +
+                        "</div>";
                 }
+                if (item.isPlaceholder) {
+                    item.content = wrap(item.itemContent, 2);
+                } else if (item.id) {
+                    item.content = wrap(item.itemContent, stackLevels[item.id]);
+                }
+            });
+        },
 
-                this.playerAdapter.setCurrentTime((newTime < 0 || newTime > this.playerAdapter.getDuration()) ? 0 : newTime);
+        /**
+         * Do preprocessing on all tracks.
+         * @alias module:views-timeline.TimelineView#preprocessAllTracks
+         */
+        preprocessAllTracks: function () {
+            _.each(this.trackItems, function (_, trackId) {
+                this.preprocessTrack(trackId);
+            }, this);
+        },
+
+        /**
+         * Check the position for the changed item
+         * @alias module:views-timeline.TimelineView#changeItem
+         * @param {Annotation} the annotation that has been changed
+         */
+        changeItem: function (annotation) {
+            var value = this.getTimelineItemFromAnnotation(annotation);
+
+            if (!_.isUndefined(value)) {
+                // Only update annotation view if the item has already been created
+                this.annotationItems[annotation.id] = this.generateItem(annotation, value.model);
+                this.preprocessTrack(value.trackId);
+                this.redraw();
+            }
+        },
+
+        /**
+         * Listener for the player timeupdate
+         * @alias module:views-timeline.TimelineView#onPlayerTimeUpdate
+         */
+        onPlayerTimeUpdate: function () {
+            var currentTime = this.playerAdapter.getCurrentTime(),
+                newDate = this.getFormatedDate(currentTime);
+
+            this.timeline.setCustomTime(newDate);
+
+            this.$el.find("span.time").html(annotationTool.getWellFormatedTime(currentTime, true));
+
+            this.moveToCurrentTime();
+        },
+
+        /**
+         * Mark an annotation as selected when it is clicked.
+         * @alias module:views-timeline.TimelineView#selectAnnotation
+         * @param {Event} event The event initiating the selection
+         */
+        selectAnnotation: function (event) {
+            var id = event.currentTarget.dataset["annotationid"],
+                trackId = event.currentTarget.dataset["trackid"];
+            annotationTool.setSelectionById([{ id: id, trackId: trackId }], true, true);
+        },
+
+        /**
+         * Listener for the selection update event
+         * @alias module:views-timeline.TimelineView#onSelectionUpdate
+         * @param  {Array} selection The new array of selected item(s)
+         */
+        onSelectionUpdate: function (selection) {
+            var data = this.filteredItems;
+
+            // If no selection, we unselected elements currently selected and return
+            if (selection.length === 0) {
+                this.timeline.unselectItem();
+                return;
+            }
+
+            // We look for the first item in the selection, that is actually currently visible
+            var indexToSelect;
+            var alreadySelected;
+            _.find(selection, function (annotation) {
+                if (this.isAnnotationSelectedonTimeline(annotation)) {
+                    alreadySelected = true;
+                    return true;
+                }
+                indexToSelect = _.findIndex(data, function (item) {
+                    return item.id === annotation.id;
+                });
+                return indexToSelect >= 0;
+            }, this);
+            if (alreadySelected) return;
+            if (indexToSelect >= 0) this.timeline.selectItem(indexToSelect, false, true);
+        },
+
+        /**
+         * Listener for the timeline timeupdate
+         * @alias module:views-timeline.TimelineView#onTimelineMoved
+         * @param {Event} event Event object
+         */
+        onTimelineMoved: function (event) {
+            var newTime = this.getTimeInSeconds(event.time),
+                hasToPlay = (this.playerAdapter.getStatus() === PlayerAdapter.STATUS.PLAYING);
+
+
+            if (hasToPlay) {
+                this.playerAdapter.pause();
+            }
+
+            this.playerAdapter.setCurrentTime((newTime < 0 || newTime > this.playerAdapter.getDuration()) ? 0 : newTime);
+
+            if (hasToPlay) {
+                this.playerAdapter.play();
+            }
+        },
+
+        /**
+         * Listener for item modification
+         * @alias module:views-timeline.TimelineView#onTimelineItemChanged
+         */
+        onTimelineItemChanged: function () {
+            var hasToPlay = (this.playerAdapter.getStatus() === PlayerAdapter.STATUS.PLAYING),
+                values = this.getSelectedItemAndAnnotation(),
+                oldItemId,
+                duration,
+                end,
+                start,
+                annJSON,
+                successCallback,
+                destroyCallback,
+                self = this;
+
+            // Pause the player if needed
+            this.playerAdapter.pause();
+
+            // Return if no values related to to item
+            if (!values || !values.annotation) {
+                console.warn("Can not get infos from updated item!");
+                this.timeline.cancelChange();
+                return;
+            }
+
+            start = this.getTimeInSeconds(values.item.start);
+            end = this.getTimeInSeconds(values.item.end);
+            duration = end - start;
+
+            // If the annotation is not owned by the current user or the annotation is moved outside the timeline,
+            // the update is canceled
+            if (!values.newTrack.get("isMine") || !values.annotation.get("isMine") ||
+                end > this.playerAdapter.getDuration() ||
+                start > this.playerAdapter.getDuration()) {
+                this.timeline.cancelChange();
+
+                this.annotationItems[values.annotation.id] = {
+                    annotation: values.annotation,
+                    start: values.item.start,
+                    end: values.item.end,
+                    itemContent: values.item.content,
+                    groupContent: this.renderTrack(values.oldTrack),
+                    id: values.annotation.id,
+                    trackId: values.oldTrack.id,
+                    model: values.oldTrack,
+                    className: values.item.className
+                };
+
+                this.preprocessTrack(values.oldTrack.id);
+                this.preprocessTrack(values.newTrack.id);
+                this.redraw();
 
                 if (hasToPlay) {
                     this.playerAdapter.play();
                 }
-            },
+                return;
+            }
 
-            /**
-             * Listener for item modification
-             * @alias module:views-timeline.TimelineView#onTimelineItemChanged
-             */
-            onTimelineItemChanged: function () {
-                var hasToPlay = (this.playerAdapter.getStatus() === PlayerAdapter.STATUS.PLAYING),
-                    values = this.getSelectedItemAndAnnotation(),
-                    oldItemId,
-                    duration,
-                    end,
-                    start,
-                    annJSON,
-                    successCallback,
-                    destroyCallback,
-                    self = this;
+            // If the annotations has been moved on another track
+            if (values.newTrack.id !== values.oldTrack.id) {
+                this.ignoreAdd = values.annotation.get("id");
+                this.ignoreDelete = this.ignoreAdd;
 
-                // Pause the player if needed
-                this.playerAdapter.pause();
+                annJSON = values.annotation.toJSON();
+                oldItemId = annJSON.id;
+                annJSON.oldId = this.ignoreAdd;
+                annJSON.start = start;
+                annJSON.duration = duration;
 
-                // Return if no values related to to item
-                if (!values || !values.annotation) {
-                    console.warn("Can not get infos from updated item!");
-                    this.timeline.cancelChange();
-                    return;
-                }
+                delete annJSON.id;
+                delete annJSON.created_at;
 
-                start = this.getTimeInSeconds(values.item.start);
-                end = this.getTimeInSeconds(values.item.end);
-                duration = end - start;
+                destroyCallback = function () {
+                    if (annotationTool.localStorage) {
+                        successCallback(values.newTrack.get("annotations").create(annJSON));
+                    } else {
+                        values.newTrack.get("annotations").create(annJSON, {
+                            wait: true,
+                            success: successCallback
+                        });
+                    }
+                },
+                successCallback = function (newAnnotation) {
+                    newAnnotation.unset("oldId", { silent: true });
+                    newAnnotation.save();
 
-                // If the annotation is not owned by the current user or the annotation is moved outside the timeline,
-                // the update is canceled
-                if (!values.newTrack.get("isMine") || !values.annotation.get("isMine") ||
-                    end > this.playerAdapter.getDuration() ||
-                    start > this.playerAdapter.getDuration()) {
-                    this.timeline.cancelChange();
+                    annJSON.id = newAnnotation.get("id");
+                    annJSON.track = values.newTrack.id;
 
-                    this.annotationItems[values.annotation.id] = {
+                    if (annJSON.label && annJSON.label.category && annJSON.label.category.settings) {
+                        annJSON.category = annJSON.label.category;
+                    }
+
+                    self.annotationItems[annJSON.id] = {
                         annotation: values.annotation,
                         start: values.item.start,
                         end: values.item.end,
-                        itemContent: values.item.content,
-                        groupContent: this.renderTrack(values.oldTrack),
-                        id: values.annotation.id,
-                        trackId: values.oldTrack.id,
-                        model: values.oldTrack,
-                        className: values.item.className
+                        groupContent: values.item.groupContent,
+                        itemContent: self.itemTemplate(annJSON),
+                        id: annJSON.id,
+                        trackId: values.newTrack.id,
+                        isPublic: values.newTrack.get("isPublic"),
+                        isMine: values.newTrack.get("isMine"),
+                        model: values.newTrack
                     };
+
+                    delete self.annotationItems[annJSON.oldId];
+
+                    annotationTool.setSelection([newAnnotation], true, true, true);
+
+                    newAnnotation.set({
+                        access: values.newTrack.get("access")
+                    });
 
                     this.preprocessTrack(values.oldTrack.id);
                     this.preprocessTrack(values.newTrack.id);
-                    this.redraw();
+                    self.redraw();
 
                     if (hasToPlay) {
-                        this.playerAdapter.play();
+                        self.playerAdapter.play();
                     }
-                    return;
-                }
+                };
 
-                // If the annotations has been moved on another track
-                if (values.newTrack.id !== values.oldTrack.id) {
-                    this.ignoreAdd = values.annotation.get("id");
-                    this.ignoreDelete = this.ignoreAdd;
-
-                    annJSON = values.annotation.toJSON();
-                    oldItemId = annJSON.id;
-                    annJSON.oldId = this.ignoreAdd;
-                    annJSON.start = start;
-                    annJSON.duration = duration;
-
-                    delete annJSON.id;
-                    delete annJSON.created_at;
-
-                    destroyCallback = function () {
-                        if (annotationTool.localStorage) {
-                            successCallback(values.newTrack.get("annotations").create(annJSON));
-                        } else {
-                            values.newTrack.get("annotations").create(annJSON, {
-                                wait: true,
-                                success: successCallback
-                            });
-                        }
-                    },
-                    successCallback = function (newAnnotation) {
-                        newAnnotation.unset("oldId", { silent: true });
-                        newAnnotation.save();
-
-                        annJSON.id = newAnnotation.get("id");
-                        annJSON.track = values.newTrack.id;
-
-                        if (annJSON.label && annJSON.label.category && annJSON.label.category.settings) {
-                            annJSON.category = annJSON.label.category;
-                        }
-
-                        self.annotationItems[annJSON.id] = {
-                            annotation: values.annotation,
-                            start: values.item.start,
-                            end: values.item.end,
-                            groupContent: values.item.groupContent,
-                            itemContent: self.itemTemplate(annJSON),
-                            id: annJSON.id,
-                            trackId: values.newTrack.id,
-                            isPublic: values.newTrack.get("isPublic"),
-                            isMine: values.newTrack.get("isMine"),
-                            model: values.newTrack
-                        };
-
-                        delete self.annotationItems[annJSON.oldId];
-
-                        annotationTool.setSelection([newAnnotation], true, true, true);
-
-                        newAnnotation.set({
-                            access: values.newTrack.get("access")
-                        });
-
-                        this.preprocessTrack(values.oldTrack.id);
-                        this.preprocessTrack(values.newTrack.id);
-                        self.redraw();
-
-                        if (hasToPlay) {
-                            self.playerAdapter.play();
-                        }
-                    };
-
-                    values.annotation.destroy({
-                        success: destroyCallback
-                    });
-
-                } else {
-                    this.annotationItems[values.annotation.id] = values.item;
-                    values.annotation.set({
-                        start: start,
-                        duration: duration
-                    });
-                    values.annotation.save();
-
-                    annotationTool.playerAdapter.setCurrentTime(values.annotation.get("start"));
-                    this.preprocessTrack(values.item.trackId);
-                    this.redraw();
-
-
-                    if (hasToPlay) {
-                        this.playerAdapter.play();
-                    }
-                }
-            },
-
-            /**
-             * Listener for timeline item deletion
-             * @alias module:views-timeline.TimelineView#onTimelineItemDeleted
-             */
-            onTimelineItemDeleted: function () {
-                var annotation = this.getSelectedItemAndAnnotation().annotation;
-                this.timeline.cancelDelete();
-                annotationTool.deleteOperation.start(annotation, this.typeForDeleteAnnotation);
-            },
-
-            /**
-             * Listener for item insertion on timeline
-             * @alias module:views-timeline.TimelineView#onTimelineItemAdded
-             */
-            onTimelineItemAdded: function () {
-                // No possiblity to add annotation directly from the timeline
-                this.timeline.cancelAdd();
-            },
-
-            /**
-             * Listener for annotation suppression
-             * @alias module:views-timeline.TimelineView#onAnnotationDestroyed
-             */
-            onAnnotationDestroyed: function (annotation) {
-                if (this.ignoreDelete === annotation.get("id")) {
-                    delete this.ignoreDelete;
-                    return;
-                }
-
-                // This function can be called multiple times per deletion so we might not have to do anything
-                var annotationItem = this.annotationItems[annotation.id];
-                if (!annotationItem) return;
-
-                var track = annotationItem.trackId;
-                delete this.annotationItems[annotation.id];
-                this.preprocessTrack(track);
-                this.redraw();
-            },
-
-            /**
-             * Reset the timeline zoom to see the whole timeline
-             * @alias module:views-timeline.TimelineView#onTimelineResetZoom
-             */
-            onTimelineResetZoom: function () {
-                this.timeline.setVisibleChartRange(this.startDate, this.endDate);
-            },
-
-            /**
-             * Listener for track deletion
-             * @alias module:views-timeline.TimelineView#onDeleteTrack
-             * @param {Event} event the action event
-             */
-            onDeleteTrack: function (event) {
-                event.stopImmediatePropagation();
-
-                var track = this.getTrackFromGroupHeader(event.target),
-                    self = this,
-                    values,
-                    newTrack,
-                    callback;
-
-                // If track already deleted
-                if (!track) {
-                    return;
-                }
-
-                // Destroy the track and redraw the timeline
-                callback = _.bind(function () {
-                    _.each(this.annotationItems, function (item) {
-                        if (item.trackId === track.id) {
-                            delete this.annotationItems[item.id];
-                        }
-                    }, this);
-
-                    self.tracks.remove(track);
-
-                    // If the track was selected
-                    if (!annotationTool.selectedTrack || annotationTool.selectedTrack.id === track.id) {
-                        if (self.tracks.length > 0) { // If there is still other tracks
-                            self.tracks.each(function (t) {
-                                if (t.get("isMine")) {
-                                    newTrack = t;
-                                }
-                            });
-                            self.markTrackSelected(newTrack);
-                        }
-                    } else {
-                        self.markTrackSelected(annotationTool.selectedTrack);
-                    }
-
-                    delete this.trackItems[track.id];
-
-                    this.redraw();
-                }, this);
-
-                annotationTool.deleteOperation.start(track, this.typeForDeleteTrack, callback);
-            },
-
-            /**
-             * Update all the items placed on the given track
-             * @alias module:views-timeline.TimelineView#changeTrack
-             * @param  {Track} track The freshly updated track
-             * @param  {PlainObject} [options] Options like silent: true to avoid a redraw (optionnal)
-             */
-            changeTrack: function (track, options) {
-                // If the track is not visible, we do nothing
-                if (!track.get(Track.FIELDS.VISIBLE)) {
-                    return;
-                }
-
-                var newGroup,
-                    redrawRequired = false;
-
-                newGroup = this.renderTrack(track);
-
-                _.each(_.values(this.annotationItems).concat(_.values(this.trackItems)), function (item) {
-                    if (item.trackId === track.get("id") && item.groupContent !== newGroup) {
-                        item.groupContent = newGroup;
-                        item.isPublic = track.get("isPublic");
-                        redrawRequired = true;
-                    }
-                }, this);
-
-                if (!(options && options.silent) && redrawRequired) {
-                    this.preprocessTrack(track.id);
-                    this.redraw();
-                }
-            },
-
-            /**
-             * Update the track with the given id
-             * @alias module:views-timeline.TimelineView#onChangeTrackVisibility
-             * @param {Event} event the action event
-             */
-            onChangeTrackVisibility: function (event) {
-                event.stopImmediatePropagation();
-
-                if (annotationTool.isPrivateOnly) {
-                    annotationTool.alertWarning(i18next.t("timeline.private only.no public tracks allowed"));
-                    return;
-                }
-
-                var track = this.getTrackFromGroupHeader(event.target);
-                if (!track) {
-                    console.warn("Track " + track.id + " does not exist!");
-                    return;
-                }
-
-                track.save({
-                    access: normalizeAccess($(event.currentTarget).data("access"))
+                values.annotation.destroy({
+                    success: destroyCallback
                 });
 
-                this.$el.find("[data-toggle='tooltip']").tooltip("hide");
-            },
+            } else {
+                this.annotationItems[values.annotation.id] = values.item;
+                values.annotation.set({
+                    start: start,
+                    duration: duration
+                });
+                values.annotation.save();
 
-            /**
-             * Mark a given track as selected
-             * @alias module:views-timeline.TimelineView#markTrackSelected
-             * @param {Track} The track to be selected
-             */
-            markTrackSelected: function (track) {
-                if (!track) return;
-                this.$el.find("div.selected").removeClass("selected");
-                this.$el.find(".timeline-group[data-id='" + track.id + "']")
-                    .closest(".timeline-groups-text").addClass("selected").width(this.$el.width());
-            },
+                annotationTool.playerAdapter.setCurrentTime(values.annotation.get("start"));
+                this.preprocessTrack(values.item.trackId);
+                this.redraw();
 
-            /**
-             * Listener for track selection
-             * @alias module:views-timeline.TimelineView#onSelectTrack
-             * @param {Event} event Event object
-             */
-            onSelectTrack: function (event) {
-                var track = this.getTrackFromGroupHeader(event.target);
-                if (!track.get("isMine")) return;
-                if (!track) return;
-                annotationTool.selectTrack(
-                    this.getTrackFromGroupHeader(event.target)
-                );
-            },
 
-            /**
-             * Listener for window resizing
-             * @alias module:views-timeline.TimelineView#onWindowsResize
-             */
-            onWindowResize: function () {
-                this.update();
-                if (annotationTool.selectedTrack) {
-                    this.markTrackSelected(annotationTool.selectedTrack);
+                if (hasToPlay) {
+                    this.playerAdapter.play();
                 }
-            },
-
-            /* --------------------------------------
-              Utils functions
-            ----------------------------------------*/
-
-            /**
-             * Get the formated date for the timeline with the given seconds.
-             * The timeline displays dates/times in local time,
-             * which is why we bias the time towards UTC.
-             * @alias module:views-timeline.TimelineView#getFormatedDate
-             * @param {Double} seconds The time in seconds to convert to Date
-             * @returns {Date} Formated date for the timeline
-             */
-            getFormatedDate: function (seconds) {
-                var newDate = new Date(seconds * 1000);
-                newDate.setTime(newDate.getTime() + newDate.getTimezoneOffset() * 60 * 1000);
-                return newDate;
-            },
-
-            /**
-             * Transform the given date into a time in seconds
-             * @alias module:views-timeline.TimelineView#getTimeInSeconds
-             * @param {Date} date The formated date from timeline
-             * @returns {Number} Date converted to time in seconds
-             */
-            getTimeInSeconds: function (date) {
-                return date.getTime() / 1000 - date.getTimezoneOffset() * 60;
-            },
-
-            /**
-             * Get the current selected annotion as object containing the timeline item and the annotation
-             * @alias module:views-timeline.TimelineView#getSelectedItemAndAnnotation
-             * @returns {Object} Object containing the annotation and the timeline item. "{item: "timeline-item", annotation: "annotation-object"}"
-             */
-            getSelectedItemAndAnnotation: function () {
-                //var itemId = $("." + this.ITEM_SELECTED_CLASS + " .annotation-id").text(),
-                var annotation = annotationTool.getSelection()[0],
-                    //selection = this.timeline.getSelection(),
-                    item,
-                    itemId,
-                    newTrackId,
-                    oldTrackId,
-                    oldTrack,
-                    newTrack;
-
-                if (_.isUndefined(annotation) || _.isUndefined(this.annotationItems[annotation.get("id")])) {
-                    return undefined;
-                }
-
-                itemId = annotation.get("id");
-
-                item = this.annotationItems[itemId];
-                newTrackId = item.trackId;
-                oldTrackId = $(item.itemContent)[0].dataset.trackid;
-                oldTrack = annotationTool.getTrack(oldTrackId);
-                newTrack = annotationTool.getTrack(newTrackId);
-                annotation = annotationTool.getAnnotation(itemId, oldTrack);
-
-                return {
-                    annotation: annotation,
-                    item: item,
-                    annotationId: itemId,
-                    trackId: newTrackId,
-                    newTrack: newTrack,
-                    oldTrack: oldTrack
-                };
-            },
-
-            /**
-             * Check if the given annotation is currently selected on the timeline
-             * @alias module:views-timeline.TimelineView#isAnnotationSelectedonTimeline
-             * @param  {Annotation}  annotation The annotation to check
-             * @return {Boolean}            If the annotation is selected or not
-             */
-            isAnnotationSelectedonTimeline: function (annotation) {
-                return this.$el.find("div." + this.ITEM_SELECTED_CLASS + " div.timeline-item div.annotation-id:contains(\"" + annotation.get("id") + "\")").length !== 0;
-            },
-
-            /**
-             * Update the position of the controls to resize the item following the stacking level
-             * @alias module:views-timeline.TimelineView#updateDraggingCtrl
-             */
-            updateDraggingCtrl: function () {
-                var selectedElement = this.$el.find("." + this.ITEM_SELECTED_CLASS),
-                    cssProperties,
-                    item = this.getSelectedItemAndAnnotation();
-
-                if (_.isUndefined(item)) {
-                    // No current selection
-                    return;
-                }
-
-                selectedElement = this.$el.find("." + this.ITEM_SELECTED_CLASS);
-                cssProperties = {
-                    "margin-top": parseInt(selectedElement.css("margin-top"), 10) + parseInt(selectedElement.find(".timeline-item").css("margin-top"), 10) + "px",
-                    "height": selectedElement.find(".timeline-item").outerHeight() + "px"
-                };
-
-                this.$el.find(".timeline-event-range-drag-left").css(cssProperties);
-
-                if (item && item.annotation && item.annotation.get("duration") < 1) {
-                    cssProperties["margin-left"] = selectedElement.find(".timeline-item").outerWidth() + "px";
-                } else {
-                    cssProperties["margin-left"] = "0px";
-                }
-
-                this.$el.find(".timeline-event-range-drag-right").css(cssProperties);
-            },
-
-            /**
-             * Get the item related to the given annotation
-             * @alias module:views-timeline.TimelineView#getTimelineItemFromAnnotation
-             * @param {Annotation} the annotation
-             * @returns {Object} an item object extend by an index parameter
-             */
-            getTimelineItemFromAnnotation: function (annotation) {
-                return this.annotationItems[annotation.id];
-            },
-
-            /**
-            * Return the duration of an annotation for rendering in the timeline.
-            * If the duration is not defined or less than a certain threshold,
-            * a minimal duration will be returned so that the annotation is still visible in the timeline.
-            * @alias module:views-timeline.TimelineView#annotationItemDuration
-            * @param {Annotation} annotation The annotation to get the duration of.
-            * @returns {Number} The duration of the annotation in the timeline.
-            */
-            annotationItemDuration: function (annotation) {
-                var duration = annotation.get("duration");
-                return duration && duration > this.DEFAULT_DURATION ? duration : this.DEFAULT_DURATION;
-            },
-
-            /**
-             * Get track with the given track id. Fallback method include if issues with the standard one.
-             * @alias module:views-timeline.TimelineView#getTrack
-             * @param {int} trackId The id from the targeted track
-             * @return {Track} a track if existing, or undefined.
-             */
-            getTrack: function (trackId) {
-                var rTrack = this.tracks.get(trackId);
-
-                if (!rTrack) {
-                    // Fallback method
-                    this.tracks.each(function (track) {
-                        if (track.id === trackId) {
-                            rTrack = track;
-                        }
-                    }, this);
-                }
-                return rTrack;
             }
-        });
-        return Timeline;
-    }
-);
+        },
+
+        /**
+         * Listener for timeline item deletion
+         * @alias module:views-timeline.TimelineView#onTimelineItemDeleted
+         */
+        onTimelineItemDeleted: function () {
+            var annotation = this.getSelectedItemAndAnnotation().annotation;
+            this.timeline.cancelDelete();
+            annotationTool.deleteOperation.start(annotation, this.typeForDeleteAnnotation);
+        },
+
+        /**
+         * Listener for item insertion on timeline
+         * @alias module:views-timeline.TimelineView#onTimelineItemAdded
+         */
+        onTimelineItemAdded: function () {
+            // No possiblity to add annotation directly from the timeline
+            this.timeline.cancelAdd();
+        },
+
+        /**
+         * Listener for annotation suppression
+         * @alias module:views-timeline.TimelineView#onAnnotationDestroyed
+         */
+        onAnnotationDestroyed: function (annotation) {
+            if (this.ignoreDelete === annotation.get("id")) {
+                delete this.ignoreDelete;
+                return;
+            }
+
+            // This function can be called multiple times per deletion so we might not have to do anything
+            var annotationItem = this.annotationItems[annotation.id];
+            if (!annotationItem) return;
+
+            var track = annotationItem.trackId;
+            delete this.annotationItems[annotation.id];
+            this.preprocessTrack(track);
+            this.redraw();
+        },
+
+        /**
+         * Reset the timeline zoom to see the whole timeline
+         * @alias module:views-timeline.TimelineView#onTimelineResetZoom
+         */
+        onTimelineResetZoom: function () {
+            this.timeline.setVisibleChartRange(this.startDate, this.endDate);
+        },
+
+        /**
+         * Listener for track deletion
+         * @alias module:views-timeline.TimelineView#onDeleteTrack
+         * @param {Event} event the action event
+         */
+        onDeleteTrack: function (event) {
+            event.stopImmediatePropagation();
+
+            var track = this.getTrackFromGroupHeader(event.target),
+                self = this,
+                values,
+                newTrack,
+                callback;
+
+            // If track already deleted
+            if (!track) {
+                return;
+            }
+
+            // Destroy the track and redraw the timeline
+            callback = _.bind(function () {
+                _.each(this.annotationItems, function (item) {
+                    if (item.trackId === track.id) {
+                        delete this.annotationItems[item.id];
+                    }
+                }, this);
+
+                self.tracks.remove(track);
+
+                // If the track was selected
+                if (!annotationTool.selectedTrack || annotationTool.selectedTrack.id === track.id) {
+                    if (self.tracks.length > 0) { // If there is still other tracks
+                        self.tracks.each(function (t) {
+                            if (t.get("isMine")) {
+                                newTrack = t;
+                            }
+                        });
+                        self.markTrackSelected(newTrack);
+                    }
+                } else {
+                    self.markTrackSelected(annotationTool.selectedTrack);
+                }
+
+                delete this.trackItems[track.id];
+
+                this.redraw();
+            }, this);
+
+            annotationTool.deleteOperation.start(track, this.typeForDeleteTrack, callback);
+        },
+
+        /**
+         * Update all the items placed on the given track
+         * @alias module:views-timeline.TimelineView#changeTrack
+         * @param  {Track} track The freshly updated track
+         * @param  {PlainObject} [options] Options like silent: true to avoid a redraw (optionnal)
+         */
+        changeTrack: function (track, options) {
+            // If the track is not visible, we do nothing
+            if (!track.get(Track.FIELDS.VISIBLE)) {
+                return;
+            }
+
+            var newGroup,
+                redrawRequired = false;
+
+            newGroup = this.renderTrack(track);
+
+            _.each(_.values(this.annotationItems).concat(_.values(this.trackItems)), function (item) {
+                if (item.trackId === track.get("id") && item.groupContent !== newGroup) {
+                    item.groupContent = newGroup;
+                    item.isPublic = track.get("isPublic");
+                    redrawRequired = true;
+                }
+            }, this);
+
+            if (!(options && options.silent) && redrawRequired) {
+                this.preprocessTrack(track.id);
+                this.redraw();
+            }
+        },
+
+        /**
+         * Update the track with the given id
+         * @alias module:views-timeline.TimelineView#onChangeTrackVisibility
+         * @param {Event} event the action event
+         */
+        onChangeTrackVisibility: function (event) {
+            event.stopImmediatePropagation();
+
+            if (annotationTool.isPrivateOnly) {
+                annotationTool.alertWarning(i18next.t("timeline.private only.no public tracks allowed"));
+                return;
+            }
+
+            var track = this.getTrackFromGroupHeader(event.target);
+            if (!track) {
+                console.warn("Track " + track.id + " does not exist!");
+                return;
+            }
+
+            track.save({
+                access: normalizeAccess($(event.currentTarget).data("access"))
+            });
+
+            this.$el.find("[data-toggle='tooltip']").tooltip("hide");
+        },
+
+        /**
+         * Mark a given track as selected
+         * @alias module:views-timeline.TimelineView#markTrackSelected
+         * @param {Track} The track to be selected
+         */
+        markTrackSelected: function (track) {
+            if (!track) return;
+            this.$el.find("div.selected").removeClass("selected");
+            this.$el.find(".timeline-group[data-id='" + track.id + "']")
+                .closest(".timeline-groups-text").addClass("selected").width(this.$el.width());
+        },
+
+        /**
+         * Listener for track selection
+         * @alias module:views-timeline.TimelineView#onSelectTrack
+         * @param {Event} event Event object
+         */
+        onSelectTrack: function (event) {
+            var track = this.getTrackFromGroupHeader(event.target);
+            if (!track.get("isMine")) return;
+            if (!track) return;
+            annotationTool.selectTrack(
+                this.getTrackFromGroupHeader(event.target)
+            );
+        },
+
+        /**
+         * Listener for window resizing
+         * @alias module:views-timeline.TimelineView#onWindowsResize
+         */
+        onWindowResize: function () {
+            this.update();
+            if (annotationTool.selectedTrack) {
+                this.markTrackSelected(annotationTool.selectedTrack);
+            }
+        },
+
+        /* --------------------------------------
+           Utils functions
+           ----------------------------------------*/
+
+        /**
+         * Get the formated date for the timeline with the given seconds.
+         * The timeline displays dates/times in local time,
+         * which is why we bias the time towards UTC.
+         * @alias module:views-timeline.TimelineView#getFormatedDate
+         * @param {Double} seconds The time in seconds to convert to Date
+         * @returns {Date} Formated date for the timeline
+         */
+        getFormatedDate: function (seconds) {
+            var newDate = new Date(seconds * 1000);
+            newDate.setTime(newDate.getTime() + newDate.getTimezoneOffset() * 60 * 1000);
+            return newDate;
+        },
+
+        /**
+         * Transform the given date into a time in seconds
+         * @alias module:views-timeline.TimelineView#getTimeInSeconds
+         * @param {Date} date The formated date from timeline
+         * @returns {Number} Date converted to time in seconds
+         */
+        getTimeInSeconds: function (date) {
+            return date.getTime() / 1000 - date.getTimezoneOffset() * 60;
+        },
+
+        /**
+         * Get the current selected annotion as object containing the timeline item and the annotation
+         * @alias module:views-timeline.TimelineView#getSelectedItemAndAnnotation
+         * @returns {Object} Object containing the annotation and the timeline item. "{item: "timeline-item", annotation: "annotation-object"}"
+         */
+        getSelectedItemAndAnnotation: function () {
+            //var itemId = $("." + this.ITEM_SELECTED_CLASS + " .annotation-id").text(),
+            var annotation = annotationTool.getSelection()[0],
+                //selection = this.timeline.getSelection(),
+                item,
+                itemId,
+                newTrackId,
+                oldTrackId,
+                oldTrack,
+                newTrack;
+
+            if (_.isUndefined(annotation) || _.isUndefined(this.annotationItems[annotation.get("id")])) {
+                return undefined;
+            }
+
+            itemId = annotation.get("id");
+
+            item = this.annotationItems[itemId];
+            newTrackId = item.trackId;
+            oldTrackId = $(item.itemContent)[0].dataset.trackid;
+            oldTrack = annotationTool.getTrack(oldTrackId);
+            newTrack = annotationTool.getTrack(newTrackId);
+            annotation = annotationTool.getAnnotation(itemId, oldTrack);
+
+            return {
+                annotation: annotation,
+                item: item,
+                annotationId: itemId,
+                trackId: newTrackId,
+                newTrack: newTrack,
+                oldTrack: oldTrack
+            };
+        },
+
+        /**
+         * Check if the given annotation is currently selected on the timeline
+         * @alias module:views-timeline.TimelineView#isAnnotationSelectedonTimeline
+         * @param  {Annotation}  annotation The annotation to check
+         * @return {Boolean}            If the annotation is selected or not
+         */
+        isAnnotationSelectedonTimeline: function (annotation) {
+            return this.$el.find("div." + this.ITEM_SELECTED_CLASS + " div.timeline-item div.annotation-id:contains(\"" + annotation.get("id") + "\")").length !== 0;
+        },
+
+        /**
+         * Update the position of the controls to resize the item following the stacking level
+         * @alias module:views-timeline.TimelineView#updateDraggingCtrl
+         */
+        updateDraggingCtrl: function () {
+            var selectedElement = this.$el.find("." + this.ITEM_SELECTED_CLASS),
+                cssProperties,
+                item = this.getSelectedItemAndAnnotation();
+
+            if (_.isUndefined(item)) {
+                // No current selection
+                return;
+            }
+
+            selectedElement = this.$el.find("." + this.ITEM_SELECTED_CLASS);
+            cssProperties = {
+                "margin-top": parseInt(selectedElement.css("margin-top"), 10) + parseInt(selectedElement.find(".timeline-item").css("margin-top"), 10) + "px",
+                "height": selectedElement.find(".timeline-item").outerHeight() + "px"
+            };
+
+            this.$el.find(".timeline-event-range-drag-left").css(cssProperties);
+
+            if (item && item.annotation && item.annotation.get("duration") < 1) {
+                cssProperties["margin-left"] = selectedElement.find(".timeline-item").outerWidth() + "px";
+            } else {
+                cssProperties["margin-left"] = "0px";
+            }
+
+            this.$el.find(".timeline-event-range-drag-right").css(cssProperties);
+        },
+
+        /**
+         * Get the item related to the given annotation
+         * @alias module:views-timeline.TimelineView#getTimelineItemFromAnnotation
+         * @param {Annotation} the annotation
+         * @returns {Object} an item object extend by an index parameter
+         */
+        getTimelineItemFromAnnotation: function (annotation) {
+            return this.annotationItems[annotation.id];
+        },
+
+        /**
+         * Return the duration of an annotation for rendering in the timeline.
+         * If the duration is not defined or less than a certain threshold,
+         * a minimal duration will be returned so that the annotation is still visible in the timeline.
+         * @alias module:views-timeline.TimelineView#annotationItemDuration
+         * @param {Annotation} annotation The annotation to get the duration of.
+         * @returns {Number} The duration of the annotation in the timeline.
+         */
+        annotationItemDuration: function (annotation) {
+            var duration = annotation.get("duration");
+            return duration && duration > this.DEFAULT_DURATION ? duration : this.DEFAULT_DURATION;
+        },
+
+        /**
+         * Get track with the given track id. Fallback method include if issues with the standard one.
+         * @alias module:views-timeline.TimelineView#getTrack
+         * @param {int} trackId The id from the targeted track
+         * @return {Track} a track if existing, or undefined.
+         */
+        getTrack: function (trackId) {
+            var rTrack = this.tracks.get(trackId);
+
+            if (!rTrack) {
+                // Fallback method
+                this.tracks.each(function (track) {
+                    if (track.id === trackId) {
+                        rTrack = track;
+                    }
+                }, this);
+            }
+            return rTrack;
+        }
+    });
+    return Timeline;
+});

--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -1533,11 +1533,9 @@ define([
          */
         onSelectTrack: function (event) {
             var track = this.getTrackFromGroupHeader(event.target);
-            if (!track.get("isMine")) return;
             if (!track) return;
-            annotationTool.selectTrack(
-                this.getTrackFromGroupHeader(event.target)
-            );
+            if (!track.get("isMine")) return;
+            annotationTool.selectTrack(track);
         },
 
         /**

--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -231,7 +231,6 @@ define([
                       "changeTrack",
                       "getFormatedDate",
                       "getSelectedItemAndAnnotation",
-                      "getTrack",
                       "onWindowResize",
                       "onTimelineResetZoom",
                       "initTrackModal",
@@ -288,8 +287,6 @@ define([
             };
 
             this.groupModals = {};
-
-            this.$navbar = this.$el.find(".navbar");
 
             // Create the timeline
             this.$timeline = this.$el.find("#timeline");
@@ -1701,26 +1698,6 @@ define([
         annotationItemDuration: function (annotation) {
             var duration = annotation.get("duration");
             return duration && duration > this.DEFAULT_DURATION ? duration : this.DEFAULT_DURATION;
-        },
-
-        /**
-         * Get track with the given track id. Fallback method include if issues with the standard one.
-         * @alias module:views-timeline.TimelineView#getTrack
-         * @param {int} trackId The id from the targeted track
-         * @return {Track} a track if existing, or undefined.
-         */
-        getTrack: function (trackId) {
-            var rTrack = this.tracks.get(trackId);
-
-            if (!rTrack) {
-                // Fallback method
-                this.tracks.each(function (track) {
-                    if (track.id === trackId) {
-                        rTrack = track;
-                    }
-                }, this);
-            }
-            return rTrack;
         }
     });
     return Timeline;

--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -42,10 +42,10 @@ define([
     PlayerAdapter,
     Track,
     template,
-    GroupTmpl,
-    ItemTmpl,
-    PlaceholderTmpl,
-    ModalGroupTmpl,
+    groupTemplate,
+    itemTemplate,
+    placeholderTemplate,
+    groupModalTemplate,
     ACCESS,
     Backbone,
     links
@@ -70,27 +70,6 @@ define([
      * @alias module:views-timeline.TimelineView
      */
     var Timeline = Backbone.View.extend({
-        /**
-         * Group template
-         * @alias module:views-timeline.TimelineView#groupTemplate
-         * @type {HandlebarsTemplate}
-         */
-        groupTemplate: GroupTmpl,
-
-        /**
-         * Item template
-         * @alias module:views-timeline.TimelineView#itemTemplate
-         * @type {HandlebarsTemplate}
-         */
-        itemTemplate: ItemTmpl,
-
-        /**
-         * Modal template for groups
-         * @alias module:views-timeline.TimelineView#modalGroupTemplate
-         * @type {HandlebarsTemplate}
-         */
-        modalGroupTemplate: ModalGroupTmpl,
-
         /**
          * Events to handle by the timeline view
          * @alias module:views-timeline.TimelineView#event
@@ -394,7 +373,7 @@ define([
                     start: this.startDate - 5000,
                     end: this.startDate - 4500,
                     content: this.VOID_ITEM_TMPL,
-                    group: this.groupTemplate(this.VOID_TRACK)
+                    group: groupTemplate(this.VOID_TRACK)
                 }];
             }
 
@@ -659,7 +638,7 @@ define([
             if (trackAttributes.access || trackAttributes.access === 0) {
                 trackAttributes.access = accessIdentifier(trackAttributes.access);
             }
-            return this.groupTemplate(trackAttributes);
+            return groupTemplate(trackAttributes);
         },
 
         /**
@@ -724,7 +703,7 @@ define([
                 editable: track.get("isMine"),
                 start: start,
                 end: end,
-                itemContent: this.itemTemplate(annotationJSON),
+                itemContent: itemTemplate(annotationJSON),
                 groupContent: this.renderTrack(track)
             };
         },
@@ -760,7 +739,7 @@ define([
             var modal = this.groupModals[action] = this.$el.find("#modal-" + action + "-group");
             modal.off();
             modal.html(
-                this.modalGroupTemplate(_.extend(
+                groupModalTemplate(_.extend(
                     { action: action },
                     track && track.attributes
                 ))
@@ -1083,7 +1062,7 @@ define([
                                 end: spilledStack.end,
                                 groupContent: spilledStack.items[0].groupContent,
                                 trackId: trackId,
-                                itemContent: PlaceholderTmpl({
+                                itemContent: placeholderTemplate({
                                     track: trackId,
                                     hiddenItems: _.map(
                                         spilledStack.items,
@@ -1332,7 +1311,7 @@ define([
                         start: values.item.start,
                         end: values.item.end,
                         groupContent: values.item.groupContent,
-                        itemContent: self.itemTemplate(annJSON),
+                        itemContent: itemTemplate(annJSON),
                         id: annJSON.id,
                         trackId: values.newTrack.id,
                         isPublic: values.newTrack.get("isPublic"),

--- a/frontend/locales/de/translation.json
+++ b/frontend/locales/de/translation.json
@@ -222,7 +222,6 @@
     "creating views": "Fenster werden erstellt",
     "get current user": "Aktueller Benutzer wird ermittelt",
     "get users saved locally": "Lokal gepseicherte Benutzer werden ermittelt",
-    "importing track": "Spur {{track}} wird importiert",
     "initializing the player": "Player wird initialisiert?",
     "loading": "Wird geladen",
     "loading video": "Video wird geladen",

--- a/frontend/locales/en/translation.json
+++ b/frontend/locales/en/translation.json
@@ -225,7 +225,6 @@
     "creating views": "Start creating views.",
     "get current user": "Get current user.",
     "get users saved locally": "Get users saved locally.",
-    "importing track": "Importing track {{track}}",
     "initializing the player": "Initializing the player.",
     "loading": "Loading",
     "loading video": "Start loading video.",

--- a/frontend/templates/list-annotation-edit.tmpl
+++ b/frontend/templates/list-annotation-edit.tmpl
@@ -4,75 +4,139 @@
             <i class="icon-chevron-down"></i>
         </button>
 
-        <button class="btn in" title="{{t "annotation.edit.set start to playhead.long"}}">{{t "annotation.edit.set start to playhead.short"}}</button>
+        <button
+            class="btn in"
+            title="{{t "annotation.edit.set start to playhead.long"}}"
+        >{{t "annotation.edit.set start to playhead.short"}}</button>
         <span class="start">
-                <input title="{{t "annotation.edit.start time"}} {{#if isMine}}({{t "annotation.edit.double click to edit"}}){{/if}}" id="start-{{id}}" class="start-value" type="text" value="{{time start}}"></input>
+            <input
+                title="{{t "annotation.edit.start time"}}{{#if isMine}} ({{t "annotation.edit.double click to edit"}}){{/if}}"
+                id="start-{{id}}"
+                class="start-value"
+                type="text"
+                value="{{time start}}"
+            ></input>
         </span>
 
-        <span class="end {{#if duration}}has-duration{{else}}no-duration{{/if}}">
-                <input title="{{t "annotation.edit.end time"}}{{#if isMine}} ({{t "annotation.edit.double click to edit"}}){{/if}}" id="end-{{id}}" class="end-value" type="text" value="{{end start duration}}"></input>
+        <span class="
+            end
+            {{#if duration}}
+                has-duration
+            {{else}}
+                no-duration
+            {{/if}}
+        ">
+            <input
+                title="{{t "annotation.edit.end time"}}{{#if isMine}} ({{t "annotation.edit.double click to edit"}}){{/if}}"
+                id="end-{{id}}"
+                class="end-value"
+                type="text"
+                value="{{end start duration}}"
+            ></input>
         </span>
-        <button class="btn out" title="{{t "annotation.edit.set end to playhead.long"}}">{{t "annotation.edit.set end to playhead.short"}}</button>
+        <button
+            class="btn out"
+            title="{{t "annotation.edit.set end to playhead.long"}}"
+        >{{t "annotation.edit.set end to playhead.short"}}</button>
 
         {{#if isMine}}
-        <i class="private icon-user" title="{{t "annotation.you own"}}"></i>
+            <i
+                class="private icon-user"
+                title="{{t "annotation.you own"}}"
+            ></i>
         {{/if}}
 
         {{#if scalevalues}}
-        <span class="scaling">
+            <span class="scaling">
                 {{#if isMine}}
-                <select>
+                    <select>
                         {{#each scalevalues}}
-                        <option value="{{this.id}}" {{#if this.isSelected}}selected="selected"{{/if}}>{{this.name}}</option>
+                            <option
+                                value="{{this.id}}"
+                                {{#if this.isSelected}}
+                                    selected="selected"
+                                {{/if}}
+                            >{{this.name}}</option>
                         {{/each}}
-                </select>
+                    </select>
                 {{/if}}
                 {{#if scalevalue}}
-                <span class="read-only" title="{{scalevalue.name}}">{{scalevalue.name}}</span>
+                    <span
+                        class="read-only"
+                        title="{{scalevalue.name}}"
+                    >{{scalevalue.name}}</span>
                 {{/if}}
-        </span>
+            </span>
         {{/if}}
 
-        <span class="category" {{#if label}}title="{{label.category.name}} - {{label.value}} ({{label.abbreviation}})"{{/if}}>
-                {{#if label}}
-                    <span class="abbreviation">{{label.abbreviation}}</span>
-                    <span class="label-value print">{{label.value}}</span>
-                    {{#if scalevalue}}
-                        <span class="scalevalue print">{{scalevalue.name}} ({{scalevalue.value}})</span>
-                    {{/if}}
-                {{else}}
-                    <span class="no-label">{{text}}</span>
+        <span
+            class="category"
+            {{#if label}}
+                title="{{label.category.name}} - {{label.value}} ({{label.abbreviation}})"
+            {{/if}}
+        >
+            {{#if label}}
+                <span class="abbreviation">{{label.abbreviation}}</span>
+                <span class="label-value print">{{label.value}}</span>
+                {{#if scalevalue}}
+                    <span class="scalevalue print">
+                        {{scalevalue.name}} ({{scalevalue.value}})
+                    </span>
                 {{/if}}
+            {{else}}
+                <span class="no-label">{{text}}</span>
+            {{/if}}
         </span>
     </div>
 
     <div class="right">
         {{#if isMine}}
-        <i class="delete icon-trash" title="{{t "annotation.edit.delete"}}"></i>
-
-        <i class="toggle-edit icon-pencil" title="{{t "annotation.edit.edit"}}"></i>
+            <i
+                class="delete icon-trash"
+                title="{{t "annotation.edit.delete"}}"
+            ></i>
+            <i
+                class="toggle-edit icon-pencil"
+                title="{{t "annotation.edit.edit"}}"
+            ></i>
         {{/if}}
 
-        <i class="{{#if numberOfComments}}icon-comment-amount{{else}}icon-comment{{/if}}" title="{{t "annotation.comments.count" count=numberOfComments}}">
+        <i
+            class="{{#if numberOfComments}}
+                icon-comment-amount
+            {{else}}
+                icon-comment
+            {{/if}}"
+            title="{{t "annotation.comments.count" count=numberOfComments}}"
+        >
             {{#if numberOfComments}}
-            <span class="comment-amount">{{numberOfComments}}</span>
+                <span class="comment-amount">
+                    {{numberOfComments}}
+                </span>
             {{/if}}
         </i>
     </div>
 </div>
 
 {{#unless label}}
-<div id="text-container{{id}}" class="in text-container">
-    <span class="text">
+    <div id="text-container{{id}}" class="in text-container">
+        <span class="text">
             <span class="freetext">
-                <textarea placeholder="{{t "annotation.edit.free text placeholder"}}" style="height: {{textHeight}}px">{{text}}</textarea>
+                <textarea
+                    placeholder="{{t "annotation.edit.free text placeholder"}}"
+                    style="height: {{textHeight}}px"
+                >{{text}}</textarea>
             </span>
             <div class="button-bar">
-                <button type="button" class="btn">Cancel</button>
-                <button type="submit" class="btn btn-primary">OK</button>
+                <button type="button" class="btn">
+                    Cancel
+                </button>
+                <button type="submit" class="btn btn-primary">
+                    OK
+                </button>
             </div>
-    </span>
-</div>
+        </span>
+    </div>
 {{/unless}}
 
 <div class="comments"></div>

--- a/frontend/templates/list-annotation-edit.tmpl
+++ b/frontend/templates/list-annotation-edit.tmpl
@@ -31,7 +31,7 @@
                 id="end-{{id}}"
                 class="end-value"
                 type="text"
-                value="{{end start duration}}"
+                value="{{time end}}"
             ></input>
         </span>
         <button

--- a/frontend/templates/list-annotation-expanded.tmpl
+++ b/frontend/templates/list-annotation-expanded.tmpl
@@ -8,46 +8,80 @@
             {{time start}}
         </span>
 
-        <span class="end {{#if duration}}has-duration{{else}}no-duration{{/if}} read-only">
-               {{end start duration}}
+        <span class="
+            end
+            {{#if duration}}
+                has-duration
+            {{else}}
+                no-duration
+            {{/if}}
+            read-only
+        ">
+            {{end start duration}}
         </span>
 
         {{#if isMine}}
-        <i class="private icon-user" title="{{t "annotation.you own"}}"></i>
+            <i
+                class="private icon-user"
+                title="{{t "annotation.you own"}}"
+            ></i>
         {{/if}}
 
         {{#if scalevalue}}
-        <span class="scaling">
+            <span class="scaling">
                 {{#if scalevalue}}
-                <span class="read-only" title="{{scalevalue.name}}">{{scalevalue.name}}</span>
+                    <span
+                        class="read-only"
+                        title="{{scalevalue.name}}"
+                    >{{scalevalue.name}}</span>
                 {{/if}}
-        </span>
+            </span>
         {{/if}}
 
-
-        <span class="category" {{#if label}}title="{{label.category.name}} - {{label.value}} ({{label.abbreviation}})"{{/if}}>
-                {{#if label}}
-                    <span class="abbreviation">{{label.abbreviation}}</span>
-                    <span class="label-value print">{{label.value}}</span>
-                    {{#if scalevalue}}
-                        <span class="scalevalue print">{{scalevalue.name}} ({{scalevalue.value}})</span>
-                    {{/if}} 
-                {{else}}
-                    <span class="no-label">{{text}}</span>
+        <span
+            class="category"
+            {{#if label}}
+                title="{{label.category.name}} - {{label.value}} ({{label.abbreviation}})"
+            {{/if}}
+        >
+            {{#if label}}
+                <span class="abbreviation">{{label.abbreviation}}</span>
+                <span class="label-value print">{{label.value}}</span>
+                {{#if scalevalue}}
+                    <span class="scalevalue print">
+                        {{scalevalue.name}} ({{scalevalue.value}})
+                    </span>
                 {{/if}}
+            {{else}}
+                <span class="no-label">{{text}}</span>
+            {{/if}}
         </span>
     </div>
 
     <div class="right">
         {{#if isMine}}
-        <i class="delete icon-trash" title="{{t "annotation.edit.delete"}}"></i>
-
-        <i class="toggle-edit icon-pencil" title="{{t "annotation.edit.edit"}}"></i>
+            <i
+                class="delete icon-trash"
+                title="{{t "annotation.edit.delete"}}"
+            ></i>
+            <i
+                class="toggle-edit icon-pencil"
+                title="{{t "annotation.edit.edit"}}"
+            ></i>
         {{/if}}
 
-        <i class="{{#if numberOfComments}}icon-comment-amount{{else}}icon-comment{{/if}}" title="{{t "annotation.comments.count" count=numberOfComments}}">
+        <i
+            class="{{#if numberOfComments}}
+                icon-comment-amount
+            {{else}}
+                icon-comment
+            {{/if}}"
+            title="{{t "annotation.comments.count" count=numberOfComments}}"
+        >
             {{#if numberOfComments}}
-            <span class="comment-amount">{{numberOfComments}}</span>
+                <span class="comment-amount">
+                    {{numberOfComments}}
+                </span>
             {{/if}}
         </i>
     </div>
@@ -55,9 +89,12 @@
 
 <div id="text-container{{id}}" class="text-container">
     <div class="creator-info">
-        {{t "annotation.author"}} <span class="user">{{created_by_nickname}}</span>
-        {{t "annotation.created"}} <span class="created">{{formatDate created_at}}</span>
-        {{t "annotation.track"}} <span class="track">{{track}}</span>
+        {{t "annotation.author"}}
+        <span class="user">{{created_by_nickname}}</span>
+        {{t "annotation.created"}}
+        <span class="created">{{formatDate created_at}}</span>
+        {{t "annotation.track"}}
+        <span class="track">{{track}}</span>
     </div>
     <span class="text freetext read-only">
         {{#if label}}

--- a/frontend/templates/list-annotation-expanded.tmpl
+++ b/frontend/templates/list-annotation-expanded.tmpl
@@ -17,7 +17,7 @@
             {{/if}}
             read-only
         ">
-            {{end start duration}}
+            {{time end}}
         </span>
 
         {{#if isMine}}

--- a/frontend/templates/list-annotation.tmpl
+++ b/frontend/templates/list-annotation.tmpl
@@ -17,7 +17,7 @@
             {{/if}}
             read-only"
         >
-            {{end start duration}}
+            {{time end}}
         </span>
 
         {{#if isMine}}

--- a/frontend/templates/list-annotation.tmpl
+++ b/frontend/templates/list-annotation.tmpl
@@ -8,39 +8,71 @@
             {{time start}}
         </span>
 
-        <span class="end {{#if duration}}has-duration{{else}}no-duration{{/if}} read-only">
-               {{end start duration}}
+        <span class="
+            end
+            {{#if duration}}
+                has-duration
+            {{else}}
+                no-duration
+            {{/if}}
+            read-only"
+        >
+            {{end start duration}}
         </span>
 
         {{#if isMine}}
-        <i class="private icon-user" title="{{t "annotation.you own"}}"></i>
+            <i
+                class="private icon-user"
+                title="{{t "annotation.you own"}}"
+            ></i>
         {{/if}}
 
         {{#if scalevalue}}
-        <span class="scaling">
+            <span class="scaling">
                 {{#if scalevalue}}
-                <span class="read-only" title="{{scalevalue.name}}">{{scalevalue.name}}</span>
+                    <span
+                        class="read-only"
+                        title="{{scalevalue.name}}"
+                    >{{scalevalue.name}}</span>
                 {{/if}}
-        </span>
+            </span>
         {{/if}}
 
-        <span class="category" {{#if label}}title="{{label.category.name}} - {{label.value}} ({{label.abbreviation}})"{{/if}}>
-                {{#if label}}
-                    <span class="abbreviation">{{label.abbreviation}}</span>
-                    <span class="label-value print">{{label.value}}</span>
-                    {{#if scalevalue}}
-                        <span class="scalevalue print">{{scalevalue.name}} ({{scalevalue.value}})</span>
-                    {{/if}}
-                {{else}}
-                    <span class="no-label">{{text}}</span>
+        <span
+            class="category"
+            {{#if label}}
+                title="{{label.category.name}} - {{label.value}} ({{label.abbreviation}})"
+            {{/if}}
+        >
+            {{#if label}}
+                <span class="abbreviation">
+                    {{label.abbreviation}}
+                </span>
+                <span class="label-value print">
+                    {{label.value}}
+                </span>
+                {{#if scalevalue}}
+                    <span class="scalevalue print">
+                        {{scalevalue.name}} ({{scalevalue.value}})
+                    </span>
                 {{/if}}
+            {{else}}
+                <span class="no-label">{{text}}</span>
+            {{/if}}
         </span>
     </div>
 
     <div class="right">
-        <i class="{{#if numberOfComments}}icon-comment-amount{{else}}icon-comment{{/if}}" title="{{t "annotation.comments.count" count=numberOfComments}}">
+        <i
+            class="{{#if numberOfComments}}
+                icon-comment-amount
+            {{else}}
+                icon-comment
+            {{/if}}"
+            title="{{t "annotation.comments.count" count=numberOfComments}}"
+        >
             {{#if numberOfComments}}
-            <span class="comment-amount">{{numberOfComments}}</span>
+                <span class="comment-amount">{{numberOfComments}}</span>
             {{/if}}
         </i>
     </div>

--- a/frontend/templates/timeline-placeholder.tmpl
+++ b/frontend/templates/timeline-placeholder.tmpl
@@ -7,15 +7,13 @@
     title="{{t "timeline.hidden items" count=hiddenItems.length}}"
     data-content="<dl>
         {{#each hiddenItems}}
-            {{#with annotation.attributes}}
-                <dt>
-                    {{time this.start}}{{!
-                    }}{{#if this.duration}}{{!
-                        }}&ndash;{{!
-                        }}{{end this.start this.duration}}{{!
-                    }}{{/if}}
-                </dt>
-            {{/with}}
+            <dt>
+                {{time start}}{{!
+                }}{{#if end}}{{!
+                    }}&ndash;{{!
+                    }}{{time end}}{{!
+                }}{{/if}}
+            </dt>
             <dd>
                 {{itemContent}}
             </dd>

--- a/frontend/templates/timeline-placeholder.tmpl
+++ b/frontend/templates/timeline-placeholder.tmpl
@@ -1,24 +1,24 @@
 <div
-  class="timeline-item timeline-placeholder"
-  data-track="{{track}}"
-  data-toggle="popover"
-  data-trigger="hover"
-  data-placement="top"
-  title="{{t "timeline.hidden items" count=hiddenItems.length}}"
-  data-content="
-    <dl>
-      {{#each hiddenItems}}
-        {{#with annotation.attributes}}
-          <dt>
-            {{time this.start}}{{#if this.duration}}&ndash;{{end this.start this.duration}}{{/if}}
-          </dt>
-        {{/with}}
-        <dd>
-          {{itemContent}}
-        </dd>
-      {{/each}}
-    </dl>
-  "
->
-  {{t "timeline.hidden items" count=hiddenItems.length}}
-</div>
+    class="timeline-item timeline-placeholder"
+    data-track="{{track}}"
+    data-toggle="popover"
+    data-trigger="hover"
+    data-placement="top"
+    title="{{t "timeline.hidden items" count=hiddenItems.length}}"
+    data-content="<dl>
+        {{#each hiddenItems}}
+            {{#with annotation.attributes}}
+                <dt>
+                    {{time this.start}}{{!
+                    }}{{#if this.duration}}{{!
+                        }}&ndash;{{!
+                        }}{{end this.start this.duration}}{{!
+                    }}{{/if}}
+                </dt>
+            {{/with}}
+            <dd>
+                {{itemContent}}
+            </dd>
+        {{/each}}
+    </dl>"
+>{{t "timeline.hidden items" count=hiddenItems.length}}</div>


### PR DESCRIPTION
I'm using the opportunity of working on porting the annotation tool over to the new vis.js timeline to improve some related issues in the codebase. This should help make the migration easier, and also improve the overall quality of the code. Maybe it even fixes some bugs in passing, although I would probably create separate pull requests for that. :wink:

I'm creating this draft PR for multiple reasons:

* The stakeholders can see that work towards the timeline migration is happening, even if it is not directly related or visible.
* They and other interested parties can already test these changes and possibly find regressions or newly introduced bugs before such a big change as the timeline migration.
* The poor soul who has to review the timeline PR at some point doesn't have to review all these little changes at the same time. They (or someone else :wink:) can do it separately.

As for the content of this PR: When you look at this, don't pay too much attention to the code changes themselves (unless you care about this stuff, of course). The purpose here is rather to find out whether I accidentally broke stuff. **The changes in this PR should not change the behavior of the application.*** Also note that I am not hesitating to rewrite the history of this branch, or force-push for any other reason.

\* As said, it might "accidentally" fix a bug, in which case I won't bother to extract it into its own PR, probably. I also won't pay too much attention to the old timeline, because this PR is in preparation for a complete replacement of that component.

---

**Note**: This now contains #265 and #267.