### PR TITLE
Fix Webkit error when sorting tracks

### DIFF
--- a/frontend/build/profiles/integration/annotation-tool-configuration.js
+++ b/frontend/build/profiles/integration/annotation-tool-configuration.js
@@ -299,6 +299,10 @@ define(["jquery",
                     videos.sort(
                         util.lexicographic([
                             util.firstWith(_.compose(
+                                RegExp.prototype.test.bind(/HLS/),
+                                _.property("transport")
+                            )),
+                            util.firstWith(_.compose(
                                 RegExp.prototype.test.bind(/presenter\/.*/),
                                 _.property("type")
                             )),


### PR DESCRIPTION
After months not seeing it now I'm back to work on the project, after testing with Webkit based browsers (Chrome, New Edge, etc) I found that if you have DASH streams showed an error.

The error occurred when sort by presenter/presentation and put DASH over the top. This error doesn't happen in Safari (Its WebKit based but is the exception) or Firefox.

I need if someone can test this fix. In theory, it supposes that it will not affect non-HLS deployments.

Best Regards.