### PR TITLE
Prevent resetting the playhead to 0:00:00 when dragging the time marker to the far right

### DIFF
--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -440,7 +440,7 @@ define([
                     Math.max(
                         0,
                         Math.min(
-                            this.playerAdapter.getDuration(),
+                            this.playerAdapter.getDuration() - 0.02,
                             newTime
                         )
                     )


### PR DESCRIPTION
Subtract a small delta from the video's duration. This way the video does not switch back to the beginning.

Fixes #303