### PR TITLE
Clean up the menu some

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,7 +28,6 @@
             <span id="video-title" class="brand"><span data-i18n="title"></span> - <%= version %></span>
 
             <ul class="nav pull-right">
-              <li><button type="button" id="about" data-i18n="menu.about"></button></li>
               <li class="dropdown" id="view-options">
                 <button type="button" class="dropdown-toggle" data-toggle="dropdown">
                   <span data-i18n="menu.view.head"></span> <b class="caret"></b>
@@ -79,9 +78,31 @@
                   <li><button type="button" class="opt-tracks-select" data-i18n="menu.view.track management"></button></li>
                 </ul>
               </li>
-              <li><button type="button" id="export" data-i18n="menu.export"></button></li>
-              <li><button type="button" id="print" data-i18n="menu.print"></button></li>
-              <li><button type="button" id="logout"></button></li>
+              <li class="dropdown">
+                <button type="button" class="dropdown-toggle" data-toggle="dropdown">
+                  <span data-i18n="menu.processing.head"></span> <b class="caret"></b>
+                </button>
+                <ul class="dropdown-menu">
+                  <li><button type="button" id="export" data-i18n="menu.processing.export"></button></li>
+                  <li><button type="button" id="print" data-i18n="menu.processing.print"></button></li>
+                </ul>
+              </li>
+              <li class="dropdown">
+                <button type="button" class="dropdown-toggle" data-toggle="dropdown">
+                  <span data-i18n="menu.help.head"></span> <b class="caret"></b>
+                </button>
+                <ul class="dropdown-menu">
+                  <li><button type="button" id="about" data-i18n="menu.help.about"></button></li>
+                </ul>
+              </li>
+              <li id="user-menu" class="dropdown">
+                <button type="button" class="dropdown-toggle" data-toggle="dropdown">
+                  <span id="user-menu-label"></span> <b class="caret"></b>
+                </button>
+                <ul class="dropdown-menu">
+                  <li><button type="button" id="logout" data-i18n="menu.logout"></button></li>
+                </ul>
+              </li>
             </ul>
           </div>
         </div>

--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -160,10 +160,8 @@ define(["jquery",
 
                 this.once(this.EVENTS.USER_LOGGED, function () {
 
-                    $("#logout").html(i18next.t(
-                        "menu.logout",
-                        { username: this.user.get("nickname") }
-                    ));
+                    $("#user-menu-label").html(this.user.get("nickname"));
+                    $("#user-menu").show();
 
                     this.fetchData();
                 }, this);

--- a/frontend/js/views/main.js
+++ b/frontend/js/views/main.js
@@ -519,9 +519,6 @@ define(["jquery",
 
                 this.setupKeyboardShortcuts();
 
-                // Show logout button
-                $("#logout").css("display", "block");
-
                 this.trigger(MainView.EVENTS.READY);
             },
 

--- a/frontend/locales/de/translation.json
+++ b/frontend/locales/de/translation.json
@@ -120,10 +120,16 @@
     "invalid loop length": "Die angegebene Schleifenlänge ist nicht gültig"
   },
   "menu": {
-    "about": "Über diese Software",
-    "export": "Für Statistik exportieren",
-    "logout": "{{username}} abmelden",
-    "print": "Drucken",
+    "help": {
+      "head": "Hilfe",
+      "about": "Über diese Software"
+    },
+    "processing": {
+      "head": "Verarbeiten",
+      "export": "Für Statistik exportieren",
+      "print": "Drucken"
+    },
+    "logout": "Abmelden",
     "view": {
       "annotate": {
         "head": "Annotieren",

--- a/frontend/locales/en/translation.json
+++ b/frontend/locales/en/translation.json
@@ -120,10 +120,16 @@
     "invalid loop length": "The given value for the loop length is not valid!"
   },
   "menu": {
-    "about": "About",
-    "export": "Export for statistics",
-    "logout": "Log out {{username}}",
-    "print": "Print",
+    "help": {
+      "head": "Help",
+      "about": "About"
+    },
+    "processing": {
+      "head": "Process",
+      "export": "Export for statistics",
+      "print": "Print"
+    },
+    "logout": "Log out",
     "view": {
       "annotate": {
         "head": "Annotate",

--- a/frontend/style/annotations/base_layout.less
+++ b/frontend/style/annotations/base_layout.less
@@ -98,11 +98,11 @@ body {
         line-height: @line-height;
         font-weight: normal;
         padding: 0 0 0 1em;
-
-        &#logout {
-            display: none;
-        }
     }
+}
+
+#user-menu {
+    display: none;
 }
 
 // Make Bootstraps dropdown styles work with button elements instead of links


### PR DESCRIPTION
SWITCH wanted to organize the menu bar a bit, and I have to agree that it was kind of a mess before.

I'm not saying this is perfect, but it makes things better overall, I think.

### Screenshots

Before:

![image](https://user-images.githubusercontent.com/123272/69643900-36c6e580-1064-11ea-9d32-bc23ac41b22d.png)

After:

![image](https://user-images.githubusercontent.com/123272/69644011-5e1db280-1064-11ea-9e28-358de2a0ba45.png)

![image](https://user-images.githubusercontent.com/123272/69644033-67a71a80-1064-11ea-940f-df23b8b35a9d.png)

![image](https://user-images.githubusercontent.com/123272/69644052-6e359200-1064-11ea-8803-f76a6fcb2437.png)

![image](https://user-images.githubusercontent.com/123272/69644071-74c40980-1064-11ea-9167-f338a8b0ac8d.png)

"Process" is a bit empty, but will at least still get the Excel export **at some point* (/I promise/); "Help" could also link to some documentation, which we could provide in the future. *cough