### PR TITLE
Disable long-pressing timeline items to select them

### DIFF
--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -427,6 +427,14 @@ define([
                     );
                 }
             );
+            // Long-pressing is normally only used for multiple selections,
+            // which we don't support.
+            // Additionally this is a problem when you select an item
+            // and then start holding the mouse button to move it,
+            // but take to long to actually start moving.
+            // If we let this event through,
+            // the item would just be deselected in that scenario.
+            this.timeline.itemSet.hammer.off("press");
             this.timeline.on("select", _.bind(function (properties) {
                 annotationTool.setSelectionById(
                     _.map(properties.items, function (itemId) {


### PR DESCRIPTION
This fixes a problem where when you begin to drag an annotation
to move it around, but wait to long to actually start moving,
you deselect the item.

Plus, long-pressing is originally intended to facilitate
multiple selections, which we don't support, anyway.

This fixes #290.