### PR TITLE
Add a border below the last track

### DIFF
--- a/frontend/style/annotations/timeline.less
+++ b/frontend/style/annotations/timeline.less
@@ -2,6 +2,13 @@
     background-color: white;
     display: flex;
     flex-basis: 0;
+
+
+    .vis-foreground .vis-group, .vis-label {
+        &:last-child {
+            border-bottom: 1px solid #bfbfbf;
+        }
+    }
 }
 
 .vis-timeline {


### PR DESCRIPTION
The timeline displays a thin line to separate tracks. It would look better and more consistent if this line also "bookended" the last track. This PR adds that.

Fixes #292.