### PR TITLE
fix: change implementation of Annotation#covers according to #317

### DIFF
--- a/frontend/build/profiles/integration/annotation-tool-configuration.js
+++ b/frontend/build/profiles/integration/annotation-tool-configuration.js
@@ -124,7 +124,7 @@ define(["jquery",
              * @memberOf module:annotation-tool-configuration.Configuration
              * @type {Object}
              */
-            MINIMAL_DURATION: 5,
+            MINIMAL_DURATION: 1,
 
             /**
              * Define the number of categories per tab in the annotate box.

--- a/frontend/build/profiles/local/annotation-tool-configuration.js
+++ b/frontend/build/profiles/local/annotation-tool-configuration.js
@@ -56,7 +56,7 @@ define(["jquery",
              * @memberOf module:annotation-tool-configuration.Configuration
              * @type {Object}
              */
-            MINIMAL_DURATION: 5,
+            MINIMAL_DURATION: 1,
 
             /**
              * Define the number of categories pro tab in the annotate box. Bigger is number, thinner will be the columns for the categories.

--- a/frontend/js/models/annotation.js
+++ b/frontend/js/models/annotation.js
@@ -243,8 +243,8 @@ define(["underscore",
             covers: function (time, minDuration) {
                 var start = this.get("start");
                 var duration = this.get("duration");
-                var end = duration === 0 ? start + minDuration : start + end;
-                
+                var end = start + (duration || minDuration);
+ 
                 return start <= time && time <= end;
             },
 

--- a/frontend/js/models/annotation.js
+++ b/frontend/js/models/annotation.js
@@ -242,8 +242,9 @@ define(["underscore",
              */
             covers: function (time, minDuration) {
                 var start = this.get("start");
-                var duration = Math.max(minDuration, this.get("duration") || 0);
-                var end = start + duration;
+                var duration = this.get("duration");
+                var end = duration === 0 ? start + minDuration : start + end;
+                
                 return start <= time && time <= end;
             },
 


### PR DESCRIPTION
Touching Annotation#covers changes:

* Point-in-time annotations are now indicated as active for 1 second
* Duration annotations are now indicated as active only as long as the actual duration of the annotation

Fixes #317 