### PR TITLE
A little bit of code clean up

### DIFF
--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/AbstractExtendedAnnotationsRestService.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/AbstractExtendedAnnotationsRestService.java
@@ -141,7 +141,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
         if (tagsMap.isSome() && tagsMap.get().isNone())
           return BAD_REQUEST;
 
-        final Option<Map<String, String>> tags = tagsMap.bind(Functions.<Option<Map<String, String>>> identity());
+        final Option<Map<String, String>> tags = tagsMap.bind(Functions.identity());
 
         return eas().getUserByExtId(userExtId).fold(new Option.Match<User, Response>() {
           @Override
@@ -242,7 +242,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
         if (tagsMap.isSome() && tagsMap.get().isNone())
           return BAD_REQUEST;
 
-        Resource resource = eas().createResource(tagsMap.bind(Functions.<Option<Map<String, String>>> identity()));
+        Resource resource = eas().createResource(tagsMap.bind(Functions.identity()));
         final Video v = eas().createVideo(videoExtId, resource);
         return Response.created(videoLocationUri(v))
                 .entity(Strings.asStringNull().apply(VideoDto.toJson.apply(eas(), v))).build();
@@ -267,7 +267,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
         if (tagsMap.isSome() && tagsMap.get().isNone())
           return BAD_REQUEST;
 
-        final Option<Map<String, String>> tags = tagsMap.bind(Functions.<Option<Map<String, String>>> identity());
+        final Option<Map<String, String>> tags = tagsMap.bind(Functions.identity());
 
         return eas().getVideoByExtId(videoExtId).fold(new Option.Match<Video, Response>() {
           @Override
@@ -312,7 +312,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
   public Response postScaleTemplate(@FormParam("name") final String name,
           @FormParam("description") final String description, @FormParam("access") final Integer access,
           @FormParam("tags") final String tags) {
-    return createScale(Option.<Long> none(), name, description, access, tags);
+    return createScale(none(), name, description, access, tags);
   }
 
   Response createScale(final Option<Long> videoId, final String name, final String description,
@@ -325,7 +325,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
                 || (tagsMap.isSome() && tagsMap.get().isNone()))
           return BAD_REQUEST;
 
-        Resource resource = eas().createResource(tagsMap.bind(Functions.<Option<Map<String, String>>> identity()),
+        Resource resource = eas().createResource(tagsMap.bind(Functions.identity()),
                 option(access));
         final Scale scale = eas().createScale(videoId, name, trimToNone(description), resource);
         return Response.created(scaleLocationUri(scale, videoId.isSome()))
@@ -339,7 +339,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
   @Path("/scales/{scaleId}")
   public Response putScale(@PathParam("scaleId") final long id, @FormParam("name") final String name,
           @FormParam("description") final String description, @FormParam("tags") final String tags) {
-    return updateScale(Option.<Long> none(), id, name, description, tags);
+    return updateScale(none(), id, name, description, tags);
   }
 
   Response updateScale(final Option<Long> videoId, final long id, final String name, final String description,
@@ -352,7 +352,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
                 || (tagsMap.isSome() && tagsMap.get().isNone()))
           return BAD_REQUEST;
 
-        final Option<Map<String, String>> tags = tagsMap.bind(Functions.<Option<Map<String, String>>> identity());
+        final Option<Map<String, String>> tags = tagsMap.bind(Functions.identity());
 
         return eas().getScale(id, false).fold(new Option.Match<Scale, Response>() {
           @Override
@@ -386,7 +386,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/scales/{scaleId}")
   public Response getScale(@PathParam("scaleId") final long id) {
-    return getScaleResponse(Option.<Long> none(), id);
+    return getScaleResponse(none(), id);
   }
 
   Response getScaleResponse(final Option<Long> videoId, final long id) {
@@ -419,7 +419,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
   public Response getScales(@QueryParam("limit") final int limit, @QueryParam("offset") final int offset,
           @QueryParam("since") final String date, @QueryParam("tags-and") final String tagsAnd,
           @QueryParam("tags-or") final String tagsOr) {
-    return getScalesResponse(Option.<Long> none(), limit, offset, date, tagsAnd, tagsOr);
+    return getScalesResponse(none(), limit, offset, date, tagsAnd, tagsOr);
   }
 
   Response getScalesResponse(final Option<Long> videoId, final int limit, final int offset, final String date,
@@ -427,8 +427,8 @@ public abstract class AbstractExtendedAnnotationsRestService {
     return run(nil, new Function0<Response>() {
       @Override
       public Response apply() {
-        final Option<Integer> offsetm = offset > 0 ? some(offset) : Option.<Integer> none();
-        final Option<Integer> limitm = limit > 0 ? some(limit) : Option.<Integer> none();
+        final Option<Integer> offsetm = offset > 0 ? some(offset) : none();
+        final Option<Integer> limitm = limit > 0 ? some(limit) : none();
         final Option<Option<Date>> datem = trimToNone(date).map(parseDate);
         final Option<Option<Map<String, String>>> tagsAndArray = trimToNone(tagsAnd).map(parseToJsonMap);
         final Option<Option<Map<String, String>>> tagsOrArray = trimToNone(tagsOr).map(parseToJsonMap);
@@ -441,9 +441,9 @@ public abstract class AbstractExtendedAnnotationsRestService {
           return buildOk(ScaleDto.toJson(
                   eas(),
                   offset,
-                  eas().getScales(videoId, offsetm, limitm, datem.bind(Functions.<Option<Date>> identity()),
-                          tagsAndArray.bind(Functions.<Option<Map<String, String>>> identity()),
-                          tagsOrArray.bind(Functions.<Option<Map<String, String>>> identity()))));
+                  eas().getScales(videoId, offsetm, limitm, datem.bind(Functions.identity()),
+                          tagsAndArray.bind(Functions.identity()),
+                          tagsOrArray.bind(Functions.identity()))));
         }
       }
     });
@@ -452,7 +452,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
   @DELETE
   @Path("/scales/{scaleId}")
   public Response deleteScale(@PathParam("scaleId") final long id) {
-    return deleteScaleResponse(Option.<Long> none(), id);
+    return deleteScaleResponse(none(), id);
   }
 
   Response deleteScaleResponse(final Option<Long> videoId, final long id) {
@@ -485,7 +485,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
           @DefaultValue("0") @FormParam("value") final double value,
           @DefaultValue("0") @FormParam("order") final int order, @FormParam("access") final Integer access,
           @FormParam("tags") final String tags) {
-    return postScaleValueResponse(Option.<Long> none(), scaleId, name, value, order, access, tags);
+    return postScaleValueResponse(none(), scaleId, name, value, order, access, tags);
   }
 
   Response postScaleValueResponse(final Option<Long> videoId, final long scaleId, final String name,
@@ -498,7 +498,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
                 || (tagsMap.isSome() && tagsMap.get().isNone()))
           return BAD_REQUEST;
 
-        Resource resource = eas().createResource(tagsMap.bind(Functions.<Option<Map<String, String>>> identity()),
+        Resource resource = eas().createResource(tagsMap.bind(Functions.identity()),
                 option(access));
         final ScaleValue scaleValue = eas().createScaleValue(scaleId, name, value, order, resource);
 
@@ -515,7 +515,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
           @FormParam("name") final String name, @DefaultValue("0") @FormParam("value") final double value,
           @DefaultValue("0") @FormParam("order") final int order, @FormParam("access") final Integer access,
           @FormParam("tags") final String tags) {
-    return putScaleValueResponse(Option.<Long> none(), scaleId, id, name, value, order, access, tags);
+    return putScaleValueResponse(none(), scaleId, id, name, value, order, access, tags);
   }
 
   Response putScaleValueResponse(final Option<Long> videoId, final long scaleId, final long id,
@@ -528,7 +528,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
                 || (tagsMap.isSome() && tagsMap.get().isNone()))
           return BAD_REQUEST;
 
-        final Option<Map<String, String>> tags = tagsMap.bind(Functions.<Option<Map<String, String>>> identity());
+        final Option<Map<String, String>> tags = tagsMap.bind(Functions.identity());
 
         return eas().getScaleValue(id).fold(new Option.Match<ScaleValue, Response>() {
           @Override
@@ -562,7 +562,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/scales/{scaleId}/scalevalues/{scaleValueId}")
   public Response getScaleValue(@PathParam("scaleId") final long scaleId, @PathParam("scaleValueId") final long id) {
-    return getScaleValueResponse(Option.<Long> none(), scaleId, id);
+    return getScaleValueResponse(none(), scaleId, id);
   }
 
   Response getScaleValueResponse(final Option<Long> videoId, final long scaleId, final long id) {
@@ -595,7 +595,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
   public Response getScaleValues(@PathParam("scaleId") final long scaleId, @QueryParam("limit") final int limit,
           @QueryParam("offset") final int offset, @QueryParam("since") final String date,
           @QueryParam("tags-and") final String tagsAnd, @QueryParam("tags-or") final String tagsOr) {
-    return getScaleValuesResponse(Option.<Long> none(), scaleId, limit, offset, date, tagsAnd, tagsOr);
+    return getScaleValuesResponse(none(), scaleId, limit, offset, date, tagsAnd, tagsOr);
   }
 
   Response getScaleValuesResponse(final Option<Long> videoId, final long scaleId, final int limit,
@@ -603,8 +603,8 @@ public abstract class AbstractExtendedAnnotationsRestService {
     return run(nil, new Function0<Response>() {
       @Override
       public Response apply() {
-        final Option<Integer> offsetm = offset > 0 ? some(offset) : Option.<Integer> none();
-        final Option<Integer> limitm = limit > 0 ? some(limit) : Option.<Integer> none();
+        final Option<Integer> offsetm = offset > 0 ? some(offset) : none();
+        final Option<Integer> limitm = limit > 0 ? some(limit) : none();
         final Option<Option<Date>> datem = trimToNone(date).map(parseDate);
         final Option<Option<Map<String, String>>> tagsAndArray = trimToNone(tagsAnd).map(parseToJsonMap);
         final Option<Option<Map<String, String>>> tagsOrArray = trimToNone(tagsOr).map(parseToJsonMap);
@@ -617,9 +617,9 @@ public abstract class AbstractExtendedAnnotationsRestService {
         return buildOk(ScaleValueDto.toJson(
                 eas(),
                 offset,
-                eas().getScaleValues(scaleId, offsetm, limitm, datem.bind(Functions.<Option<Date>> identity()),
-                        tagsAndArray.bind(Functions.<Option<Map<String, String>>> identity()),
-                        tagsOrArray.bind(Functions.<Option<Map<String, String>>> identity()))));
+                eas().getScaleValues(scaleId, offsetm, limitm, datem.bind(Functions.identity()),
+                        tagsAndArray.bind(Functions.identity()),
+                        tagsOrArray.bind(Functions.identity()))));
       }
     });
   }
@@ -627,7 +627,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
   @DELETE
   @Path("/scales/{scaleId}/scalevalues/{scaleValueId}")
   public Response deleteScaleValue(@PathParam("scaleId") final long scaleId, @PathParam("scaleValueId") final long id) {
-    return deleteScaleValueResponse(Option.<Long> none(), scaleId, id);
+    return deleteScaleValueResponse(none(), scaleId, id);
   }
 
   Response deleteScaleValueResponse(final Option<Long> videoId, final long scaleId, final long id) {
@@ -661,7 +661,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
           @FormParam("description") final String description,
           @FormParam("scale_id") final Long scaleId, @FormParam("settings") final String settings,
           @FormParam("access") final Integer access, @FormParam("tags") final String tags) {
-    return postCategoryResponse(Option.<Long> none(), name, description, scaleId, settings, access, tags);
+    return postCategoryResponse(none(), name, description, scaleId, settings, access, tags);
   }
 
   Response postCategoryResponse(final Option<Long> videoId, final String name, final String description,
@@ -674,7 +674,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
                 || (tagsMap.isSome() && tagsMap.get().isNone()))
           return BAD_REQUEST;
 
-        Resource resource = eas().createResource(tagsMap.bind(Functions.<Option<Map<String, String>>> identity()),
+        Resource resource = eas().createResource(tagsMap.bind(Functions.identity()),
                 option(access));
         final Category category = eas().createCategory(videoId, option(scaleId), name, trimToNone(description),
                 trimToNone(settings), resource);
@@ -692,8 +692,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
           @FormParam("description") final String description,
           @FormParam("scale_id") final Long scaleId, @FormParam("settings") final String settings,
           @FormParam("tags") final String tags) {
-    return putCategoryResponse(Option.<Long> none(), id, name, description, option(scaleId), settings,
-            tags);
+    return putCategoryResponse(none(), id, name, description, option(scaleId), settings, tags);
   }
 
   Response putCategoryResponse(final Option<Long> videoId, final long id, final String name,
@@ -706,7 +705,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
                 || (tagsMap.isSome() && tagsMap.get().isNone()))
           return BAD_REQUEST;
 
-        final Option<Map<String, String>> tags = tagsMap.bind(Functions.<Option<Map<String, String>>> identity());
+        final Option<Map<String, String>> tags = tagsMap.bind(Functions.identity());
 
         return eas().getCategory(id, false).fold(new Option.Match<Category, Response>() {
           @Override
@@ -742,7 +741,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/categories/{categoryId}")
   public Response getCategory(@PathParam("categoryId") final long id) {
-    return getCategoryResponse(Option.<Long> none(), id);
+    return getCategoryResponse(none(), id);
   }
 
   Response getCategoryResponse(final Option<Long> videoId, final long id) {
@@ -775,7 +774,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
   public Response getCategories(@QueryParam("limit") final int limit, @QueryParam("offset") final int offset,
           @QueryParam("since") final String date, @QueryParam("tags-and") final String tagsAnd,
           @QueryParam("tags-or") final String tagsOr) {
-    return getCategoriesResponse(Option.<Long> none(), limit, offset, date, tagsAnd, tagsOr);
+    return getCategoriesResponse(none(), limit, offset, date, tagsAnd, tagsOr);
   }
 
   Response getCategoriesResponse(final Option<Long> videoId, final int limit, final int offset,
@@ -783,8 +782,8 @@ public abstract class AbstractExtendedAnnotationsRestService {
     return run(nil, new Function0<Response>() {
       @Override
       public Response apply() {
-        final Option<Integer> offsetm = offset > 0 ? some(offset) : Option.<Integer> none();
-        final Option<Integer> limitm = limit > 0 ? some(limit) : Option.<Integer> none();
+        final Option<Integer> offsetm = offset > 0 ? some(offset) : none();
+        final Option<Integer> limitm = limit > 0 ? some(limit) : none();
         final Option<Option<Date>> datem = trimToNone(date).map(parseDate);
         final Option<Option<Map<String, String>>> tagsAndArray = trimToNone(tagsAnd).map(parseToJsonMap);
         final Option<Option<Map<String, String>>> tagsOrArray = trimToNone(tagsOr).map(parseToJsonMap);
@@ -797,9 +796,9 @@ public abstract class AbstractExtendedAnnotationsRestService {
           return buildOk(CategoryDto.toJson(
                   eas(),
                   offset,
-                  eas().getCategories(videoId, offsetm, limitm, datem.bind(Functions.<Option<Date>> identity()),
-                          tagsAndArray.bind(Functions.<Option<Map<String, String>>> identity()),
-                          tagsOrArray.bind(Functions.<Option<Map<String, String>>> identity()))));
+                  eas().getCategories(videoId, offsetm, limitm, datem.bind(Functions.identity()),
+                          tagsAndArray.bind(Functions.identity()),
+                          tagsOrArray.bind(Functions.identity()))));
         }
       }
     });
@@ -808,7 +807,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
   @DELETE
   @Path("/categories/{categoryId}")
   public Response deleteCategory(@PathParam("categoryId") final long categoryId) {
-    return deleteCategoryResponse(Option.<Long> none(), categoryId);
+    return deleteCategoryResponse(none(), categoryId);
   }
 
   Response deleteCategoryResponse(final Option<Long> videoId, final long categoryId) {
@@ -842,7 +841,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
           @FormParam("abbreviation") final String abbreviation, @FormParam("description") final String description,
           @FormParam("access") final Integer access, @FormParam("settings") final String settings,
           @FormParam("tags") final String tags) {
-    return postLabelResponse(Option.<Long> none(), categoryId, value, abbreviation, description, access, settings,
+    return postLabelResponse(none(), categoryId, value, abbreviation, description, access, settings,
             tags);
   }
 
@@ -857,7 +856,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
                 || eas().getCategory(categoryId, false).isNone() || (tagsMap.isSome() && tagsMap.get().isNone()))
           return BAD_REQUEST;
 
-        Resource resource = eas().createResource(tagsMap.bind(Functions.<Option<Map<String, String>>> identity()),
+        Resource resource = eas().createResource(tagsMap.bind(Functions.identity()),
                 option(access));
         final Label label = eas().createLabel(categoryId, value, abbreviation, trimToNone(description),
                 trimToNone(settings), resource);
@@ -875,7 +874,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
           @FormParam("value") final String value, @FormParam("abbreviation") final String abbreviation,
           @FormParam("description") final String description, @FormParam("access") final Integer access,
           @FormParam("settings") final String settings, @FormParam("tags") final String tags) {
-    return putLabelResponse(Option.<Long> none(), categoryId, id, value, abbreviation, description, access, settings,
+    return putLabelResponse(none(), categoryId, id, value, abbreviation, description, access, settings,
             tags);
   }
 
@@ -890,7 +889,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
                 || eas().getCategory(categoryId, false).isNone() || (tagsMap.isSome() && tagsMap.get().isNone()))
           return BAD_REQUEST;
 
-        final Option<Map<String, String>> tags = tagsMap.bind(Functions.<Option<Map<String, String>>> identity());
+        final Option<Map<String, String>> tags = tagsMap.bind(Functions.identity());
 
         return eas().getLabel(id, false).fold(new Option.Match<Label, Response>() {
           @Override
@@ -926,7 +925,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/categories/{categoryId}/labels/{labelId}")
   public Response getLabel(@PathParam("categoryId") final long categoryId, @PathParam("labelId") final long id) {
-    return getLabelResponse(Option.<Long> none(), categoryId, id);
+    return getLabelResponse(none(), categoryId, id);
   }
 
   Response getLabelResponse(final Option<Long> videoId, final long categoryId, final long id) {
@@ -959,7 +958,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
   public Response getLabels(@PathParam("categoryId") final long categoryId, @QueryParam("limit") final int limit,
           @QueryParam("offset") final int offset, @QueryParam("since") final String date,
           @QueryParam("tags-and") final String tagsAnd, @QueryParam("tags-or") final String tagsOr) {
-    return getLabelsResponse(Option.<Long> none(), categoryId, limit, offset, date, tagsAnd, tagsOr);
+    return getLabelsResponse(none(), categoryId, limit, offset, date, tagsAnd, tagsOr);
   }
 
   Response getLabelsResponse(final Option<Long> videoId, final long categoryId, final int limit,
@@ -967,8 +966,8 @@ public abstract class AbstractExtendedAnnotationsRestService {
     return run(nil, new Function0<Response>() {
       @Override
       public Response apply() {
-        final Option<Integer> offsetm = offset > 0 ? some(offset) : Option.<Integer> none();
-        final Option<Integer> limitm = limit > 0 ? some(limit) : Option.<Integer> none();
+        final Option<Integer> offsetm = offset > 0 ? some(offset) : none();
+        final Option<Integer> limitm = limit > 0 ? some(limit) : none();
         final Option<Option<Date>> datem = trimToNone(date).map(parseDate);
         Option<Option<Map<String, String>>> tagsAndArray = trimToNone(tagsAnd).map(parseToJsonMap);
         Option<Option<Map<String, String>>> tagsOrArray = trimToNone(tagsOr).map(parseToJsonMap);
@@ -982,9 +981,9 @@ public abstract class AbstractExtendedAnnotationsRestService {
         return buildOk(LabelDto.toJson(
                 eas(),
                 offset,
-                eas().getLabels(categoryId, offsetm, limitm, datem.bind(Functions.<Option<Date>> identity()),
-                        tagsAndArray.bind(Functions.<Option<Map<String, String>>> identity()),
-                        tagsOrArray.bind(Functions.<Option<Map<String, String>>> identity()))));
+                eas().getLabels(categoryId, offsetm, limitm, datem.bind(Functions.identity()),
+                        tagsAndArray.bind(Functions.identity()),
+                        tagsOrArray.bind(Functions.identity()))));
       }
     });
   }
@@ -992,7 +991,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
   @DELETE
   @Path("/categories/{categoryId}/labels/{labelId}")
   public Response deleteLabel(@PathParam("categoryId") final long categoryId, @PathParam("labelId") final long id) {
-    return deleteLabelResponse(Option.<Long> none(), categoryId, id);
+    return deleteLabelResponse(none(), categoryId, id);
   }
 
   Response deleteLabelResponse(final Option<Long> videoId, final long categoryId, final long id) {
@@ -1021,18 +1020,18 @@ public abstract class AbstractExtendedAnnotationsRestService {
 
   // --
 
-  public static final Response NOT_FOUND = Response.status(Response.Status.NOT_FOUND).build();
-  public static final Response UNAUTHORIZED = Response.status(Response.Status.UNAUTHORIZED).build();
-  public static final Response FORBIDDEN = Response.status(Response.Status.FORBIDDEN).build();
-  public static final Response BAD_REQUEST = Response.status(Response.Status.BAD_REQUEST).build();
-  public static final Response CONFLICT = Response.status(Response.Status.CONFLICT).build();
-  public static final Response SERVER_ERROR = Response.serverError().build();
-  public static final Response NO_CONTENT = Response.noContent().build();
+  static final Response NOT_FOUND = Response.status(Response.Status.NOT_FOUND).build();
+  static final Response UNAUTHORIZED = Response.status(Response.Status.UNAUTHORIZED).build();
+  static final Response FORBIDDEN = Response.status(Response.Status.FORBIDDEN).build();
+  static final Response BAD_REQUEST = Response.status(Response.Status.BAD_REQUEST).build();
+  static final Response CONFLICT = Response.status(Response.Status.CONFLICT).build();
+  static final Response SERVER_ERROR = Response.serverError().build();
+  static final Response NO_CONTENT = Response.noContent().build();
 
-  public static final Object[] nil = new Object[0];
+  static final Object[] nil = new Object[0];
 
   /** Run <code>f</code> doing common exception transformation. */
-  public static Response run(Object[] mandatoryParams, Function0<Response> f) {
+  static Response run(Object[] mandatoryParams, Function0<Response> f) {
     for (Object a : mandatoryParams) {
       if (a == null || StringUtils.isEmpty(a.toString()))
         return BAD_REQUEST;
@@ -1104,12 +1103,13 @@ public abstract class AbstractExtendedAnnotationsRestService {
     }
   };
 
-  @SuppressWarnings("unchecked")
   static final Function<String, Option<Map<String, String>>> parseToJsonMap = new Function<String, Option<Map<String, String>>>() {
     @Override
     public Option<Map<String, String>> apply(String s) {
       try {
-        return some((Map<String, String>) new JSONParser().parse(s));
+        @SuppressWarnings("unchecked")
+        Map<String, String> result = (Map<String, String>) new JSONParser().parse(s);
+        return some(result);
       } catch (Exception e) {
         return none();
       }

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestService.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestService.java
@@ -40,6 +40,7 @@ public class ExtendedAnnotationsRestService extends AbstractExtendedAnnotationsR
   private String endpointBaseUrl;
 
   /** OSGi callback. */
+  @SuppressWarnings("unused")
   public void activate(ComponentContext cc) {
     logger.info("Start");
     final Tuple<String, String> endpointUrl = getEndpointUrl(cc);
@@ -47,11 +48,13 @@ public class ExtendedAnnotationsRestService extends AbstractExtendedAnnotationsR
   }
 
   /** OSGi callback. */
+  @SuppressWarnings("unused")
   public void deactivate() {
     logger.info("Stop");
   }
 
   /** OSGi callback. */
+  @SuppressWarnings("unused")
   public void setExtendedAnnotationsService(ExtendedAnnotationService eas) {
     this.eas = eas;
   }
@@ -65,5 +68,4 @@ public class ExtendedAnnotationsRestService extends AbstractExtendedAnnotationsR
   protected String getEndpointBaseUrl() {
     return endpointBaseUrl;
   }
-
 }

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/VideoEndpoint.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/VideoEndpoint.java
@@ -120,7 +120,7 @@ public class VideoEndpoint {
     return VideoData.Access.NONE;
   }
 
-  public VideoEndpoint(final long videoId, final AbstractExtendedAnnotationsRestService host,
+  VideoEndpoint(final long videoId, final AbstractExtendedAnnotationsRestService host,
           final ExtendedAnnotationService eas) {
     this.videoId = videoId;
     this.host = host;
@@ -203,7 +203,7 @@ public class VideoEndpoint {
 
         try {
 
-          Resource resource = eas.createResource(tagsMap.bind(Functions.<Option<Map<String, String>>> identity()),
+          Resource resource = eas.createResource(tagsMap.bind(Functions.identity()),
                   option(access));
           final Track t = eas.createTrack(videoId, name, trimToNone(description), trimToNone(settings), resource);
 
@@ -240,7 +240,7 @@ public class VideoEndpoint {
                 return BAD_REQUEST;
 
               Resource resource = eas.updateResource(track,
-                      tagsMap.bind(Functions.<Option<Map<String, String>>> identity()));
+                      tagsMap.bind(Functions.identity()));
 
               final Track updated = new TrackImpl(id, videoId, name, trimToNone(description), trimToNone(settings),
                       new ResourceImpl(option(access), resource.getCreatedBy(), resource.getUpdatedBy(), resource
@@ -331,8 +331,8 @@ public class VideoEndpoint {
     return run(nil, new Function0<Response>() {
       @Override
       public Response apply() {
-        final Option<Integer> offsetm = offset > 0 ? some(offset) : Option.<Integer> none();
-        final Option<Integer> limitm = limit > 0 ? some(limit) : Option.<Integer> none();
+        final Option<Integer> offsetm = offset > 0 ? some(offset) : none();
+        final Option<Integer> limitm = limit > 0 ? some(limit) : none();
         final Option<Option<Date>> datem = trimToNone(date).map(parseDate);
         final Option<Option<Map<String, String>>> tagsAndArray = trimToNone(tagsAnd).map(parseToJsonMap);
         final Option<Option<Map<String, String>>> tagsOrArray = trimToNone(tagsOr).map(parseToJsonMap);
@@ -345,9 +345,9 @@ public class VideoEndpoint {
           return buildOk(TrackDto.toJson(
                   eas,
                   offset,
-                  eas.getTracks(videoId, offsetm, limitm, datem.bind(Functions.<Option<Date>> identity()),
-                          tagsAndArray.bind(Functions.<Option<Map<String, String>>> identity()),
-                          tagsOrArray.bind(Functions.<Option<Map<String, String>>> identity()))));
+                  eas.getTracks(videoId, offsetm, limitm, datem.bind(Functions.identity()),
+                          tagsAndArray.bind(Functions.identity()),
+                          tagsOrArray.bind(Functions.identity()))));
         }
       }
     });
@@ -369,7 +369,7 @@ public class VideoEndpoint {
             return BAD_REQUEST;
 
           Resource resource = eas.createResource(
-                  tagsMap.bind(Functions.<Option<Map<String, String>>> identity()));
+                  tagsMap.bind(Functions.identity()));
           final Annotation a = eas.createAnnotation(trackId, trimToNone(text), start, option(duration),
                   trimToNone(settings), option(labelId), option(scaleValueId), resource);
           return Response.created(annotationLocationUri(videoId, a))
@@ -396,7 +396,7 @@ public class VideoEndpoint {
         if (tagsMap.isSome() && tagsMap.get().isNone())
           return BAD_REQUEST;
 
-        final Option<Map<String, String>> tags = tagsMap.bind(Functions.<Option<Map<String, String>>> identity());
+        final Option<Map<String, String>> tags = tagsMap.bind(Functions.identity());
 
         // check if video and track exist
         if (videoData.isSome() && eas.getTrack(trackId).isSome()) {
@@ -505,10 +505,10 @@ public class VideoEndpoint {
       @Override
       public Response apply() {
         if (videoData.isSome()) {
-          final Option<Double> startm = start > 0 ? some(start) : Option.<Double> none();
-          final Option<Double> endm = end > 0 ? some(end) : Option.<Double> none();
-          final Option<Integer> offsetm = offset > 0 ? some(offset) : Option.<Integer> none();
-          final Option<Integer> limitm = limit > 0 ? some(limit) : Option.<Integer> none();
+          final Option<Double> startm = start > 0 ? some(start) : none();
+          final Option<Double> endm = end > 0 ? some(end) : none();
+          final Option<Integer> offsetm = offset > 0 ? some(offset) : none();
+          final Option<Integer> limitm = limit > 0 ? some(limit) : none();
           final Option<Option<Date>> datem = trimToNone(date).map(parseDate);
           final Option<Option<Map<String, String>>> tagsAndArray = trimToNone(tagsAnd).map(parseToJsonMap);
           final Option<Option<Map<String, String>>> tagsOrArray = trimToNone(tagsOr).map(parseToJsonMap);
@@ -521,9 +521,9 @@ public class VideoEndpoint {
                     eas,
                     offset,
                     eas.getAnnotations(trackId, startm, endm, offsetm, limitm,
-                            datem.bind(Functions.<Option<Date>> identity()),
-                            tagsAndArray.bind(Functions.<Option<Map<String, String>>> identity()),
-                            tagsOrArray.bind(Functions.<Option<Map<String, String>>> identity()))));
+                            datem.bind(Functions.identity()),
+                            tagsAndArray.bind(Functions.identity()),
+                            tagsOrArray.bind(Functions.identity()))));
           }
         } else {
           return NOT_FOUND;
@@ -550,7 +550,7 @@ public class VideoEndpoint {
                 || (tagsMap.isSome() && tagsMap.get().isNone()))
           return BAD_REQUEST;
 
-        Resource resource = eas.createResource(tagsMap.bind(Functions.<Option<Map<String, String>>> identity()),
+        Resource resource = eas.createResource(tagsMap.bind(Functions.identity()),
                 option(access));
         final Scale scale = eas.createScaleFromTemplate(videoId, scaleId, resource);
         return Response.created(host.scaleLocationUri(scale, true))
@@ -649,7 +649,7 @@ public class VideoEndpoint {
         if (videoData.isNone() || (tagsMap.isSome() && tagsMap.get().isNone()))
           return BAD_REQUEST;
 
-        Resource resource = eas.createResource(tagsMap.bind(Functions.<Option<Map<String, String>>> identity()));
+        Resource resource = eas.createResource(tagsMap.bind(Functions.identity()));
         Option<Category> categoryFromTemplate = eas.createCategoryFromTemplate(videoId, id, resource);
         return categoryFromTemplate.fold(new Option.Match<Category, Response>() {
 
@@ -750,10 +750,10 @@ public class VideoEndpoint {
   public Response postComment(@PathParam("trackId") final long trackId,
           @PathParam("annotationId") final long annotationId, @FormParam("text") final String text,
           @FormParam("tags") final String tags) {
-    return postCommentResponse(trackId, annotationId, Option.<Long> none(), text, tags);
+    return postCommentResponse(trackId, annotationId, none(), text, tags);
   }
 
-  public Response postCommentResponse(final long trackId, final long annotationId, final Option<Long> replyToId,
+  private Response postCommentResponse(final long trackId, final long annotationId, final Option<Long> replyToId,
           final String text, final String tags) {
     if (videoData.isSome() && eas.getTrack(trackId).isSome()
             && eas.getAnnotation(annotationId).isSome()) {
@@ -764,7 +764,7 @@ public class VideoEndpoint {
           if (tagsMap.isSome() && tagsMap.get().isNone())
             return BAD_REQUEST;
 
-          Resource resource = eas.createResource(tagsMap.bind(Functions.<Option<Map<String, String>>> identity()));
+          Resource resource = eas.createResource(tagsMap.bind(Functions.identity()));
           final Comment comment = eas.createComment(annotationId, replyToId, text, resource);
 
           return Response.created(commentLocationUri(comment, videoId, trackId))
@@ -792,7 +792,7 @@ public class VideoEndpoint {
           if (tagsMap.isSome() && tagsMap.get().isNone())
             return BAD_REQUEST;
 
-          final Option<Map<String, String>> tags = tagsMap.bind(Functions.<Option<Map<String, String>>> identity());
+          final Option<Map<String, String>> tags = tagsMap.bind(Functions.identity());
 
           return eas.getComment(commentId).fold(new Option.Match<Comment, Response>() {
             @Override
@@ -800,7 +800,7 @@ public class VideoEndpoint {
               if (!eas.hasResourceAccess(c))
                 return UNAUTHORIZED;
               Resource resource = eas.updateResource(c, tags);
-              final Comment updated = new CommentImpl(commentId, annotationId, text, Option.<Long> none(), resource);
+              final Comment updated = new CommentImpl(commentId, annotationId, text, Option.none(), resource);
               if (!c.equals(updated)) {
                 eas.updateComment(updated);
                 c = updated;
@@ -812,7 +812,7 @@ public class VideoEndpoint {
             @Override
             public Response none() {
               Resource resource = eas.createResource(tags);
-              final Comment comment = eas.createComment(annotationId, Option.<Long> none(), text, resource);
+              final Comment comment = eas.createComment(annotationId, Option.none(), text, resource);
 
               return Response.created(commentLocationUri(comment, videoId, trackId))
                       .entity(Strings.asStringNull().apply(CommentDto.toJson.apply(eas, comment))).build();
@@ -895,18 +895,18 @@ public class VideoEndpoint {
           @PathParam("annotationId") final long annotationId, @QueryParam("limit") final int limit,
           @QueryParam("offset") final int offset, @QueryParam("since") final String date,
           @QueryParam("tags-and") final String tagsAnd, @QueryParam("tags-or") final String tagsOr) {
-    return getCommentsResponse(trackId, annotationId, Option.<Long> none(), limit, offset, date, tagsAnd, tagsOr);
+    return getCommentsResponse(trackId, annotationId, none(), limit, offset, date, tagsAnd, tagsOr);
   }
 
-  public Response getCommentsResponse(final long trackId, final long annotationId, final Option<Long> replyToId,
+  private Response getCommentsResponse(final long trackId, final long annotationId, final Option<Long> replyToId,
           final int limit, final int offset, final String date, final String tagsAnd, final String tagsOr) {
     if (videoData.isSome() && eas.getTrack(trackId).isSome()
             && eas.getAnnotation(annotationId).isSome()) {
       return run(nil, new Function0<Response>() {
         @Override
         public Response apply() {
-          final Option<Integer> offsetm = offset > 0 ? some(offset) : Option.<Integer> none();
-          final Option<Integer> limitm = limit > 0 ? some(limit) : Option.<Integer> none();
+          final Option<Integer> offsetm = offset > 0 ? some(offset) : none();
+          final Option<Integer> limitm = limit > 0 ? some(limit) : none();
           final Option<Option<Date>> datem = trimToNone(date).map(parseDate);
           Option<Option<Map<String, String>>> tagsAndArray = trimToNone(tagsAnd).map(parseToJsonMap);
           Option<Option<Map<String, String>>> tagsOrArray = trimToNone(tagsOr).map(parseToJsonMap);
@@ -919,9 +919,9 @@ public class VideoEndpoint {
                   eas,
                   offset,
                   eas.getComments(annotationId, replyToId, offsetm, limitm,
-                          datem.bind(Functions.<Option<Date>> identity()),
-                          tagsAndArray.bind(Functions.<Option<Map<String, String>>> identity()),
-                          tagsOrArray.bind(Functions.<Option<Map<String, String>>> identity()))));
+                          datem.bind(Functions.identity()),
+                          tagsAndArray.bind(Functions.identity()),
+                          tagsOrArray.bind(Functions.identity()))));
         }
       });
     } else {
@@ -999,17 +999,15 @@ public class VideoEndpoint {
     header.add("Scale name");
     header.add("Scale value name");
     header.add("Scale value value");
-    writer.writeNext(header.toArray(new String[header.size()]));
+    writer.writeNext(header.toArray(new String[0]));
 
     for (VideoData videoData : this.videoData) {
       Video video = videoData.video;
-      List<Track> tracks = eas.getTracks(video.getId(), Option.<Integer> none(), Option.<Integer> none(),
-              Option.<Date> none(), Option.<Map<String, String>> none(), Option.<Map<String, String>> none());
+      List<Track> tracks = eas.getTracks(video.getId(), none(), none(), none(), none(), none());
       for (Track track : tracks) {
         if (tracksToExport != null && !tracksToExport.contains(track.getId())) continue;
-        List<Annotation> annotations = eas.getAnnotations(track.getId(), none(Double.class), none(Double.class),
-                none(Integer.class), none(Integer.class), none(Date.class), Option.<Map<String, String>> none(),
-                Option.<Map<String, String>> none());
+        List<Annotation> annotations = eas.getAnnotations(track.getId(), none(), none(), none(), none(), none(), none(),
+                none());
         for (Annotation annotation : annotations) {
           Option<Label> label = annotation.getLabelId().bind(new Function<Long, Option<Label>>() {
             @Override
@@ -1061,7 +1059,7 @@ public class VideoEndpoint {
             line.add("");
           }
 
-          writer.writeNext(line.toArray(new String[line.size()]));
+          writer.writeNext(line.toArray(new String[0]));
         }
       }
     }

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/ExtendedAnnotationServicePublisher.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/ExtendedAnnotationServicePublisher.java
@@ -45,6 +45,7 @@ public class ExtendedAnnotationServicePublisher extends SimpleServicePublisher {
   private SearchService searchService;
 
   /** OSGi DI */
+  @SuppressWarnings("unused")
   void setEntityManagerFactory(EntityManagerFactory emf) {
     this.emf = emf;
   }
@@ -55,6 +56,7 @@ public class ExtendedAnnotationServicePublisher extends SimpleServicePublisher {
    * @param securityService
    *          the security service
    */
+  @SuppressWarnings("unused")
   public void setSecurityService(SecurityService securityService) {
     this.securityService = securityService;
   }
@@ -65,6 +67,7 @@ public class ExtendedAnnotationServicePublisher extends SimpleServicePublisher {
    * @param authorizationService
    *          the authorization service
    */
+  @SuppressWarnings("unused")
   public void setAuthorizationService(AuthorizationService authorizationService) {
     this.authorizationService = authorizationService;
   }
@@ -75,6 +78,7 @@ public class ExtendedAnnotationServicePublisher extends SimpleServicePublisher {
    * @param searchService
    *          the search service
    */
+  @SuppressWarnings("unused")
   public void setSearchService(SearchService searchService) {
     this.searchService = searchService;
   }

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/CommentDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/CommentDto.java
@@ -104,7 +104,7 @@ public class CommentDto extends AbstractResourceDto {
   }
 
   public Comment toComment() {
-    return new CommentImpl(id, annotationId, text, none(Long.class), new ResourceImpl(option(access), option(createdBy),
+    return new CommentImpl(id, annotationId, text, none(), new ResourceImpl(option(access), option(createdBy),
             option(updatedBy), option(deletedBy), option(createdAt), option(updatedAt), option(deletedAt), tags));
   }
 

--- a/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/Collections.java
+++ b/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/Collections.java
@@ -238,12 +238,12 @@ public final class Collections {
 
   /** Return the last element of the list. */
   public static <A> Option<A> last(List<A> as) {
-    return as.size() > 0 ? some(as.get(as.size() - 1)) : Option.<A> none();
+    return as.size() > 0 ? some(as.get(as.size() - 1)) : Option.none();
   }
 
   /** Return the last element of the array. */
   public static <A> Option<A> last(A[] as) {
-    return as.length > 0 ? some(as[as.length - 1]) : Option.<A> none();
+    return as.length > 0 ? some(as[as.length - 1]) : Option.none();
   }
 
   /** Make a string from a collection separating each element by <code>sep</code>. */
@@ -320,12 +320,12 @@ public final class Collections {
 
   /** Return nil if <code>a</code> is null or a list containing <code>a</code> otherwise. */
   public static <A> List<A> toList(A a) {
-    return a != null ? list(a) : Collections.<A> nil();
+    return a != null ? list(a) : Collections.nil();
   }
 
   /** Return the list as is or nil, if <code>as</code> is null. */
   public static <A> List<A> mkList(List<A> as) {
-    return as != null ? as : Collections.<A> nil();
+    return as != null ? as : Collections.nil();
   }
 
   /** Create a list from an array. */

--- a/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestServiceTest.java
+++ b/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestServiceTest.java
@@ -213,18 +213,18 @@ public class ExtendedAnnotationsRestServiceTest {
 
   @Test
   public void testEqualsIgnoreTimestamp() throws Exception {
-    Resource resource = new ResourceImpl(some(Resource.PRIVATE), none(Long.class), none(Long.class), none(Long.class),
-            some(new Date()), none(Date.class), none(Date.class), new HashMap<String, String>());
-    final Annotation a = new AnnotationImpl(1, 1, some("a text"), 10D, some(20D), some("the settings"), none(-1L),
-            none(-1L), resource);
+    Resource resource = new ResourceImpl(some(Resource.PRIVATE), none(), none(), none(), some(new Date()), none(),
+            none(), new HashMap<String, String>());
+    final Annotation a = new AnnotationImpl(1, 1, some("a text"), 10D, some(20D), some("the settings"), none(), none(),
+            resource);
     Thread.sleep(10);
-    final Annotation b = new AnnotationImpl(1, 1, some("a text"), 10D, some(20D), some("the settings"), none(-1L),
-            none(-1L), new ResourceImpl(some(Resource.PRIVATE), none(Long.class), none(Long.class), none(Long.class),
-                    some(new Date()), none(Date.class), none(Date.class), new HashMap<String, String>()));
-    final Annotation c = new AnnotationImpl(1, 2, some("a text"), 10D, some(10D), some("the settings"), none(-1L),
-            none(-1L), resource);
-    final Annotation d = new AnnotationImpl(1, 1, some("another text"), 10D, some(20D), some("other settings"),
-            none(-1L), none(-1L), resource);
+    final Annotation b = new AnnotationImpl(1, 1, some("a text"), 10D, some(20D), some("the settings"), none(), none(),
+            new ResourceImpl(some(Resource.PRIVATE), none(), none(), none(), some(new Date()), none(), none(),
+            new HashMap<String, String>()));
+    final Annotation c = new AnnotationImpl(1, 2, some("a text"), 10D, some(10D), some("the settings"), none(), none(),
+            resource);
+    final Annotation d = new AnnotationImpl(1, 1, some("another text"), 10D, some(20D), some("other settings"), none(),
+            none(), resource);
     assertTrue(a.equals(b));
     assertFalse(a.equals(c));
     assertFalse(a.equals(d));

--- a/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestServiceTest.java
+++ b/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestServiceTest.java
@@ -82,30 +82,30 @@ public class ExtendedAnnotationsRestServiceTest {
             .header(LOCATION, regex(host("/users/[0-9]+"))).body("nickname", equalTo("klausi"))
             .body("tags", equalTo(json)).when().post(host("/users")));
     // get
-    given().pathParam("id", id).expect().statusCode(OK).log().all().body("user_extid", equalTo("admin"))
+    given().pathParam("id", id).expect().statusCode(OK).body("user_extid", equalTo("admin"))
             .body("nickname", equalTo("klausi")).body("tags", equalTo(json)).when().get(host("/users/{id}"));
     // update
     json.put("channel", "22");
     given().formParam("user_extid", "admin").formParam("nickname", "santa").formParam("tags", json.toJSONString())
             .expect().statusCode(OK).body("nickname", equalTo("santa")).when().put(host("/users"));
-    given().pathParam("id", id).expect().statusCode(OK).log().all().body("nickname", equalTo("santa"))
+    given().pathParam("id", id).expect().statusCode(OK).body("nickname", equalTo("santa"))
             .body("tags", equalTo(json)).when().get(host("/users/{id}"));
     // get all
     // Removed get all method until Sprint X
-    // given().expect().statusCode(OK).log().all().body("users", iterableWithSize(1)).when().get(host("/users"));
+    // given().expect().statusCode(OK).body("users", iterableWithSize(1)).when().get(host("/users"));
     // Thread.sleep(10);
-    // given().log().all().queryParam("since", ISODateTimeFormat.dateTime().print(new Date().getTime())).expect()
-    // .statusCode(OK).log().all().body("users", iterableWithSize(0)).when().get(host("/users"));
+    // given().queryParam("since", ISODateTimeFormat.dateTime().print(new Date().getTime())).expect()
+    // .statusCode(OK).body("users", iterableWithSize(0)).when().get(host("/users"));
     // Calendar c = Calendar.getInstance();
     // c.add(Calendar.MINUTE, -1);
     // given().queryParam("since",
-    // ISODateTimeFormat.dateTime().print(c.getTimeInMillis())).expect().statusCode(OK).log()
-    // .all().body("users", iterableWithSize(1)).when().get(host("/users"));
+    // ISODateTimeFormat.dateTime().print(c.getTimeInMillis())).expect().statusCode(OK)
+    // .body("users", iterableWithSize(1)).when().get(host("/users"));
     // post/another one
     given().formParam("user_extid", "klaus2").formParam("nickname", "klausi2").expect().statusCode(CREATED)
             .header(LOCATION, regex(host("/users/[0-9]+"))).body("nickname", equalTo("klausi2")).when()
             .put(host("/users"));
-    // given().expect().statusCode(OK).log().all().body("users", iterableWithSize(2)).when().get(host("/users"));
+    // given().expect().statusCode(OK).body("users", iterableWithSize(2)).when().get(host("/users"));
     // post duplicated
     given().formParam("user_extid", "klaus2").formParam("nickname", "klausi2").expect().statusCode(CONFLICT).when()
             .post(host("/users"));
@@ -170,7 +170,6 @@ public class ExtendedAnnotationsRestServiceTest {
     // given().pathParam("videoId", videoId)
     // .pathParam("id", trackId)
     // .expect().statusCode(OK)
-    // .log().all()
     // .body("tracks", iterableWithSize(1))
     // .when().get(host("/videos/{videoId}/tracks/{id}");
     // post/create with same name
@@ -179,7 +178,7 @@ public class ExtendedAnnotationsRestServiceTest {
     // get/not found
     given().expect().statusCode(NOT_FOUND).when().get(host("/videos/abc/tracks/1"));
     // get
-    given().pathParam("videoId", videoId).pathParam("trackId", trackId).expect().statusCode(OK).log().all()
+    given().pathParam("videoId", videoId).pathParam("trackId", trackId).expect().statusCode(OK)
             .body("name", equalTo("track")).body("description", equalTo("just a track"))
             // .body("settings.type", equalTo("lecture")) todo
             .when().get(host("/videos/{videoId}/tracks/{trackId}"));
@@ -190,14 +189,14 @@ public class ExtendedAnnotationsRestServiceTest {
             .body("tags", equalTo(json)).when().put(host("/videos/{videoId}/tracks/{trackId}"));
 
     // get all
-    given().pathParam("videoId", videoId).expect().statusCode(OK).log().all().body("tracks", iterableWithSize(2))
+    given().pathParam("videoId", videoId).expect().statusCode(OK).body("tracks", iterableWithSize(2))
             .when().get(host("/videos/{videoId}/tracks"));
-    given().pathParam("videoId", videoId).queryParam("tags-or", json.toJSONString()).expect().statusCode(OK).log()
-            .all().body("tracks", iterableWithSize(1))
+    given().pathParam("videoId", videoId).queryParam("tags-or", json.toJSONString()).expect().statusCode(OK)
+            .body("tracks", iterableWithSize(1))
             // .body("tracks.name", hasItems("track", "track"))
             .when().get(host("/videos/{videoId}/tracks"));
-    given().pathParam("videoId", videoId).queryParam("tags-and", json.toJSONString()).expect().statusCode(OK).log()
-            .all().body("tracks", iterableWithSize(1))
+    given().pathParam("videoId", videoId).queryParam("tags-and", json.toJSONString()).expect().statusCode(OK)
+            .body("tracks", iterableWithSize(1))
             // .body("tracks.name", hasItems("track", "track"))
             .when().get(host("/videos/{videoId}/tracks"));
     // delete
@@ -257,34 +256,34 @@ public class ExtendedAnnotationsRestServiceTest {
     given().pathParam("videoId", videoId).pathParam("trackId", trackId).pathParam("id", id).expect().statusCode(OK)
             .body("text", equalTo("cool video")).when()
             .get(host("/videos/{videoId}/tracks/{trackId}/annotations/{id}"));
-    given().pathParam("videoId", videoId).pathParam("trackId", trackId).expect().statusCode(OK).log().all()
+    given().pathParam("videoId", videoId).pathParam("trackId", trackId).expect().statusCode(OK)
             .body("annotations", iterableWithSize(1)).when()
             .get(host("/videos/{videoId}/tracks/{trackId}/annotations"));
     // get all since temporary removed!
     // Thread.sleep(10);
-    // given().log().all().pathParam("videoId", videoId).pathParam("trackId", trackId)
+    // given().pathParam("videoId", videoId).pathParam("trackId", trackId)
     // .queryParam("since", ISODateTimeFormat.dateTime().print(new Date().getTime())).expect().statusCode(OK)
-    // .log().all().body("annotations", iterableWithSize(0)).when()
+    // .body("annotations", iterableWithSize(0)).when()
     // .get(host("/videos/{videoId}/tracks/{trackId}/annotations"));
     // Calendar c = Calendar.getInstance();
     // c.add(Calendar.MINUTE, -1);
     // given().pathParam("videoId", videoId).pathParam("trackId", trackId)
-    // .queryParam("since", ISODateTimeFormat.dateTime().print(c.getTimeInMillis())).expect().statusCode(OK).log()
-    // .all().body("annotations", iterableWithSize(1)).when()
+    // .queryParam("since", ISODateTimeFormat.dateTime().print(c.getTimeInMillis())).expect().statusCode(OK)
+    // .body("annotations", iterableWithSize(1)).when()
     // .get(host("/videos/{videoId}/tracks/{trackId}/annotations"));
     // post/another one
     given().pathParam("videoId", videoId).pathParam("trackId", trackId).formParam("text", "nice")
             .formParam("start", 50).expect().statusCode(CREATED)
             .header(LOCATION, regex(host("/videos/[0-9]+/tracks/[0-9]+/annotations/[0-9]+")))
             .body("text", equalTo("nice")).when().post(host("/videos/{videoId}/tracks/{trackId}/annotations"));
-    given().pathParam("videoId", videoId).pathParam("trackId", trackId).expect().statusCode(OK).log().all()
+    given().pathParam("videoId", videoId).pathParam("trackId", trackId).expect().statusCode(OK)
             .body("annotations", iterableWithSize(2)).when()
             .get(host("/videos/{videoId}/tracks/{trackId}/annotations"));
     given().pathParam("videoId", videoId).pathParam("trackId", trackId).queryParam("tags-and", json.toJSONString())
-            .expect().statusCode(OK).log().all().body("annotations", iterableWithSize(1)).when()
+            .expect().statusCode(OK).body("annotations", iterableWithSize(1)).when()
             .get(host("/videos/{videoId}/tracks/{trackId}/annotations"));
     given().pathParam("videoId", videoId).pathParam("trackId", trackId).queryParam("tags-or", json.toJSONString())
-            .expect().statusCode(OK).log().all().body("annotations", iterableWithSize(1)).when()
+            .expect().statusCode(OK).body("annotations", iterableWithSize(1)).when()
             .get(host("/videos/{videoId}/tracks/{trackId}/annotations"));
     // delete
     given().pathParam("videoId", 12345).pathParam("trackId", 12345).pathParam("id", 12345).expect()
@@ -341,20 +340,20 @@ public class ExtendedAnnotationsRestServiceTest {
             .get(host("/videos/{videoId}/categories/{categoryId}"));
     // get all
     json.put("channel", "33");
-    given().log().all().expect().statusCode(OK).log().all().body("categories", iterableWithSize(1)).when()
+    given().expect().statusCode(OK).body("categories", iterableWithSize(1)).when()
             .get(host("/categories"));
-    given().log().all().queryParam("tags-and", json.toJSONString()).expect().statusCode(OK).log().all()
+    given().queryParam("tags-and", json.toJSONString()).expect().statusCode(OK)
             .body("categories", iterableWithSize(1)).when().get(host("/categories"));
-    given().log().all().queryParam("tags-or", json.toJSONString()).expect().statusCode(OK).log().all()
+    given().queryParam("tags-or", json.toJSONString()).expect().statusCode(OK)
             .body("categories", iterableWithSize(1)).when().get(host("/categories"));
-    given().log().all().pathParam("videoId", videoId).expect().statusCode(OK).log().all()
+    given().pathParam("videoId", videoId).expect().statusCode(OK)
             .body("categories", iterableWithSize(2)).when().get(host("/videos/{videoId}/categories"));
     json.put("channel", "22");
-    given().log().all().queryParam("tags-and", json.toJSONString()).pathParam("videoId", videoId).expect()
-            .statusCode(OK).log().all().body("categories", iterableWithSize(1)).when()
+    given().queryParam("tags-and", json.toJSONString()).pathParam("videoId", videoId).expect()
+            .statusCode(OK).body("categories", iterableWithSize(1)).when()
             .get(host("/videos/{videoId}/categories"));
-    given().log().all().queryParam("tags-or", json.toJSONString()).pathParam("videoId", videoId).expect()
-            .statusCode(OK).log().all().body("categories", iterableWithSize(1)).when()
+    given().queryParam("tags-or", json.toJSONString()).pathParam("videoId", videoId).expect()
+            .statusCode(OK).body("categories", iterableWithSize(1)).when()
             .get(host("/videos/{videoId}/categories"));
   }
 
@@ -398,20 +397,20 @@ public class ExtendedAnnotationsRestServiceTest {
             .get(host("/videos/{videoId}/scales/{scaleId}"));
     // get all
     json.put("channel", "33");
-    given().log().all().expect().statusCode(OK).log().all().body("scales", iterableWithSize(1)).when()
+    given().expect().statusCode(OK).body("scales", iterableWithSize(1)).when()
             .get(host("/scales"));
-    given().log().all().queryParam("tags-and", json.toJSONString()).expect().statusCode(OK).log().all()
+    given().queryParam("tags-and", json.toJSONString()).expect().statusCode(OK)
             .body("scales", iterableWithSize(1)).when().get(host("/scales"));
-    given().log().all().queryParam("tags-or", json.toJSONString()).expect().statusCode(OK).log().all()
+    given().queryParam("tags-or", json.toJSONString()).expect().statusCode(OK)
             .body("scales", iterableWithSize(1)).when().get(host("/scales"));
-    given().log().all().pathParam("videoId", videoId).expect().statusCode(OK).log().all()
+    given().pathParam("videoId", videoId).expect().statusCode(OK)
             .body("scales", iterableWithSize(2)).when().get(host("/videos/{videoId}/scales"));
     json.put("channel", "22");
-    given().log().all().queryParam("tags-and", json.toJSONString()).pathParam("videoId", videoId).expect()
-            .statusCode(OK).log().all().body("scales", iterableWithSize(1)).when()
+    given().queryParam("tags-and", json.toJSONString()).pathParam("videoId", videoId).expect()
+            .statusCode(OK).body("scales", iterableWithSize(1)).when()
             .get(host("/videos/{videoId}/scales"));
-    given().log().all().queryParam("tags-or", json.toJSONString()).pathParam("videoId", videoId).expect()
-            .statusCode(OK).log().all().body("scales", iterableWithSize(1)).when()
+    given().queryParam("tags-or", json.toJSONString()).pathParam("videoId", videoId).expect()
+            .statusCode(OK).body("scales", iterableWithSize(1)).when()
             .get(host("/videos/{videoId}/scales"));
     // delete
     given().pathParam("scaleId", 12345).expect().statusCode(NOT_FOUND).when().delete(host("/scales/{scaleId}"));
@@ -472,23 +471,23 @@ public class ExtendedAnnotationsRestServiceTest {
     given().pathParam("videoId", videoId).pathParam("scaleId", 323).pathParam("scaleValueId", id).expect()
             .statusCode(BAD_REQUEST).when().get(host("/videos/{videoId}/scales/{scaleId}/scalevalues/{scaleValueId}"));
     // get all
-    given().log().all().pathParam("scaleId", scaleId).expect().statusCode(OK).log().all()
+    given().pathParam("scaleId", scaleId).expect().statusCode(OK)
             .body("scaleValues", iterableWithSize(2)).when().get(host("/scales/{scaleId}/scalevalues"));
-    given().log().all().queryParam("tags-and", json.toJSONString()).pathParam("scaleId", scaleId).expect()
-            .statusCode(OK).log().all().body("scaleValues", iterableWithSize(1)).when()
+    given().queryParam("tags-and", json.toJSONString()).pathParam("scaleId", scaleId).expect()
+            .statusCode(OK).body("scaleValues", iterableWithSize(1)).when()
             .get(host("/scales/{scaleId}/scalevalues"));
-    given().log().all().queryParam("tags-or", json.toJSONString()).pathParam("scaleId", scaleId).expect()
-            .statusCode(OK).log().all().body("scaleValues", iterableWithSize(1)).when()
+    given().queryParam("tags-or", json.toJSONString()).pathParam("scaleId", scaleId).expect()
+            .statusCode(OK).body("scaleValues", iterableWithSize(1)).when()
             .get(host("/scales/{scaleId}/scalevalues"));
-    given().log().all().pathParam("videoId", videoId).pathParam("scaleId", scaleId).expect().statusCode(OK).log().all()
+    given().pathParam("videoId", videoId).pathParam("scaleId", scaleId).expect().statusCode(OK)
             .body("scaleValues", iterableWithSize(2)).when()
             .get(host("/videos/{videoId}/scales/{scaleId}/scalevalues"));
-    given().log().all().pathParam("videoId", videoId).pathParam("scaleId", scaleId)
-            .queryParam("tags-and", json.toJSONString()).expect().statusCode(OK).log().all()
+    given().pathParam("videoId", videoId).pathParam("scaleId", scaleId)
+            .queryParam("tags-and", json.toJSONString()).expect().statusCode(OK)
             .body("scaleValues", iterableWithSize(1)).when()
             .get(host("/videos/{videoId}/scales/{scaleId}/scalevalues"));
-    given().log().all().pathParam("videoId", videoId).pathParam("scaleId", scaleId)
-            .queryParam("tags-or", json.toJSONString()).expect().statusCode(OK).log().all()
+    given().pathParam("videoId", videoId).pathParam("scaleId", scaleId)
+            .queryParam("tags-or", json.toJSONString()).expect().statusCode(OK)
             .body("scaleValues", iterableWithSize(1)).when()
             .get(host("/videos/{videoId}/scales/{scaleId}/scalevalues"));
     // delete
@@ -561,22 +560,22 @@ public class ExtendedAnnotationsRestServiceTest {
     given().pathParam("videoId", videoId).pathParam("categoryId", 323).pathParam("labelId", id).expect()
             .statusCode(BAD_REQUEST).when().get(host("/videos/{videoId}/categories/{categoryId}/labels/{labelId}"));
     // get all
-    given().log().all().pathParam("categoryId", categoryId).expect().statusCode(OK).log().all()
+    given().pathParam("categoryId", categoryId).expect().statusCode(OK)
             .body("labels", iterableWithSize(2)).when().get(host("/categories/{categoryId}/labels"));
-    given().log().all().pathParam("categoryId", categoryId).queryParam("tags-and", json.toJSONString()).expect()
-            .statusCode(OK).log().all().body("labels", iterableWithSize(1)).when()
+    given().pathParam("categoryId", categoryId).queryParam("tags-and", json.toJSONString()).expect()
+            .statusCode(OK).body("labels", iterableWithSize(1)).when()
             .get(host("/categories/{categoryId}/labels"));
-    given().log().all().pathParam("categoryId", categoryId).queryParam("tags-or", json.toJSONString()).expect()
-            .statusCode(OK).log().all().body("labels", iterableWithSize(1)).when()
+    given().pathParam("categoryId", categoryId).queryParam("tags-or", json.toJSONString()).expect()
+            .statusCode(OK).body("labels", iterableWithSize(1)).when()
             .get(host("/categories/{categoryId}/labels"));
-    given().log().all().pathParam("videoId", videoId).pathParam("categoryId", categoryId).expect().statusCode(OK).log()
-            .all().body("labels", iterableWithSize(2)).when()
+    given().pathParam("videoId", videoId).pathParam("categoryId", categoryId).expect().statusCode(OK)
+            .body("labels", iterableWithSize(2)).when()
             .get(host("/videos/{videoId}/categories/{categoryId}/labels"));
-    given().log().all().pathParam("videoId", videoId).pathParam("categoryId", categoryId)
-            .queryParam("tags-and", json.toJSONString()).expect().statusCode(OK).log().all()
+    given().pathParam("videoId", videoId).pathParam("categoryId", categoryId)
+            .queryParam("tags-and", json.toJSONString()).expect().statusCode(OK)
             .body("labels", iterableWithSize(1)).when().get(host("/videos/{videoId}/categories/{categoryId}/labels"));
-    given().log().all().pathParam("videoId", videoId).pathParam("categoryId", categoryId)
-            .queryParam("tags-or", json.toJSONString()).expect().statusCode(OK).log().all()
+    given().pathParam("videoId", videoId).pathParam("categoryId", categoryId)
+            .queryParam("tags-or", json.toJSONString()).expect().statusCode(OK)
             .body("labels", iterableWithSize(1)).when().get(host("/videos/{videoId}/categories/{categoryId}/labels"));
     // delete
     given().pathParam("categoryId", categoryId).pathParam("labelId", 12345).expect().statusCode(NOT_FOUND).when()
@@ -670,17 +669,17 @@ public class ExtendedAnnotationsRestServiceTest {
             .formParam("text", "Second comment").expect().statusCode(CREATED).when()
             .post(host("/videos/{videoId}/tracks/{trackId}/annotations/{annotationId}/comments"));
 
-    given().log().all().pathParam("videoId", videoId).pathParam("trackId", trackId)
-            .pathParam("annotationId", annotationId).expect().statusCode(OK).log().all()
+    given().pathParam("videoId", videoId).pathParam("trackId", trackId)
+            .pathParam("annotationId", annotationId).expect().statusCode(OK)
             .body("comments", iterableWithSize(2)).when()
             .get(host("/videos/{videoId}/tracks/{trackId}/annotations/{annotationId}/comments"));
-    given().log().all().pathParam("videoId", videoId).pathParam("trackId", trackId)
+    given().pathParam("videoId", videoId).pathParam("trackId", trackId)
             .pathParam("annotationId", annotationId).queryParam("tags-and", json.toJSONString()).expect()
-            .statusCode(OK).log().all().body("comments", iterableWithSize(1)).when()
+            .statusCode(OK).body("comments", iterableWithSize(1)).when()
             .get(host("/videos/{videoId}/tracks/{trackId}/annotations/{annotationId}/comments"));
-    given().log().all().pathParam("videoId", videoId).pathParam("trackId", trackId)
+    given().pathParam("videoId", videoId).pathParam("trackId", trackId)
             .pathParam("annotationId", annotationId).queryParam("tags-or", json.toJSONString()).expect().statusCode(OK)
-            .log().all().body("comments", iterableWithSize(1)).when()
+            .body("comments", iterableWithSize(1)).when()
             .get(host("/videos/{videoId}/tracks/{trackId}/annotations/{annotationId}/comments"));
 
     // delete
@@ -725,7 +724,7 @@ public class ExtendedAnnotationsRestServiceTest {
     // post
     given().pathParam("videoId", videoId).pathParam("trackId", trackId).formParam("text", "cool video")
             .formParam("start", 40).formParam("settings", "{\"type\":\"test\"}").formParam("label_id", labelId)
-            .formParam("scale_value_id", scaleValueId).expect().log().all().statusCode(CREATED)
+            .formParam("scale_value_id", scaleValueId).expect().statusCode(CREATED)
             .body(containsString("label")).body(containsString("scalevalue")).body(containsString("scale"))
             .body(containsString("category")).when().post(host("/videos/{videoId}/tracks/{trackId}/annotations"));
   }
@@ -818,8 +817,8 @@ public class ExtendedAnnotationsRestServiceTest {
             .statusCode(CREATED).when()
             .post(host("/videos/{videoId}/tracks/{trackId}/annotations/{annotationId}/comments")));
 
-    given().log().all().pathParam("videoId", videoId).pathParam("trackId", trackId)
-            .pathParam("annotationId", annotationId).expect().statusCode(OK).log().all()
+    given().pathParam("videoId", videoId).pathParam("trackId", trackId)
+            .pathParam("annotationId", annotationId).expect().statusCode(OK)
             .body("comments", iterableWithSize(2)).when()
             .get(host("/videos/{videoId}/tracks/{trackId}/annotations/{annotationId}/comments"));
 
@@ -832,13 +831,13 @@ public class ExtendedAnnotationsRestServiceTest {
             .statusCode(CREATED).when()
             .post(host("/videos/{videoId}/tracks/{trackId}/annotations/{annotationId}/comments/{commentId}/replies"));
 
-    given().log().all().pathParam("videoId", videoId).pathParam("trackId", trackId)
-            .pathParam("annotationId", annotationId).pathParam("commentId", commentId).expect().statusCode(OK).log()
-            .all().body("comments", iterableWithSize(2)).when()
+    given().pathParam("videoId", videoId).pathParam("trackId", trackId)
+            .pathParam("annotationId", annotationId).pathParam("commentId", commentId).expect().statusCode(OK)
+            .body("comments", iterableWithSize(2)).when()
             .get(host("/videos/{videoId}/tracks/{trackId}/annotations/{annotationId}/comments/{commentId}/replies"));
-    given().log().all().pathParam("videoId", videoId).pathParam("trackId", trackId)
-            .pathParam("annotationId", annotationId).pathParam("commentId", commentId2).expect().statusCode(OK).log()
-            .all().body("comments", iterableWithSize(1)).when()
+    given().pathParam("videoId", videoId).pathParam("trackId", trackId)
+            .pathParam("annotationId", annotationId).pathParam("commentId", commentId2).expect().statusCode(OK)
+            .body("comments", iterableWithSize(1)).when()
             .get(host("/videos/{videoId}/tracks/{trackId}/annotations/{annotationId}/comments/{commentId}/replies"));
 
     // delete

--- a/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/impl/ExtendedAnnotationServiceJpaImplTest.java
+++ b/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/impl/ExtendedAnnotationServiceJpaImplTest.java
@@ -84,39 +84,39 @@ public class ExtendedAnnotationServiceJpaImplTest {
   public void testCreateAndFindUser() throws Exception {
     ExtendedAnnotationService eas = newExtendedAnnotationService();
     final Resource resource = eas.createResource(tags);
-    final User u = eas.createUser("k_dall", "Karl Dall", none(""), resource);
-    eas.createUser("k_dall2", "Karl Dall2", none(""), resource);
-    eas.createUser("k_dall3", "Karl Dall3", none(""), resource);
+    final User u = eas.createUser("k_dall", "Karl Dall", none(), resource);
+    eas.createUser("k_dall2", "Karl Dall2", none(), resource);
+    eas.createUser("k_dall3", "Karl Dall3", none(), resource);
     assertEquals("k_dall", u.getExtId());
     assertEquals("Karl Dall", u.getNickname());
-    assertEquals(none(""), u.getEmail());
+    assertEquals(none(), u.getEmail());
     assertTrue(eas.getUser(u.getId()).isSome());
     assertEquals("k_dall", eas.getUser(u.getId()).get().getExtId());
     assertTrue(eas.getUserByExtId(u.getExtId()).isSome());
     assertEquals("Karl Dall", eas.getUserByExtId(u.getExtId()).get().getNickname());
     assertEquals(tags.get(), u.getTags());
 
-    assertEquals(3, eas.getUsers(none(0), none(0), none(Date.class)).size());
-    assertEquals(2, eas.getUsers(some(1), none(0), none(Date.class)).size());
-    assertEquals(1, eas.getUsers(some(1), some(1), none(Date.class)).size());
+    assertEquals(3, eas.getUsers(none(), none(), none()).size());
+    assertEquals(2, eas.getUsers(some(1), none(), none()).size());
+    assertEquals(1, eas.getUsers(some(1), some(1), none()).size());
 
     // get all since
     Thread.sleep(10);
-    assertEquals(0, eas.getUsers(none(0), none(0), some(new Date())).size());
+    assertEquals(0, eas.getUsers(none(), none(), some(new Date())).size());
     Calendar c = Calendar.getInstance();
     c.add(Calendar.MINUTE, -1);
-    assertEquals(3, eas.getUsers(none(0), none(0), some(c.getTime())).size());
+    assertEquals(3, eas.getUsers(none(), none(), some(c.getTime())).size());
   }
 
   @Test
   public void testCreateDuplicateUser() {
     final ExtendedAnnotationService eas = newExtendedAnnotationService();
     final Resource resource = eas.createResource();
-    eas.createUser("jsbach", "J.S. Bach", none(""), resource);
+    eas.createUser("jsbach", "J.S. Bach", none(), resource);
     expectCause(Cause.DUPLICATE, new Effect0() {
       @Override
       protected void run() {
-        eas.createUser("jsbach", "J.S. Bach", none(""), resource);
+        eas.createUser("jsbach", "J.S. Bach", none(), resource);
       }
     });
   }
@@ -130,7 +130,7 @@ public class ExtendedAnnotationServiceJpaImplTest {
     assertEquals(some("js@bach.de"), eas.getUser(u.getId()).get().getEmail());
 
     resource = eas.updateResource(resource, tags);
-    eas.updateUser(new UserImpl(u.getId(), u.getExtId(), "Bach", none(""), resource));
+    eas.updateUser(new UserImpl(u.getId(), u.getExtId(), "Bach", none(), resource));
     assertEquals("Bach", eas.getUser(u.getId()).get().getNickname());
     assertEquals(none(), eas.getUser(u.getId()).get().getEmail());
     assertEquals(tags.get(), eas.getUser(u.getId()).get().getTags());
@@ -143,7 +143,7 @@ public class ExtendedAnnotationServiceJpaImplTest {
     expectCause(Cause.NOT_FOUND, new Effect0() {
       @Override
       protected void run() {
-        eas.updateUser(new UserImpl(999, "klaus", "Klaus", none(""), resource));
+        eas.updateUser(new UserImpl(999, "klaus", "Klaus", none(), resource));
       }
     });
   }
@@ -216,17 +216,17 @@ public class ExtendedAnnotationServiceJpaImplTest {
     final ExtendedAnnotationService eas = newExtendedAnnotationService();
     final Resource resource = eas.createResource(tags, some(Resource.PUBLIC));
     final Video v = eas.createVideo("lecture1", resource);
-    final Track t = eas.createTrack(v.getId(), "track1", none(""), none(""), resource);
+    final Track t = eas.createTrack(v.getId(), "track1", none(), none(), resource);
     // try adding a track to a non existing video
     expectCause(Cause.NOT_FOUND, new Effect0() {
       @Override
       protected void run() {
-        eas.createTrack(999, "track1", none(""), none(""), resource);
+        eas.createTrack(999, "track1", none(), none(), resource);
       }
     });
     // add another video
-    eas.createTrack(v.getId(), "track2", none(""), none(""), resource);
-    eas.createTrack(v.getId(), "track3", none(""), none(""), resource);
+    eas.createTrack(v.getId(), "track2", none(), none(), resource);
+    eas.createTrack(v.getId(), "track3", none(), none(), resource);
 
     assertTrue(eas.getTrack(3478813).isNone());
     assertTrue(eas.getTrack(t.getId()).isSome());
@@ -238,21 +238,17 @@ public class ExtendedAnnotationServiceJpaImplTest {
             resource));
     assertEquals(updatedSettings, eas.getTrack(t.getId()).get().getSettings().get());
     // get all/non existing track
-    assertTrue(eas.getTracks(12345, none(0), none(0), none(Date.class), Option.<Map<String, String>> none(),
-            Option.<Map<String, String>> none()).isEmpty());
+    assertTrue(eas.getTracks(12345, none(), none(), none(), Option.none(), Option.none()).isEmpty());
     // get all
     assertEquals(
             3,
-            eas.getTracks(v.getId(), none(0), none(0), none(Date.class), Option.<Map<String, String>> none(),
-                    Option.<Map<String, String>> none()).size());
+            eas.getTracks(v.getId(), none(), none(), none(), Option.none(), Option.none()).size());
     assertEquals(
             2,
-            eas.getTracks(v.getId(), some(1), none(0), none(Date.class), Option.<Map<String, String>> none(),
-                    Option.<Map<String, String>> none()).size());
+            eas.getTracks(v.getId(), some(1), none(), none(), Option.none(), Option.none()).size());
     assertEquals(
             1,
-            eas.getTracks(v.getId(), some(1), some(1), none(Date.class), Option.<Map<String, String>> none(),
-                    Option.<Map<String, String>> none()).size());
+            eas.getTracks(v.getId(), some(1), some(1), none(), Option.none(), Option.none()).size());
   }
 
   @Test
@@ -260,8 +256,7 @@ public class ExtendedAnnotationServiceJpaImplTest {
     ExtendedAnnotationService eas = newExtendedAnnotationService();
     final Resource resource = eas.createResource();
     final Video v = eas.createVideo("lecture", resource);
-    final Track t = eas.createTrack(v.getId(), "track1", none(""), some("{color:blue, url:http://localhost}"),
-            resource);
+    final Track t = eas.createTrack(v.getId(), "track1", none(), some("{color:blue, url:http://localhost}"), resource);
     assertTrue(eas.getTrack(t.getId()).isSome());
     assertEquals("{color:blue, url:http://localhost}", eas.getTrack(t.getId()).get().getSettings().get());
   }
@@ -271,8 +266,7 @@ public class ExtendedAnnotationServiceJpaImplTest {
     ExtendedAnnotationService eas = newExtendedAnnotationService();
     final Resource resource = eas.createResource();
     final Video v = eas.createVideo("lecture", resource);
-    final Track t = eas.createTrack(v.getId(), "track99", none(""), some("{color:blue, url:http://localhost}"),
-            resource);
+    final Track t = eas.createTrack(v.getId(), "track99", none(), some("{color:blue, url:http://localhost}"), resource);
     assertTrue(eas.getTrack(t.getId()).isSome());
     eas.deleteTrack(t);
     assertTrue(eas.getTrack(t.getId()).isNone());
@@ -283,38 +277,36 @@ public class ExtendedAnnotationServiceJpaImplTest {
     final ExtendedAnnotationService eas = newExtendedAnnotationService();
     final Resource resource = eas.createResource(tags, some(Resource.PUBLIC));
     final Video v = eas.createVideo("lecture", resource);
-    final Track t = eas.createTrack(v.getId(), "track1", none(""), none(""), resource);
+    final Track t = eas.createTrack(v.getId(), "track1", none(), none(), resource);
     // create
-    final Annotation a = eas.createAnnotation(t.getId(), some("cool video"), 20.0D, some(10.0D), none(""), none(-1L),
-            none(-1L), resource);
-    eas.createAnnotation(t.getId(), some("nice!"), 30.0D, some(3.0D), none(""), none(-1L), none(-1L), resource);
-    eas.createAnnotation(t.getId(), some("look at this"), 40.0D, some(5.0D), none(""), none(-1L), none(-1L), resource);
+    final Annotation a = eas.createAnnotation(t.getId(), some("cool video"), 20.0D, some(10.0D), none(), none(), none(),
+            resource);
+    eas.createAnnotation(t.getId(), some("nice!"), 30.0D, some(3.0D), none(), none(), none(), resource);
+    eas.createAnnotation(t.getId(), some("look at this"), 40.0D, some(5.0D), none(), none(), none(), resource);
     // get
     assertTrue(eas.getAnnotation(a.getId()).isSome());
     assertEquals(some("cool video"), eas.getAnnotation(a.getId()).get().getText());
     assertEquals(tags.get(), a.getTags());
     // get all/non existing track
-    assertTrue(eas.getAnnotations(12345, none(0D), none(0D), none(0), none(0), none(Date.class),
-            Option.<Map<String, String>> none(), Option.<Map<String, String>> none()).isEmpty());
+    assertTrue(eas.getAnnotations(12345, none(), none(), none(), none(), none(), Option.none(), Option.none())
+            .isEmpty());
     // get all
     assertEquals(
             3,
-            eas.getAnnotations(t.getId(), none(0D), none(0D), none(0), none(0), none(Date.class),
-                    Option.<Map<String, String>> none(), Option.<Map<String, String>> none()).size());
+            eas.getAnnotations(t.getId(), none(), none(), none(), none(), none(), Option.none(), Option.none()).size());
     assertEquals(
             2,
-            eas.getAnnotations(t.getId(), none(0D), none(0D), some(1), none(0), none(Date.class),
-                    Option.<Map<String, String>> none(), Option.<Map<String, String>> none()).size());
+            eas.getAnnotations(t.getId(), none(), none(), some(1), none(), none(), Option.none(), Option.none()).size());
     assertEquals(
             1,
-            eas.getAnnotations(t.getId(), none(0D), none(0D), some(1), some(1), none(Date.class),
-                    Option.<Map<String, String>> none(), Option.<Map<String, String>> none()).size());
+            eas.getAnnotations(t.getId(), none(), none(), some(1), some(1), none(), Option.none(), Option.none())
+                    .size());
     // get all since
     // Thread.sleep(10);
-    // assertEquals(0, eas.getAnnotations(t.getId(), none(0D), none(0D), none(0), none(0), some(new Date())).size());
+    // assertEquals(0, eas.getAnnotations(t.getId(), none(), none(), none(), none(), some(new Date())).size());
     // Calendar c = Calendar.getInstance();
     // c.add(Calendar.MINUTE, -1);
-    // assertEquals(3, eas.getAnnotations(t.getId(), none(0D), none(0D), none(0), none(0), some(c.getTime())).size());
+    // assertEquals(3, eas.getAnnotations(t.getId(), none(), none(), none(), none(), some(c.getTime())).size());
   }
 
   @Test
@@ -322,23 +314,23 @@ public class ExtendedAnnotationServiceJpaImplTest {
     final ExtendedAnnotationService eas = newExtendedAnnotationService();
     final Resource resource = eas.createResource();
     final Video v = eas.createVideo("lecture", resource);
-    final Track t = eas.createTrack(v.getId(), "track", none(""), none(""), resource);
+    final Track t = eas.createTrack(v.getId(), "track", none(), none(), resource);
     // update/non existing
     expectCause(Cause.NOT_FOUND, new Effect0() {
       @Override
       protected void run() {
-        eas.updateAnnotation(new AnnotationImpl(12345, 12345, some("not cool"), 21.0D, some(10.0D), none(""),
-                none(-1L), none(-1L), resource));
+        eas.updateAnnotation(new AnnotationImpl(12345, 12345, some("not cool"), 21.0D, some(10.0D), none(), none(),
+                none(), resource));
       }
     });
     // create
-    final Annotation a = eas.createAnnotation(t.getId(), some("cool video"), 20.0D, some(10.0D), none(""), none(-1L),
-            none(-1L), resource);
+    final Annotation a = eas.createAnnotation(t.getId(), some("cool video"), 20.0D, some(10.0D), none(), none(), none(),
+            resource);
     assertEquals(some("cool video"), eas.getAnnotation(a.getId()).get().getText());
 
     Resource updatedResource = eas.updateResource(a, tags);
-    eas.updateAnnotation(new AnnotationImpl(a.getId(), t.getId(), some("not cool"), 22.0D, some(5.0D), none(""),
-            none(-1L), none(-1L), updatedResource));
+    eas.updateAnnotation(new AnnotationImpl(a.getId(), t.getId(), some("not cool"), 22.0D, some(5.0D), none(), none(),
+            none(), updatedResource));
     assertEquals(some("not cool"), eas.getAnnotation(a.getId()).get().getText());
     assertEquals(tags.get(), eas.getAnnotation(a.getId()).get().getTags());
   }
@@ -348,10 +340,10 @@ public class ExtendedAnnotationServiceJpaImplTest {
     final ExtendedAnnotationService eas = newExtendedAnnotationService();
     final Resource resource = eas.createResource();
     final Video v = eas.createVideo("lecture", resource);
-    final Track t = eas.createTrack(v.getId(), "track", none(""), none(""), resource);
+    final Track t = eas.createTrack(v.getId(), "track", none(), none(), resource);
     // create
-    final Annotation a = eas.createAnnotation(t.getId(), some("cool video"), 20.0D, some(10.0D), none(""), none(-1L),
-            none(-1L), resource);
+    final Annotation a = eas.createAnnotation(t.getId(), some("cool video"), 20.0D, some(10.0D), none(), none(), none(),
+            resource);
     assertTrue(eas.getAnnotation(a.getId()).isSome());
     // delete
     eas.deleteAnnotation(a);
@@ -363,11 +355,11 @@ public class ExtendedAnnotationServiceJpaImplTest {
     final ExtendedAnnotationService eas = newExtendedAnnotationService();
     final Resource resource = eas.createResource(tags);
 
-    final Scale s = eas.createScale(Option.<Long> none(), "test scale", some("test description"), resource);
+    final Scale s = eas.createScale(Option.none(), "test scale", some("test description"), resource);
 
-    final Category categoryTemplate = eas.createCategory(none(0L), some(s.getId()), "Sozialform",
+    final Category categoryTemplate = eas.createCategory(none(), some(s.getId()), "Sozialform",
             some("description Sozialform"), some("sozial form settings"), resource);
-    eas.createLabel(categoryTemplate.getId(), "Bla", "Test", none(""), none(""), resource);
+    eas.createLabel(categoryTemplate.getId(), "Bla", "Test", none(), none(), resource);
 
     final Category c = eas.createCategory(some(3L), some(32L), "Verhalten", some("verhalten "), some("settings"),
             resource);
@@ -387,8 +379,7 @@ public class ExtendedAnnotationServiceJpaImplTest {
     Option<Scale> copyScale = eas.getScale(cCopy.get().getScaleId().get(), false);
     assertTrue(copyScale.isSome());
     assertEquals(cCopy.get().getVideoId(), copyScale.get().getVideoId());
-    List<Label> labels = eas.getLabels(cCopy.get().getId(), some(0), some(0), none(Date.class),
-            Option.<Map<String, String>> none(), Option.<Map<String, String>> none());
+    List<Label> labels = eas.getLabels(cCopy.get().getId(), some(0), some(0), none(), Option.none(), Option.none());
     assertEquals(1, labels.size());
     assertEquals(cCopy.get().getId(), labels.get(0).getCategoryId());
   }
@@ -403,16 +394,16 @@ public class ExtendedAnnotationServiceJpaImplTest {
     expectCause(Cause.NOT_FOUND, new Effect0() {
       @Override
       protected void run() {
-        eas.updateCategory(new CategoryImpl(1212, some(323L), some(32L), "bla", none(""), none(""), resource));
+        eas.updateCategory(new CategoryImpl(1212, some(323L), some(32L), "bla", none(), none(), resource));
       }
     });
     // create
-    final Category c = eas.createCategory(none(0L), none(0L), name, some("description Sozialform"),
+    final Category c = eas.createCategory(none(), none(), name, some("description Sozialform"),
             some("sozial form settings"), resource);
     assertEquals(name, eas.getCategory(c.getId(), false).get().getName());
 
     final Resource updatedResource = eas.updateResource(resource, tags);
-    eas.updateCategory(new CategoryImpl(c.getId(), some(323L), some(32L), "name2", none(""), none(""), updatedResource));
+    eas.updateCategory(new CategoryImpl(c.getId(), some(323L), some(32L), "name2", none(), none(), updatedResource));
     assertEquals("name2", eas.getCategory(c.getId(), false).get().getName());
     assertEquals(tags.get(), eas.getCategory(c.getId(), false).get().getTags());
   }
@@ -422,7 +413,7 @@ public class ExtendedAnnotationServiceJpaImplTest {
     final ExtendedAnnotationService eas = newExtendedAnnotationService();
     final Resource resource = eas.createResource();
     // create
-    final Category c = eas.createCategory(none(0L), none(0L), "Sozialform", some("description Sozialform"),
+    final Category c = eas.createCategory(none(), none(), "Sozialform", some("description Sozialform"),
             some("sozial form settings"), resource);
     assertTrue(eas.getCategory(c.getId(), false).isSome());
     // delete
@@ -435,7 +426,7 @@ public class ExtendedAnnotationServiceJpaImplTest {
     final ExtendedAnnotationService eas = newExtendedAnnotationService();
     final Resource resource = eas.createResource(tags);
 
-    final Scale scaleTemplate = eas.createScale(none(0L), "test template scale", some("hallo"), resource);
+    final Scale scaleTemplate = eas.createScale(none(), "test template scale", some("hallo"), resource);
     eas.createScaleValue(scaleTemplate.getId(), "test", 1.5D, 2, resource);
 
     final Scale s = eas.createScale(some(23L), "test scale", some("test description"), resource);
@@ -445,8 +436,8 @@ public class ExtendedAnnotationServiceJpaImplTest {
     assertEquals(tags.get(), sCopy.getTags());
     assertEquals("test template scale", sCopy.getName());
 
-    List<ScaleValue> scaleValues = eas.getScaleValues(sCopy.getId(), some(0), some(0), none(Date.class),
-            Option.<Map<String, String>> none(), Option.<Map<String, String>> none());
+    List<ScaleValue> scaleValues = eas.getScaleValues(sCopy.getId(), some(0), some(0), none(),
+            Option.none(), Option.none());
     assertEquals(1, scaleValues.size());
     assertEquals(sCopy.getId(), scaleValues.get(0).getScaleId());
     assertEquals(1.5D, scaleValues.get(0).getValue(), 0D);
@@ -475,7 +466,7 @@ public class ExtendedAnnotationServiceJpaImplTest {
     assertEquals("test scale", eas.getScale(s.getId(), false).get().getName());
 
     final Resource updatedResource = eas.updateResource(resource, tags);
-    eas.updateScale(new ScaleImpl(s.getId(), some(222L), "new", none(""), updatedResource));
+    eas.updateScale(new ScaleImpl(s.getId(), some(222L), "new", none(), updatedResource));
     assertEquals("new", eas.getScale(s.getId(), false).get().getName());
     assertEquals(tags.get(), eas.getScale(s.getId(), false).get().getTags());
   }
@@ -570,15 +561,15 @@ public class ExtendedAnnotationServiceJpaImplTest {
     expectCause(Cause.NOT_FOUND, new Effect0() {
       @Override
       protected void run() {
-        eas.updateLabel(new LabelImpl(323, 29, "test", "i dont know", none(""), none(""), resource));
+        eas.updateLabel(new LabelImpl(323, 29, "test", "i dont know", none(), none(), resource));
       }
     });
     // create
-    final Label l = eas.createLabel(32, "Good", "abbreviation3", none(""), none(""), resource);
+    final Label l = eas.createLabel(32, "Good", "abbreviation3", none(), none(), resource);
     assertEquals("Good", eas.getLabel(l.getId(), false).get().getValue());
 
     final Resource updatedResource = eas.updateResource(resource, tags);
-    eas.updateLabel(new LabelImpl(l.getId(), 11, "test", "i dont know", none(""), none(""), updatedResource));
+    eas.updateLabel(new LabelImpl(l.getId(), 11, "test", "i dont know", none(), none(), updatedResource));
     assertEquals("test", eas.getLabel(l.getId(), false).get().getValue());
     assertEquals(tags.get(), eas.getLabel(l.getId(), false).get().getTags());
   }
@@ -588,7 +579,7 @@ public class ExtendedAnnotationServiceJpaImplTest {
     final ExtendedAnnotationService eas = newExtendedAnnotationService();
     final Resource resource = eas.createResource();
     // create
-    final Label l = eas.createLabel(32, "Good", "abbreviation3", none(""), none(""), resource);
+    final Label l = eas.createLabel(32, "Good", "abbreviation3", none(), none(), resource);
     assertTrue(eas.getLabel(l.getId(), false).isSome());
     // delete
     eas.deleteLabel(l);
@@ -600,7 +591,7 @@ public class ExtendedAnnotationServiceJpaImplTest {
     final ExtendedAnnotationService eas = newExtendedAnnotationService();
     final Resource resource = eas.createResource(tags);
 
-    final Comment c = eas.createComment(32, none(Long.class), "New comment", resource);
+    final Comment c = eas.createComment(32, none(), "New comment", resource);
     Option<Comment> comment = eas.getComment(c.getId());
 
     assertTrue(comment.isSome());
@@ -618,15 +609,15 @@ public class ExtendedAnnotationServiceJpaImplTest {
     expectCause(Cause.NOT_FOUND, new Effect0() {
       @Override
       protected void run() {
-        eas.updateComment(new CommentImpl(323, 29, "comment", none(Long.class), resource));
+        eas.updateComment(new CommentImpl(323, 29, "comment", none(), resource));
       }
     });
     // create
-    final Comment c = eas.createComment(32, none(Long.class), "New comment", resource);
+    final Comment c = eas.createComment(32, none(), "New comment", resource);
     assertEquals("New comment", eas.getComment(c.getId()).get().getText());
 
     final Resource updatedResource = eas.updateResource(resource, tags);
-    eas.updateComment(new CommentImpl(c.getId(), 11, "new text", none(Long.class), updatedResource));
+    eas.updateComment(new CommentImpl(c.getId(), 11, "new text", none(), updatedResource));
     assertEquals(32, eas.getComment(c.getId()).get().getAnnotationId());
     assertEquals("new text", eas.getComment(c.getId()).get().getText());
     assertEquals(tags.get(), eas.getComment(c.getId()).get().getTags());
@@ -637,7 +628,7 @@ public class ExtendedAnnotationServiceJpaImplTest {
     final ExtendedAnnotationService eas = newExtendedAnnotationService();
     final Resource resource = eas.createResource();
     // create
-    final Comment c = eas.createComment(32, none(Long.class), "New comment", resource);
+    final Comment c = eas.createComment(32, none(), "New comment", resource);
     assertTrue(eas.getComment(c.getId()).isSome());
     // delete
     eas.deleteComment(c);
@@ -651,9 +642,9 @@ public class ExtendedAnnotationServiceJpaImplTest {
     // create resources
     final User u = eas.createUser("jsbach", "J.S. Bach", some("js@bach.de"), resource);
     final Video v = eas.createVideo("lecture", resource);
-    final Track t = eas.createTrack(v.getId(), "track", none(""), none(""), resource);
-    final Annotation a = eas.createAnnotation(t.getId(), some("cool video"), 20.0D, some(10.0D), none(""), none(-1L),
-            none(-1L), resource);
+    final Track t = eas.createTrack(v.getId(), "track", none(), none(), resource);
+    final Annotation a = eas.createAnnotation(t.getId(), some("cool video"), 20.0D, some(10.0D), none(), none(), none(),
+            resource);
     assertTrue(eas.getUser(u.getId()).isSome());
     assertTrue(eas.getVideo(v.getId()).isSome());
     assertTrue(eas.getTrack(t.getId()).isSome());


### PR DESCRIPTION
Mostly removing some of the unnecessary type parameters in calls to generic methods. This makes the code a bit more readable and also gets rid of some of the warnings in IntelliJ. :wink: 

This also removes the logging from the REST tests. It can be reenabled on demand for debugging purposes, but it is pretty useless otherwise, and probably slows down the tests quite a bit. (IO is expensive.)