### PR TITLE
Set minimal zoom of the time line to at least the video duration

### DIFF
--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -181,7 +181,7 @@ define([
                 //groupEditable: {
                 //    order: true
                 //},
-                zoomMin: 5000,
+                zoomMin: Math.min(5000, this.endDate - this.startDate),
                 start: this.startDate,
                 end: this.endDate,
                 min: this.startDate,


### PR DESCRIPTION
Fixes #385.