### PR TITLE
fix: debounce window resize handlers

### DIFF
--- a/frontend/js/views/annotate-category.js
+++ b/frontend/js/views/annotate-category.js
@@ -146,7 +146,8 @@ define(["jquery",
                     this.listenTo(annotationTool, annotationTool.EVENTS.ANNOTATE_TOGGLE_EDIT, this.switchEditModus);
                 }
 
-                $(window).on("resize.annotate-category", this.updateInputWidth);
+                var onResize = _.debounce(this.updateInputWidth, 250);
+                $(window).on("resize.annotate-category", onResize);
 
                 //this.render();
                 this.nameInput = this.$el.find(".catItem-header input");

--- a/frontend/js/views/annotate-category.js
+++ b/frontend/js/views/annotate-category.js
@@ -146,7 +146,7 @@ define(["jquery",
                     this.listenTo(annotationTool, annotationTool.EVENTS.ANNOTATE_TOGGLE_EDIT, this.switchEditModus);
                 }
 
-                var onResize = _.debounce(this.updateInputWidth, 250);
+                var onResize = _.debounce(this.updateInputWidth, 30);
                 $(window).on("resize.annotate-category", onResize);
 
                 //this.render();

--- a/frontend/js/views/main.js
+++ b/frontend/js/views/main.js
@@ -512,7 +512,7 @@ define(["jquery",
                 this.setLoadingProgress(100, i18next.t("startup.ready"));
                 this.loadingBox.hide();
                 this.onWindowResize();
-                var onResize = _.debounce(this.onWindowResize, 250)
+                var onResize = _.debounce(this.onWindowResize, 30)
                 $(window).resize(onResize);
 
                 this.setupKeyboardShortcuts();

--- a/frontend/js/views/main.js
+++ b/frontend/js/views/main.js
@@ -512,7 +512,8 @@ define(["jquery",
                 this.setLoadingProgress(100, i18next.t("startup.ready"));
                 this.loadingBox.hide();
                 this.onWindowResize();
-                $(window).resize(this.onWindowResize);
+                var onResize = _.debounce(this.onWindowResize, 250)
+                $(window).resize(onResize);
 
                 this.setupKeyboardShortcuts();
 


### PR DESCRIPTION
window resize handlers should always be debounced to prevent sluggish behaviour.