### PR TITLE
fix: convert string to number for correct sorting

### DIFF
--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -434,11 +434,14 @@ define(["jquery",
              * @param {Array} order The new track order
              */
             orderTracks: function (order) {
+                // convert the new order to string to compare reliably
+                var strOrder = order.map(function (item) { return "" + item; });
                 //   Make sure every visible track is represented in the order,
                 // and only those, with non-explicitly ordered tracks in front.
                 this.tracksOrder = _.chain(this.getTracks().getVisibleTracks())
                     .sortBy(function (track) {
-                        return order.indexOf(track.id);
+                        // convert each track ID to string to reliably compare them
+                        return strOrder.indexOf("" + track.id);
                     }, this)
                     .map("id")
                     .value();

--- a/frontend/js/views/tracks-selection.js
+++ b/frontend/js/views/tracks-selection.js
@@ -195,7 +195,7 @@ define(["jquery",
                     }, this))
                 );
 
-                annotationTool.orderTracks(this.sortableTrackSelection.toArray().map(id => parseInt(id, 10)));
+                annotationTool.orderTracks(this.sortableTrackSelection.toArray());
 
                 this.hide();
             },

--- a/frontend/js/views/tracks-selection.js
+++ b/frontend/js/views/tracks-selection.js
@@ -195,7 +195,7 @@ define(["jquery",
                     }, this))
                 );
 
-                annotationTool.orderTracks(this.sortableTrackSelection.toArray());
+                annotationTool.orderTracks(this.sortableTrackSelection.toArray().map(id => parseInt(id, 10)));
 
                 this.hide();
             },


### PR DESCRIPTION
The list of track IDs is sometimes a list of strings instead of integers. AnnotationTool#orderTracks sorts the tracks incorrectly when the new order is a list of strings.

Refs #295