### PR TITLE
Remove annotations access control from the `Annotations` collection

### DIFF
--- a/frontend/js/collections/annotations.js
+++ b/frontend/js/collections/annotations.js
@@ -48,7 +48,7 @@ define([
          * constructor
          * @alias module:collections-annotations.Annotations#initialize
          */
-        initialize: function (models, track) {
+        initialize: function (models, options) {
             _.bindAll(this, "updateAccess", "setAccess");
 
             /**
@@ -58,10 +58,10 @@ define([
              */
             this.access = undefined;
 
-            if (!_.isUndefined(track)) {
-                this.track = track;
-                track.on("change:access", this.updateAccess, this);
-                this.updateAccess(track);
+            if (!_.isUndefined(options.track)) {
+                this.track = options.track;
+                this.track.on("change:access", this.updateAccess, this);
+                this.updateAccess(options.track);
             }
 
             if (!_.isUndefined(models) && _.isArray(models) && models.length > 0 && !(models[0] instanceof Annotation)) {

--- a/frontend/js/collections/annotations.js
+++ b/frontend/js/collections/annotations.js
@@ -21,7 +21,7 @@
 define([
     "underscore",
     "models/annotation",
-    "backbone",
+    "backbone"
 ], function (
     _,
     Annotation,
@@ -37,7 +37,6 @@ define([
      * @alias module:collections-annotations.Annotations
      */
     var Annotations = Backbone.Collection.extend({
-
         /**
          * Model of the instances contained in this collection
          * @alias module:collections-annotations.Annotations#initialize
@@ -49,26 +48,7 @@ define([
          * @alias module:collections-annotations.Annotations#initialize
          */
         initialize: function (models, options) {
-            _.bindAll(this, "updateAccess", "setAccess");
-
-            /**
-             * Access value for all the annotations in the collection
-             * @alias module:collections-annotations.Annotations#access
-             * @type {integer}
-             */
-            this.access = undefined;
-
-            if (!_.isUndefined(options.track)) {
-                this.track = options.track;
-                this.track.on("change:access", this.updateAccess, this);
-                this.updateAccess(options.track);
-            }
-
-            if (!_.isUndefined(models) && _.isArray(models) && models.length > 0 && !(models[0] instanceof Annotation)) {
-                _.each(models, function (annotation) {
-                    this.create(annotation);
-                }, this);
-            }
+            this.track = options.track;
         },
 
         /**
@@ -81,32 +61,6 @@ define([
         },
 
         /**
-         * Listener on track acess changes, keep the annotations access value up to date.
-         * @alias module:collections-annotations.Annotations#updateAccess
-         * @param  {object} [track] The track containing the annotations
-         */
-        updateAccess: function (track) {
-            var newAccess = (_.isUndefined(track)) ? this.track.get("access") : track.get("access");
-            if (this.access !== newAccess) {
-                this.access = newAccess;
-                this.each(this.setAccess, this);
-            }
-        },
-
-        /**
-         * Set access for the model
-         * @alias module:collections-annotations.Annotations#setAccess
-         * @param {model} model The model to update
-         */
-        setAccess: function (model) {
-            if (!_.isUndefined(model.attributes)) {
-                model.set({ access: this.access }, { silent: true });
-            } else {
-                model.access = this.access;
-            }
-        },
-
-        /**
          * Parse the given data
          * @alias module:collections-annotations.Annotations#parse
          * @param  {object} data Object or array containing the data to parse.
@@ -114,10 +68,8 @@ define([
          */
         parse: function (data) {
             if (data.annotations && _.isArray(data.annotations)) {
-                _.each(data.annotations, this.setAccess, this);
                 return data.annotations;
             } else if (_.isArray(data)) {
-                _.each(data, this.setAccess, this);
                 return data;
             } else {
                 return null;

--- a/frontend/js/collections/annotations.js
+++ b/frontend/js/collections/annotations.js
@@ -18,110 +18,112 @@
  * A module representing an annotations collection
  * @module collections-annotations
  */
-define(["underscore",
-        "models/annotation",
-        "backbone"],
+define([
+    "underscore",
+    "models/annotation",
+    "backbone",
+], function (
+    _,
+    Annotation,
+    Backbone
+) {
+    "use strict";
 
-    function (_, Annotation, Backbone) {
-
-        "use strict";
+    /**
+     * @constructor
+     * @see {@link http://www.backbonejs.org/#Collection}
+     * @augments module:Backbone.Collection
+     * @memberOf module:collections-annotations
+     * @alias module:collections-annotations.Annotations
+     */
+    var Annotations = Backbone.Collection.extend({
 
         /**
-         * @constructor
-         * @see {@link http://www.backbonejs.org/#Collection}
-         * @augments module:Backbone.Collection
-         * @memberOf module:collections-annotations
-         * @alias module:collections-annotations.Annotations
+         * Model of the instances contained in this collection
+         * @alias module:collections-annotations.Annotations#initialize
          */
-        var Annotations = Backbone.Collection.extend({
+        model: Annotation,
+
+        /**
+         * constructor
+         * @alias module:collections-annotations.Annotations#initialize
+         */
+        initialize: function (models, track) {
+            _.bindAll(this, "updateAccess", "setAccess");
 
             /**
-             * Model of the instances contained in this collection
-             * @alias module:collections-annotations.Annotations#initialize
+             * Access value for all the annotations in the collection
+             * @alias module:collections-annotations.Annotations#access
+             * @type {integer}
              */
-            model: Annotation,
+            this.access = undefined;
 
-            /**
-             * constructor
-             * @alias module:collections-annotations.Annotations#initialize
-             */
-            initialize: function (models, track) {
-                _.bindAll(this, "updateAccess", "setAccess");
-
-                /**
-                 * Access value for all the annotations in the collection
-                 * @alias module:collections-annotations.Annotations#access
-                 * @type {integer}
-                 */
-                this.access = undefined;
-
-                if (!_.isUndefined(track)) {
-                    this.track = track;
-                    track.on("change:access", this.updateAccess, this);
-                    this.updateAccess(track);
-                }
-
-                if (!_.isUndefined(models) && _.isArray(models) && models.length > 0 && !(models[0] instanceof Annotation)) {
-                    _.each(models, function (annotation) {
-                        this.create(annotation);
-                    }, this);
-                }
-            },
-
-            /**
-             * Get the url for this collection
-             * @alias module:collections-annotations.Annotations#url
-             * @return {String} The url of this collection
-             */
-            url: function () {
-                return _.result(this.track, "url") + "/annotations";
-            },
-
-            /**
-             * Listener on track acess changes, keep the annotations access value up to date.
-             * @alias module:collections-annotations.Annotations#updateAccess
-             * @param  {object} [track] The track containing the annotations
-             */
-            updateAccess: function (track) {
-                var newAccess = (_.isUndefined(track)) ? this.track.get("access") : track.get("access");
-                if (this.access !== newAccess) {
-                    this.access = newAccess;
-                    this.each(this.setAccess, this);
-                }
-            },
-
-            /**
-             * Set access for the model
-             * @alias module:collections-annotations.Annotations#setAccess
-             * @param {model} model The model to update
-             */
-            setAccess: function (model) {
-                if (!_.isUndefined(model.attributes)) {
-                    model.set({ access: this.access }, { silent: true });
-                } else {
-                    model.access = this.access;
-                }
-            },
-
-            /**
-             * Parse the given data
-             * @alias module:collections-annotations.Annotations#parse
-             * @param  {object} data Object or array containing the data to parse.
-             * @return {object}      the part of the given data related to the annotations
-             */
-            parse: function (data) {
-                if (data.annotations && _.isArray(data.annotations)) {
-                    _.each(data.annotations, this.setAccess, this);
-                    return data.annotations;
-                } else if (_.isArray(data)) {
-                    _.each(data, this.setAccess, this);
-                    return data;
-                } else {
-                    return null;
-                }
+            if (!_.isUndefined(track)) {
+                this.track = track;
+                track.on("change:access", this.updateAccess, this);
+                this.updateAccess(track);
             }
-        });
 
-        return Annotations;
-    }
-);
+            if (!_.isUndefined(models) && _.isArray(models) && models.length > 0 && !(models[0] instanceof Annotation)) {
+                _.each(models, function (annotation) {
+                    this.create(annotation);
+                }, this);
+            }
+        },
+
+        /**
+         * Get the url for this collection
+         * @alias module:collections-annotations.Annotations#url
+         * @return {String} The url of this collection
+         */
+        url: function () {
+            return _.result(this.track, "url") + "/annotations";
+        },
+
+        /**
+         * Listener on track acess changes, keep the annotations access value up to date.
+         * @alias module:collections-annotations.Annotations#updateAccess
+         * @param  {object} [track] The track containing the annotations
+         */
+        updateAccess: function (track) {
+            var newAccess = (_.isUndefined(track)) ? this.track.get("access") : track.get("access");
+            if (this.access !== newAccess) {
+                this.access = newAccess;
+                this.each(this.setAccess, this);
+            }
+        },
+
+        /**
+         * Set access for the model
+         * @alias module:collections-annotations.Annotations#setAccess
+         * @param {model} model The model to update
+         */
+        setAccess: function (model) {
+            if (!_.isUndefined(model.attributes)) {
+                model.set({ access: this.access }, { silent: true });
+            } else {
+                model.access = this.access;
+            }
+        },
+
+        /**
+         * Parse the given data
+         * @alias module:collections-annotations.Annotations#parse
+         * @param  {object} data Object or array containing the data to parse.
+         * @return {object}      the part of the given data related to the annotations
+         */
+        parse: function (data) {
+            if (data.annotations && _.isArray(data.annotations)) {
+                _.each(data.annotations, this.setAccess, this);
+                return data.annotations;
+            } else if (_.isArray(data)) {
+                _.each(data, this.setAccess, this);
+                return data;
+            } else {
+                return null;
+            }
+        }
+    });
+
+    return Annotations;
+});

--- a/frontend/js/collections/categories.js
+++ b/frontend/js/collections/categories.js
@@ -45,8 +45,8 @@ define(["underscore",
              * constructor
              * @alias module:collections-categories.Categories#initialize
              */
-            initialize: function (models, video) {
-                this.video = video;
+            initialize: function (models, options) {
+                this.video = options.video;
             },
 
             /**

--- a/frontend/js/collections/labels.js
+++ b/frontend/js/collections/labels.js
@@ -45,8 +45,8 @@ define(["underscore",
              * constructor
              * @alias module:collections-labels.Labels#initialize
              */
-            initialize: function (models, category) {
-                this.category = category;
+            initialize: function (models, options) {
+                this.category = options.category;
             },
 
             /**

--- a/frontend/js/collections/scales.js
+++ b/frontend/js/collections/scales.js
@@ -45,8 +45,8 @@ define(["underscore",
              * constructor
              * @alias module:collections-scales.Scales#initialize
              */
-            initialize: function (models, video) {
-                this.video = video;
+            initialize: function (models, options) {
+                this.video = options.video;
             },
 
             /**

--- a/frontend/js/collections/scalevalues.js
+++ b/frontend/js/collections/scalevalues.js
@@ -45,8 +45,8 @@ define(["underscore",
              * constructor
              * @alias module:collections-scalevalues.ScaleValues#initialize
              */
-            initialize: function (models, scale) {
-                this.scale = scale;
+            initialize: function (models, options) {
+                this.scale = options.scale;
             },
 
             /**

--- a/frontend/js/collections/tracks.js
+++ b/frontend/js/collections/tracks.js
@@ -56,7 +56,7 @@ define(["underscore",
              * constructor
              * @alias module:collections-tracks.Tracks#initialize
              */
-            initialize: function (models, video) {
+            initialize: function (models, options) {
                 _.bindAll(this, "showTracks",
                                 "showTracksById",
                                 "hideTracks",
@@ -65,7 +65,7 @@ define(["underscore",
                                 "getAllCreators",
                                 "showTracksByCreators");
 
-                this.video = video;
+                this.video = options.video;
 
                 this.on("add", function (track) {
                     // Show the new track

--- a/frontend/js/models/category.js
+++ b/frontend/js/models/category.js
@@ -76,12 +76,12 @@ define(["underscore",
                 this.set("settings", _.extend({ hasScale: true }, this.get("settings")));
 
                 if (attr.labels && _.isArray(attr.labels)) {
-                    this.attributes.labels  = new Labels(attr.labels, this);
+                    this.attributes.labels  = new Labels(attr.labels, { category: this });
                     delete attr.labels;
                 } else if (!attr.labels) {
-                    this.attributes.labels  = new Labels([], this);
+                    this.attributes.labels  = new Labels([], { category: this });
                 } else if (_.isObject(attr.labels) && attr.labels.model) {
-                    this.attributes.labels = new Labels(attr.labels.models, this);
+                    this.attributes.labels = new Labels(attr.labels.models, { category: this });
                     delete attr.labels;
                 }
 
@@ -101,7 +101,7 @@ define(["underscore",
             parse: function (data) {
                 return Resource.prototype.parse.call(this, data, function (attr) {
                     if (annotationTool.localStorage && _.isArray(attr.labels)) {
-                        attr.labels = new Labels(attr.labels, this);
+                        attr.labels = new Labels(attr.labels, { category: this });
                     }
 
                     if (!annotationTool.localStorage && attr.scale_id && (_.isNumber(attr.scale_id) || _.isString(attr.scale_id))) {

--- a/frontend/js/models/scale.js
+++ b/frontend/js/models/scale.js
@@ -72,9 +72,9 @@ define(["underscore",
                 Resource.prototype.initialize.apply(this, arguments);
 
                 if (attr.scaleValues && _.isArray(attr.scaleValues)) {
-                    this.set({ scaleValues: new ScaleValues(attr.scaleValues, this) });
+                    this.set({ scaleValues: new ScaleValues(attr.scaleValues, { scale: this }) });
                 } else {
-                    this.set({ scaleValues: new ScaleValues([], this) });
+                    this.set({ scaleValues: new ScaleValues([], { scale: this }) });
                 }
 
                 if (attr.id) {

--- a/frontend/js/models/track.js
+++ b/frontend/js/models/track.js
@@ -71,9 +71,9 @@ define(["underscore",
                 });
 
                 if (attr.annotations && _.isArray(attr.annotations)) {
-                    this.set({ annotations: new Annotations(attr.annotations, this) });
+                    this.set({ annotations: new Annotations(attr.annotations, { track: this }) });
                 } else {
-                    this.set({ annotations: new Annotations([], this) });
+                    this.set({ annotations: new Annotations([], { track: this }) });
                 }
             },
 

--- a/frontend/js/models/video.js
+++ b/frontend/js/models/video.js
@@ -75,23 +75,23 @@ define(["underscore",
 
                 // Check if tracks are given
                 if (attr.tracks && _.isArray(attr.tracks)) {
-                    this.set({ tracks: new Tracks(attr.tracks, this) });
+                    this.set({ tracks: new Tracks(attr.tracks, { video: this }) });
                 }  else {
-                    this.set({ tracks: new Tracks([], this) });
+                    this.set({ tracks: new Tracks([], { video: this }) });
                 }
 
                 // Check if supported categories are given
                 if (attr.categories && _.isArray(attr.categories)) {
-                    this.set({ categories: new Categories(attr.categories, this) });
+                    this.set({ categories: new Categories(attr.categories, { video: this }) });
                 } else {
-                    this.set({ categories: new Categories([], this) });
+                    this.set({ categories: new Categories([], { video: this }) });
                 }
 
                 // Check if the possible video scales are given
                 if (attr.scales && _.isArray(attr.scales)) {
-                    this.set({ scales: new Scales(attr.scales, this) });
+                    this.set({ scales: new Scales(attr.scales, { video: this }) });
                 } else {
-                    this.set({ scales: new Scales([], this) });
+                    this.set({ scales: new Scales([], { video: this }) });
                 }
 
                 if (attr.id) {


### PR DESCRIPTION
The `Annotations` collection manages the `access` property of its children based on its parent `Track`. This is unnecessary, though, since `Annotation#access` is never used for anything.

Also: If we ever **do** need it, I would prefer a getter on `Annotation`.