### PR TITLE
Frontend changes to enable multi content annotations

### DIFF
--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -24,13 +24,14 @@ define(["jquery",
         "i18next",
         "collections/videos",
         "views/main",
+        "views/modal-container",
         "alerts",
         "templates/delete-modal",
         "player-adapter",
         "colors",
         "handlebarsHelpers"],
 
-    function ($, _, Backbone, i18next, Videos, MainView, alerts, DeleteModalTmpl, PlayerAdapter, ColorsManager) {
+    function ($, _, Backbone, i18next, Videos, MainView, ModalContainerView, alerts, DeleteModalTmpl, PlayerAdapter, ColorsManager) {
 
         "use strict";
 
@@ -672,6 +673,20 @@ define(["jquery",
                         }
                     }, this)
                 );
+            },
+
+            addModal: function (header, contentView, buttonText) {
+                var container = new ModalContainerView(
+                    {
+                        buttonText: buttonText,
+                        contentView: contentView,
+                        header: header
+                    }
+                );
+
+                return function closeModal() {
+                    container.close();
+                };
             }
         });
 

--- a/frontend/js/collections/annotation-content.js
+++ b/frontend/js/collections/annotation-content.js
@@ -1,0 +1,43 @@
+/**
+ *  Copyright 2020, ELAN e.V., Germany
+ *  Licensed under the Educational Community License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.osedu.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an "AS IS"
+ *  BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ *  or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ *
+ */
+
+/**
+ * A module representing a comments collection
+ * @module collections-annotation-content
+ */
+define(["underscore", "models/content-item", "backbone"], function(
+    _,
+    ContentItem,
+    Backbone
+) {
+    "use strict";
+
+    /**
+     * @constructor
+     * @see {@link http://www.backbonejs.org/#Collection}
+     * @augments module:Backbone.Collection
+     * @memberOf module:collections-annotation-content
+     * @alias module:collections-annotation-content.AnnotationContent
+     */
+    var AnnotationContent = Backbone.Collection.extend({
+        /**
+         * Model of the instances contained in this collection
+         * @alias module:collections-annotation-content.AnnotationContent#initialize
+         */
+        model: ContentItem
+    });
+    return AnnotationContent;
+});

--- a/frontend/js/handlebarsHelpers.js
+++ b/frontend/js/handlebarsHelpers.js
@@ -73,5 +73,34 @@ define(["handlebars", "underscore", "i18next", "util"], function (Handlebars, _,
         );
     });
 
+    /**
+     * Useful for debugging templates.
+     * @alias module:Handlebars#json
+     */
+    Handlebars.registerHelper("json", function (value) {
+        return new Handlebars.SafeString(
+            JSON.stringify(value)
+        );
+    });
+
+    Handlebars.registerHelper('ifeq', function (a, b, options) {
+        if (a == b) {
+            return options.fn(this);
+        }
+        return options.inverse(this);
+    });
+
+    Handlebars.registerHelper("withScaleValue", function (id) {
+        var scaleValue = _.findWhere(annotationTool.video.getScaleValues(), { id: id });
+
+        return scaleValue && scaleValue.toJSON();
+    });
+
+    Handlebars.registerHelper("withLabel", function (id) {
+        var label = _.findWhere(annotationTool.video.getLabels(), { id: id });
+
+        return label && label.toJSON();
+    });
+
     return Handlebars;
 });

--- a/frontend/js/libs/handlebars.js
+++ b/frontend/js/libs/handlebars.js
@@ -1,9 +1,9 @@
 /**!
 
  @license
- handlebars v4.5.3
+ handlebars v4.7.6
 
-Copyright (C) 2011-2017 by Yehuda Katz
+Copyright (C) 2011-2019 by Yehuda Katz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,5187 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 */
-define("handlebars/utils",["exports"],function(a){"use strict";function b(a){return j[a]}function c(a){for(var b=1;b<arguments.length;b++)for(var c in arguments[b])Object.prototype.hasOwnProperty.call(arguments[b],c)&&(a[c]=arguments[b][c]);return a}function d(a,b){for(var c=0,d=a.length;c<d;c++)if(a[c]===b)return c;return-1}function e(a){if("string"!=typeof a){if(a&&a.toHTML)return a.toHTML();if(null==a)return"";if(!a)return a+"";a=""+a}return l.test(a)?a.replace(k,b):a}function f(a){return!a&&0!==a||!(!o(a)||0!==a.length)}function g(a){var b=c({},a);return b._parent=a,b}function h(a,b){return a.path=b,a}function i(a,b){return(a?a+".":"")+b}a.__esModule=!0,a.extend=c,a.indexOf=d,a.escapeExpression=e,a.isEmpty=f,a.createFrame=g,a.blockParams=h,a.appendContextPath=i;var j={"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#x27;","`":"&#x60;","=":"&#x3D;"},k=/[&<>"'`=]/g,l=/[&<>"'`=]/,m=Object.prototype.toString;a.toString=m;var n=function(a){return"function"==typeof a};n(/x/)&&(a.isFunction=n=function(a){return"function"==typeof a&&"[object Function]"===m.call(a)}),a.isFunction=n;var o=Array.isArray||function(a){return!(!a||"object"!=typeof a)&&"[object Array]"===m.call(a)};a.isArray=o}),define("handlebars/exception",["exports","module"],function(a,b){"use strict";function c(a,b){var e=b&&b.loc,f=void 0,g=void 0,h=void 0,i=void 0;e&&(f=e.start.line,g=e.end.line,h=e.start.column,i=e.end.column,a+=" - "+f+":"+h);for(var j=Error.prototype.constructor.call(this,a),k=0;k<d.length;k++)this[d[k]]=j[d[k]];Error.captureStackTrace&&Error.captureStackTrace(this,c);try{e&&(this.lineNumber=f,this.endLineNumber=g,Object.defineProperty?(Object.defineProperty(this,"column",{value:h,enumerable:!0}),Object.defineProperty(this,"endColumn",{value:i,enumerable:!0})):(this.column=h,this.endColumn=i))}catch(l){}}var d=["description","fileName","lineNumber","endLineNumber","message","name","number","stack"];c.prototype=new Error,b.exports=c}),define("handlebars/helpers/block-helper-missing",["exports","module","../utils"],function(a,b,c){"use strict";b.exports=function(a){a.registerHelper("blockHelperMissing",function(b,d){var e=d.inverse,f=d.fn;if(b===!0)return f(this);if(b===!1||null==b)return e(this);if(c.isArray(b))return b.length>0?(d.ids&&(d.ids=[d.name]),a.helpers.each(b,d)):e(this);if(d.data&&d.ids){var g=c.createFrame(d.data);g.contextPath=c.appendContextPath(d.data.contextPath,d.name),d={data:g}}return f(b,d)})}}),define("handlebars/helpers/each",["exports","module","../utils","../exception"],function(a,b,c,d){"use strict";function e(a){return a&&a.__esModule?a:{"default":a}}var f=e(d);b.exports=function(a){a.registerHelper("each",function(a,b){function d(b,d,f){j&&(j.key=b,j.index=d,j.first=0===d,j.last=!!f,k&&(j.contextPath=k+b)),i+=e(a[b],{data:j,blockParams:c.blockParams([a[b],b],[k+b,null])})}if(!b)throw new f["default"]("Must pass iterator to #each");var e=b.fn,g=b.inverse,h=0,i="",j=void 0,k=void 0;if(b.data&&b.ids&&(k=c.appendContextPath(b.data.contextPath,b.ids[0])+"."),c.isFunction(a)&&(a=a.call(this)),b.data&&(j=c.createFrame(b.data)),a&&"object"==typeof a)if(c.isArray(a))for(var l=a.length;h<l;h++)h in a&&d(h,h,h===a.length-1);else if(global.Symbol&&a[global.Symbol.iterator]){for(var m=[],n=a[global.Symbol.iterator](),o=n.next();!o.done;o=n.next())m.push(o.value);a=m;for(var l=a.length;h<l;h++)d(h,h,h===a.length-1)}else!function(){var b=void 0;Object.keys(a).forEach(function(a){void 0!==b&&d(b,h-1),b=a,h++}),void 0!==b&&d(b,h-1,!0)}();return 0===h&&(i=g(this)),i})}}),define("handlebars/helpers/helper-missing",["exports","module","../exception"],function(a,b,c){"use strict";function d(a){return a&&a.__esModule?a:{"default":a}}var e=d(c);b.exports=function(a){a.registerHelper("helperMissing",function(){if(1!==arguments.length)throw new e["default"]('Missing helper: "'+arguments[arguments.length-1].name+'"')})}}),define("handlebars/helpers/if",["exports","module","../utils","../exception"],function(a,b,c,d){"use strict";function e(a){return a&&a.__esModule?a:{"default":a}}var f=e(d);b.exports=function(a){a.registerHelper("if",function(a,b){if(2!=arguments.length)throw new f["default"]("#if requires exactly one argument");return c.isFunction(a)&&(a=a.call(this)),!b.hash.includeZero&&!a||c.isEmpty(a)?b.inverse(this):b.fn(this)}),a.registerHelper("unless",function(b,c){if(2!=arguments.length)throw new f["default"]("#unless requires exactly one argument");return a.helpers["if"].call(this,b,{fn:c.inverse,inverse:c.fn,hash:c.hash})})}}),define("handlebars/helpers/log",["exports","module"],function(a,b){"use strict";b.exports=function(a){a.registerHelper("log",function(){for(var b=[void 0],c=arguments[arguments.length-1],d=0;d<arguments.length-1;d++)b.push(arguments[d]);var e=1;null!=c.hash.level?e=c.hash.level:c.data&&null!=c.data.level&&(e=c.data.level),b[0]=e,a.log.apply(a,b)})}}),define("handlebars/helpers/lookup",["exports"],function(a){"use strict";a.__esModule=!0;var b=/^(constructor|__defineGetter__|__defineSetter__|__lookupGetter__|__proto__)$/;a.dangerousPropertyRegex=b,a["default"]=function(a){a.registerHelper("lookup",function(a,c){if(!a)return a;if(!b.test(String(c))||Object.prototype.propertyIsEnumerable.call(a,c))return a[c]})}}),define("handlebars/helpers/with",["exports","module","../utils","../exception"],function(a,b,c,d){"use strict";function e(a){return a&&a.__esModule?a:{"default":a}}var f=e(d);b.exports=function(a){a.registerHelper("with",function(a,b){if(2!=arguments.length)throw new f["default"]("#with requires exactly one argument");c.isFunction(a)&&(a=a.call(this));var d=b.fn;if(c.isEmpty(a))return b.inverse(this);var e=b.data;return b.data&&b.ids&&(e=c.createFrame(b.data),e.contextPath=c.appendContextPath(b.data.contextPath,b.ids[0])),d(a,{data:e,blockParams:c.blockParams([a],[e&&e.contextPath])})})}}),define("handlebars/helpers",["exports","./helpers/block-helper-missing","./helpers/each","./helpers/helper-missing","./helpers/if","./helpers/log","./helpers/lookup","./helpers/with"],function(a,b,c,d,e,f,g,h){"use strict";function i(a){return a&&a.__esModule?a:{"default":a}}function j(a){l["default"](a),m["default"](a),n["default"](a),o["default"](a),p["default"](a),q["default"](a),r["default"](a)}function k(a,b,c){a.helpers[b]&&(a.hooks[b]=a.helpers[b],c||delete a.helpers[b])}a.__esModule=!0,a.registerDefaultHelpers=j,a.moveHelperToHooks=k;var l=i(b),m=i(c),n=i(d),o=i(e),p=i(f),q=i(g),r=i(h)}),define("handlebars/decorators/inline",["exports","module","../utils"],function(a,b,c){"use strict";b.exports=function(a){a.registerDecorator("inline",function(a,b,d,e){var f=a;return b.partials||(b.partials={},f=function(e,f){var g=d.partials;d.partials=c.extend({},g,b.partials);var h=a(e,f);return d.partials=g,h}),b.partials[e.args[0]]=e.fn,f})}}),define("handlebars/decorators",["exports","./decorators/inline"],function(a,b){"use strict";function c(a){return a&&a.__esModule?a:{"default":a}}function d(a){e["default"](a)}a.__esModule=!0,a.registerDefaultDecorators=d;var e=c(b)}),define("handlebars/logger",["exports","module","./utils"],function(a,b,c){"use strict";var d={methodMap:["debug","info","warn","error"],level:"info",lookupLevel:function(a){if("string"==typeof a){var b=c.indexOf(d.methodMap,a.toLowerCase());a=b>=0?b:parseInt(a,10)}return a},log:function(a){if(a=d.lookupLevel(a),"undefined"!=typeof console&&d.lookupLevel(d.level)<=a){var b=d.methodMap[a];console[b]||(b="log");for(var c=arguments.length,e=Array(c>1?c-1:0),f=1;f<c;f++)e[f-1]=arguments[f];console[b].apply(console,e)}}};b.exports=d}),define("handlebars/base",["exports","./utils","./exception","./helpers","./decorators","./logger"],function(a,b,c,d,e,f){"use strict";function g(a){return a&&a.__esModule?a:{"default":a}}function h(a,b,c){this.helpers=a||{},this.partials=b||{},this.decorators=c||{},d.registerDefaultHelpers(this),e.registerDefaultDecorators(this)}a.__esModule=!0,a.HandlebarsEnvironment=h;var i=g(c),j=g(f),k="4.5.3";a.VERSION=k;var l=8;a.COMPILER_REVISION=l;var m=7;a.LAST_COMPATIBLE_COMPILER_REVISION=m;var n={1:"<= 1.0.rc.2",2:"== 1.0.0-rc.3",3:"== 1.0.0-rc.4",4:"== 1.x.x",5:"== 2.0.0-alpha.x",6:">= 2.0.0-beta.1",7:">= 4.0.0 <4.3.0",8:">= 4.3.0"};a.REVISION_CHANGES=n;var o="[object Object]";h.prototype={constructor:h,logger:j["default"],log:j["default"].log,registerHelper:function(a,c){if(b.toString.call(a)===o){if(c)throw new i["default"]("Arg not supported with multiple helpers");b.extend(this.helpers,a)}else this.helpers[a]=c},unregisterHelper:function(a){delete this.helpers[a]},registerPartial:function(a,c){if(b.toString.call(a)===o)b.extend(this.partials,a);else{if("undefined"==typeof c)throw new i["default"]('Attempting to register a partial called "'+a+'" as undefined');this.partials[a]=c}},unregisterPartial:function(a){delete this.partials[a]},registerDecorator:function(a,c){if(b.toString.call(a)===o){if(c)throw new i["default"]("Arg not supported with multiple decorators");b.extend(this.decorators,a)}else this.decorators[a]=c},unregisterDecorator:function(a){delete this.decorators[a]}};var p=j["default"].log;a.log=p,a.createFrame=b.createFrame,a.logger=j["default"]}),define("handlebars/safe-string",["exports","module"],function(a,b){"use strict";function c(a){this.string=a}c.prototype.toString=c.prototype.toHTML=function(){return""+this.string},b.exports=c}),define("handlebars/runtime",["exports","./utils","./exception","./base","./helpers"],function(a,b,c,d,e){"use strict";function f(a){return a&&a.__esModule?a:{"default":a}}function g(a){var b=a&&a[0]||1,c=d.COMPILER_REVISION;if(!(b>=d.LAST_COMPATIBLE_COMPILER_REVISION&&b<=d.COMPILER_REVISION)){if(b<d.LAST_COMPATIBLE_COMPILER_REVISION){var e=d.REVISION_CHANGES[c],f=d.REVISION_CHANGES[b];throw new o["default"]("Template was precompiled with an older version of Handlebars than the current runtime. Please update your precompiler to a newer version ("+e+") or downgrade your runtime to an older version ("+f+").")}throw new o["default"]("Template was precompiled with a newer version of Handlebars than the current runtime. Please update your runtime to a newer version ("+a[1]+").")}}function h(a,c){function d(d,e,f){f.hash&&(e=b.extend({},e,f.hash),f.ids&&(f.ids[0]=!0)),d=c.VM.resolvePartial.call(this,d,e,f);var g=b.extend({},f,{hooks:this.hooks}),h=c.VM.invokePartial.call(this,d,e,g);if(null==h&&c.compile&&(f.partials[f.name]=c.compile(d,a.compilerOptions,c),h=f.partials[f.name](e,g)),null!=h){if(f.indent){for(var i=h.split("\n"),j=0,k=i.length;j<k&&(i[j]||j+1!==k);j++)i[j]=f.indent+i[j];h=i.join("\n")}return h}throw new o["default"]("The partial "+f.name+" could not be compiled when running in runtime-only mode")}function f(b){function c(b){return""+a.main(h,b,h.helpers,h.partials,e,i,g)}var d=arguments.length<=1||void 0===arguments[1]?{}:arguments[1],e=d.data;f._setup(d),!d.partial&&a.useData&&(e=m(b,e));var g=void 0,i=a.useBlockParams?[]:void 0;return a.useDepths&&(g=d.depths?b!=d.depths[0]?[b].concat(d.depths):d.depths:[b]),(c=n(a.main,c,h,d.depths||[],e,i))(b,d)}if(!c)throw new o["default"]("No environment passed to template");if(!a||!a.main)throw new o["default"]("Unknown template object: "+typeof a);a.main.decorator=a.main_d,c.VM.checkRevision(a.compiler);var g=a.compiler&&7===a.compiler[0],h={strict:function(a,b,c){if(!(a&&b in a))throw new o["default"]('"'+b+'" not defined in '+a,{loc:c});return a[b]},lookup:function(a,b){for(var c=a.length,d=0;d<c;d++)if(a[d]&&null!=a[d][b])return a[d][b]},lambda:function(a,b){return"function"==typeof a?a.call(b):a},escapeExpression:b.escapeExpression,invokePartial:d,fn:function(b){var c=a[b];return c.decorator=a[b+"_d"],c},programs:[],program:function(a,b,c,d,e){var f=this.programs[a],g=this.fn(a);return b||e||d||c?f=i(this,a,g,b,c,d,e):f||(f=this.programs[a]=i(this,a,g)),f},data:function(a,b){for(;a&&b--;)a=a._parent;return a},nullContext:Object.seal({}),noop:c.VM.noop,compilerInfo:a.compiler};return f.isTop=!0,f._setup=function(d){if(d.partial)h.helpers=d.helpers,h.partials=d.partials,h.decorators=d.decorators,h.hooks=d.hooks;else{h.helpers=b.extend({},c.helpers,d.helpers),a.usePartial&&(h.partials=b.extend({},c.partials,d.partials)),(a.usePartial||a.useDecorators)&&(h.decorators=b.extend({},c.decorators,d.decorators)),h.hooks={};var f=d.allowCallsToHelperMissing||g;e.moveHelperToHooks(h,"helperMissing",f),e.moveHelperToHooks(h,"blockHelperMissing",f)}},f._child=function(b,c,d,e){if(a.useBlockParams&&!d)throw new o["default"]("must pass block params");if(a.useDepths&&!e)throw new o["default"]("must pass parent depths");return i(h,b,a[b],c,0,d,e)},f}function i(a,b,c,d,e,f,g){function h(b){var e=arguments.length<=1||void 0===arguments[1]?{}:arguments[1],h=g;return!g||b==g[0]||b===a.nullContext&&null===g[0]||(h=[b].concat(g)),c(a,b,a.helpers,a.partials,e.data||d,f&&[e.blockParams].concat(f),h)}return h=n(c,h,a,g,d,f),h.program=b,h.depth=g?g.length:0,h.blockParams=e||0,h}function j(a,b,c){return a?a.call||c.name||(c.name=a,a=c.partials[a]):a="@partial-block"===c.name?c.data["partial-block"]:c.partials[c.name],a}function k(a,c,e){var f=e.data&&e.data["partial-block"];e.partial=!0,e.ids&&(e.data.contextPath=e.ids[0]||e.data.contextPath);var g=void 0;if(e.fn&&e.fn!==l&&!function(){e.data=d.createFrame(e.data);var a=e.fn;g=e.data["partial-block"]=function(b){var c=arguments.length<=1||void 0===arguments[1]?{}:arguments[1];return c.data=d.createFrame(c.data),c.data["partial-block"]=f,a(b,c)},a.partials&&(e.partials=b.extend({},e.partials,a.partials))}(),void 0===a&&g&&(a=g),void 0===a)throw new o["default"]("The partial "+e.name+" could not be found");if(a instanceof Function)return a(c,e)}function l(){return""}function m(a,b){return b&&"root"in b||(b=b?d.createFrame(b):{},b.root=a),b}function n(a,c,d,e,f,g){if(a.decorator){var h={};c=a.decorator(c,h,d,e&&e[0],f,g,e),b.extend(c,h)}return c}a.__esModule=!0,a.checkRevision=g,a.template=h,a.wrapProgram=i,a.resolvePartial=j,a.invokePartial=k,a.noop=l;var o=f(c)}),define("handlebars/no-conflict",["exports","module"],function(a,b){"use strict";b.exports=function(a){var b="undefined"!=typeof global?global:window,c=b.Handlebars;a.noConflict=function(){return b.Handlebars===a&&(b.Handlebars=c),a}}}),define("handlebars.runtime",["exports","module","./handlebars/base","./handlebars/safe-string","./handlebars/exception","./handlebars/utils","./handlebars/runtime","./handlebars/no-conflict"],function(a,b,c,d,e,f,g,h){"use strict";function i(a){return a&&a.__esModule?a:{"default":a}}function j(){var a=new c.HandlebarsEnvironment;return f.extend(a,c),a.SafeString=k["default"],a.Exception=l["default"],a.Utils=f,a.escapeExpression=f.escapeExpression,a.VM=g,a.template=function(b){return g.template(b,a)},a}var k=i(d),l=i(e),m=i(h),n=j();n.create=j,m["default"](n),n["default"]=n,b.exports=n}),define("handlebars/compiler/ast",["exports","module"],function(a,b){"use strict";var c={helpers:{helperExpression:function(a){return"SubExpression"===a.type||("MustacheStatement"===a.type||"BlockStatement"===a.type)&&!!(a.params&&a.params.length||a.hash)},scopedId:function(a){return/^\.|this\b/.test(a.original)},simpleId:function(a){return 1===a.parts.length&&!c.helpers.scopedId(a)&&!a.depth}}};b.exports=c}),define("handlebars/compiler/parser",["exports","module"],function(a,b){"use strict";var c=function(){function a(){this.yy={}}var b={trace:function(){},yy:{},symbols_:{error:2,root:3,program:4,EOF:5,program_repetition0:6,statement:7,mustache:8,block:9,rawBlock:10,partial:11,partialBlock:12,content:13,COMMENT:14,CONTENT:15,openRawBlock:16,rawBlock_repetition0:17,END_RAW_BLOCK:18,OPEN_RAW_BLOCK:19,helperName:20,openRawBlock_repetition0:21,openRawBlock_option0:22,CLOSE_RAW_BLOCK:23,openBlock:24,block_option0:25,closeBlock:26,openInverse:27,block_option1:28,OPEN_BLOCK:29,openBlock_repetition0:30,openBlock_option0:31,openBlock_option1:32,CLOSE:33,OPEN_INVERSE:34,openInverse_repetition0:35,openInverse_option0:36,openInverse_option1:37,openInverseChain:38,OPEN_INVERSE_CHAIN:39,openInverseChain_repetition0:40,openInverseChain_option0:41,openInverseChain_option1:42,inverseAndProgram:43,INVERSE:44,inverseChain:45,inverseChain_option0:46,OPEN_ENDBLOCK:47,OPEN:48,mustache_repetition0:49,mustache_option0:50,OPEN_UNESCAPED:51,mustache_repetition1:52,mustache_option1:53,CLOSE_UNESCAPED:54,OPEN_PARTIAL:55,partialName:56,partial_repetition0:57,partial_option0:58,openPartialBlock:59,OPEN_PARTIAL_BLOCK:60,openPartialBlock_repetition0:61,openPartialBlock_option0:62,param:63,sexpr:64,OPEN_SEXPR:65,sexpr_repetition0:66,sexpr_option0:67,CLOSE_SEXPR:68,hash:69,hash_repetition_plus0:70,hashSegment:71,ID:72,EQUALS:73,blockParams:74,OPEN_BLOCK_PARAMS:75,blockParams_repetition_plus0:76,CLOSE_BLOCK_PARAMS:77,path:78,dataName:79,STRING:80,NUMBER:81,BOOLEAN:82,UNDEFINED:83,NULL:84,DATA:85,pathSegments:86,SEP:87,$accept:0,$end:1},terminals_:{2:"error",5:"EOF",14:"COMMENT",15:"CONTENT",18:"END_RAW_BLOCK",19:"OPEN_RAW_BLOCK",23:"CLOSE_RAW_BLOCK",29:"OPEN_BLOCK",33:"CLOSE",34:"OPEN_INVERSE",39:"OPEN_INVERSE_CHAIN",44:"INVERSE",47:"OPEN_ENDBLOCK",48:"OPEN",51:"OPEN_UNESCAPED",54:"CLOSE_UNESCAPED",55:"OPEN_PARTIAL",60:"OPEN_PARTIAL_BLOCK",65:"OPEN_SEXPR",68:"CLOSE_SEXPR",72:"ID",73:"EQUALS",75:"OPEN_BLOCK_PARAMS",77:"CLOSE_BLOCK_PARAMS",80:"STRING",81:"NUMBER",82:"BOOLEAN",83:"UNDEFINED",84:"NULL",85:"DATA",87:"SEP"},productions_:[0,[3,2],[4,1],[7,1],[7,1],[7,1],[7,1],[7,1],[7,1],[7,1],[13,1],[10,3],[16,5],[9,4],[9,4],[24,6],[27,6],[38,6],[43,2],[45,3],[45,1],[26,3],[8,5],[8,5],[11,5],[12,3],[59,5],[63,1],[63,1],[64,5],[69,1],[71,3],[74,3],[20,1],[20,1],[20,1],[20,1],[20,1],[20,1],[20,1],[56,1],[56,1],[79,2],[78,1],[86,3],[86,1],[6,0],[6,2],[17,0],[17,2],[21,0],[21,2],[22,0],[22,1],[25,0],[25,1],[28,0],[28,1],[30,0],[30,2],[31,0],[31,1],[32,0],[32,1],[35,0],[35,2],[36,0],[36,1],[37,0],[37,1],[40,0],[40,2],[41,0],[41,1],[42,0],[42,1],[46,0],[46,1],[49,0],[49,2],[50,0],[50,1],[52,0],[52,2],[53,0],[53,1],[57,0],[57,2],[58,0],[58,1],[61,0],[61,2],[62,0],[62,1],[66,0],[66,2],[67,0],[67,1],[70,1],[70,2],[76,1],[76,2]],performAction:function(a,b,c,d,e,f,g){var h=f.length-1;switch(e){case 1:return f[h-1];case 2:this.$=d.prepareProgram(f[h]);break;case 3:this.$=f[h];break;case 4:this.$=f[h];break;case 5:this.$=f[h];break;case 6:this.$=f[h];break;case 7:this.$=f[h];break;case 8:this.$=f[h];break;case 9:this.$={type:"CommentStatement",value:d.stripComment(f[h]),strip:d.stripFlags(f[h],f[h]),loc:d.locInfo(this._$)};break;case 10:this.$={type:"ContentStatement",original:f[h],value:f[h],loc:d.locInfo(this._$)};break;case 11:this.$=d.prepareRawBlock(f[h-2],f[h-1],f[h],this._$);break;case 12:this.$={path:f[h-3],params:f[h-2],hash:f[h-1]};break;case 13:this.$=d.prepareBlock(f[h-3],f[h-2],f[h-1],f[h],!1,this._$);break;case 14:this.$=d.prepareBlock(f[h-3],f[h-2],f[h-1],f[h],!0,this._$);break;case 15:this.$={open:f[h-5],path:f[h-4],params:f[h-3],hash:f[h-2],blockParams:f[h-1],strip:d.stripFlags(f[h-5],f[h])};break;case 16:this.$={path:f[h-4],params:f[h-3],hash:f[h-2],blockParams:f[h-1],strip:d.stripFlags(f[h-5],f[h])};break;case 17:this.$={path:f[h-4],params:f[h-3],hash:f[h-2],blockParams:f[h-1],strip:d.stripFlags(f[h-5],f[h])};break;case 18:this.$={strip:d.stripFlags(f[h-1],f[h-1]),program:f[h]};break;case 19:var i=d.prepareBlock(f[h-2],f[h-1],f[h],f[h],!1,this._$),j=d.prepareProgram([i],f[h-1].loc);j.chained=!0,this.$={strip:f[h-2].strip,program:j,chain:!0};break;case 20:this.$=f[h];break;case 21:this.$={path:f[h-1],strip:d.stripFlags(f[h-2],f[h])};break;case 22:this.$=d.prepareMustache(f[h-3],f[h-2],f[h-1],f[h-4],d.stripFlags(f[h-4],f[h]),this._$);break;case 23:this.$=d.prepareMustache(f[h-3],f[h-2],f[h-1],f[h-4],d.stripFlags(f[h-4],f[h]),this._$);break;case 24:this.$={type:"PartialStatement",name:f[h-3],params:f[h-2],hash:f[h-1],indent:"",strip:d.stripFlags(f[h-4],f[h]),loc:d.locInfo(this._$)};break;case 25:this.$=d.preparePartialBlock(f[h-2],f[h-1],f[h],this._$);break;case 26:this.$={path:f[h-3],params:f[h-2],hash:f[h-1],strip:d.stripFlags(f[h-4],f[h])};break;case 27:this.$=f[h];break;case 28:this.$=f[h];break;case 29:this.$={type:"SubExpression",path:f[h-3],params:f[h-2],hash:f[h-1],loc:d.locInfo(this._$)};break;case 30:this.$={type:"Hash",pairs:f[h],loc:d.locInfo(this._$)};break;case 31:this.$={type:"HashPair",key:d.id(f[h-2]),value:f[h],loc:d.locInfo(this._$)};break;case 32:this.$=d.id(f[h-1]);break;case 33:this.$=f[h];break;case 34:this.$=f[h];break;case 35:this.$={type:"StringLiteral",value:f[h],original:f[h],loc:d.locInfo(this._$)};break;case 36:this.$={type:"NumberLiteral",value:Number(f[h]),original:Number(f[h]),loc:d.locInfo(this._$)};break;case 37:this.$={type:"BooleanLiteral",value:"true"===f[h],original:"true"===f[h],loc:d.locInfo(this._$)};break;case 38:this.$={type:"UndefinedLiteral",original:void 0,value:void 0,loc:d.locInfo(this._$)};break;case 39:this.$={type:"NullLiteral",original:null,value:null,loc:d.locInfo(this._$)};break;case 40:this.$=f[h];break;case 41:this.$=f[h];break;case 42:this.$=d.preparePath(!0,f[h],this._$);break;case 43:this.$=d.preparePath(!1,f[h],this._$);break;case 44:f[h-2].push({part:d.id(f[h]),original:f[h],separator:f[h-1]}),this.$=f[h-2];break;case 45:this.$=[{part:d.id(f[h]),original:f[h]}];break;case 46:this.$=[];break;case 47:f[h-1].push(f[h]);break;case 48:this.$=[];break;case 49:f[h-1].push(f[h]);break;case 50:this.$=[];break;case 51:f[h-1].push(f[h]);break;case 58:this.$=[];break;case 59:f[h-1].push(f[h]);break;case 64:this.$=[];break;case 65:f[h-1].push(f[h]);break;case 70:this.$=[];break;case 71:f[h-1].push(f[h]);break;case 78:this.$=[];break;case 79:f[h-1].push(f[h]);break;case 82:this.$=[];break;case 83:f[h-1].push(f[h]);break;case 86:this.$=[];break;case 87:f[h-1].push(f[h]);break;case 90:this.$=[];break;case 91:f[h-1].push(f[h]);break;case 94:this.$=[];break;case 95:f[h-1].push(f[h]);break;case 98:this.$=[f[h]];break;case 99:f[h-1].push(f[h]);break;case 100:this.$=[f[h]];break;case 101:f[h-1].push(f[h])}},table:[{3:1,4:2,5:[2,46],6:3,14:[2,46],15:[2,46],19:[2,46],29:[2,46],34:[2,46],48:[2,46],51:[2,46],55:[2,46],60:[2,46]},{1:[3]},{5:[1,4]},{5:[2,2],7:5,8:6,9:7,10:8,11:9,12:10,13:11,14:[1,12],15:[1,20],16:17,19:[1,23],24:15,27:16,29:[1,21],34:[1,22],39:[2,2],44:[2,2],47:[2,2],48:[1,13],51:[1,14],55:[1,18],59:19,60:[1,24]},{1:[2,1]},{5:[2,47],14:[2,47],15:[2,47],19:[2,47],29:[2,47],34:[2,47],39:[2,47],44:[2,47],47:[2,47],48:[2,47],51:[2,47],55:[2,47],60:[2,47]},{5:[2,3],14:[2,3],15:[2,3],19:[2,3],29:[2,3],34:[2,3],39:[2,3],44:[2,3],47:[2,3],48:[2,3],51:[2,3],55:[2,3],60:[2,3]},{5:[2,4],14:[2,4],15:[2,4],19:[2,4],29:[2,4],34:[2,4],39:[2,4],44:[2,4],47:[2,4],48:[2,4],51:[2,4],55:[2,4],60:[2,4]},{5:[2,5],14:[2,5],15:[2,5],19:[2,5],29:[2,5],34:[2,5],39:[2,5],44:[2,5],47:[2,5],48:[2,5],51:[2,5],55:[2,5],60:[2,5]},{5:[2,6],14:[2,6],15:[2,6],19:[2,6],29:[2,6],34:[2,6],39:[2,6],44:[2,6],47:[2,6],48:[2,6],51:[2,6],55:[2,6],60:[2,6]},{5:[2,7],14:[2,7],15:[2,7],19:[2,7],29:[2,7],34:[2,7],39:[2,7],44:[2,7],47:[2,7],48:[2,7],51:[2,7],55:[2,7],60:[2,7]},{5:[2,8],14:[2,8],15:[2,8],19:[2,8],29:[2,8],34:[2,8],39:[2,8],44:[2,8],47:[2,8],48:[2,8],51:[2,8],55:[2,8],60:[2,8]},{5:[2,9],14:[2,9],15:[2,9],19:[2,9],29:[2,9],34:[2,9],39:[2,9],44:[2,9],47:[2,9],48:[2,9],51:[2,9],55:[2,9],60:[2,9]},{20:25,72:[1,35],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{20:36,72:[1,35],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{4:37,6:3,14:[2,46],15:[2,46],19:[2,46],29:[2,46],34:[2,46],39:[2,46],44:[2,46],47:[2,46],48:[2,46],51:[2,46],55:[2,46],60:[2,46]},{4:38,6:3,14:[2,46],15:[2,46],19:[2,46],29:[2,46],34:[2,46],44:[2,46],47:[2,46],48:[2,46],51:[2,46],55:[2,46],60:[2,46]},{15:[2,48],17:39,18:[2,48]},{20:41,56:40,64:42,65:[1,43],72:[1,35],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{4:44,6:3,14:[2,46],15:[2,46],19:[2,46],29:[2,46],34:[2,46],47:[2,46],48:[2,46],51:[2,46],55:[2,46],60:[2,46]},{5:[2,10],14:[2,10],15:[2,10],18:[2,10],19:[2,10],29:[2,10],34:[2,10],39:[2,10],44:[2,10],47:[2,10],48:[2,10],51:[2,10],55:[2,10],60:[2,10]},{20:45,72:[1,35],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{20:46,72:[1,35],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{20:47,72:[1,35],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{20:41,56:48,64:42,65:[1,43],72:[1,35],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{33:[2,78],49:49,65:[2,78],72:[2,78],80:[2,78],81:[2,78],82:[2,78],83:[2,78],84:[2,78],85:[2,78]},{23:[2,33],33:[2,33],54:[2,33],65:[2,33],68:[2,33],72:[2,33],75:[2,33],80:[2,33],81:[2,33],82:[2,33],83:[2,33],84:[2,33],85:[2,33]},{23:[2,34],33:[2,34],54:[2,34],65:[2,34],68:[2,34],72:[2,34],75:[2,34],80:[2,34],81:[2,34],82:[2,34],83:[2,34],84:[2,34],85:[2,34]},{23:[2,35],33:[2,35],54:[2,35],65:[2,35],68:[2,35],72:[2,35],75:[2,35],80:[2,35],81:[2,35],82:[2,35],83:[2,35],84:[2,35],85:[2,35]},{23:[2,36],33:[2,36],54:[2,36],65:[2,36],68:[2,36],72:[2,36],75:[2,36],80:[2,36],81:[2,36],82:[2,36],83:[2,36],84:[2,36],85:[2,36]},{23:[2,37],33:[2,37],54:[2,37],65:[2,37],68:[2,37],72:[2,37],75:[2,37],80:[2,37],81:[2,37],82:[2,37],83:[2,37],84:[2,37],85:[2,37]},{23:[2,38],33:[2,38],54:[2,38],65:[2,38],68:[2,38],72:[2,38],75:[2,38],80:[2,38],81:[2,38],82:[2,38],83:[2,38],84:[2,38],85:[2,38]},{23:[2,39],33:[2,39],54:[2,39],65:[2,39],68:[2,39],72:[2,39],75:[2,39],80:[2,39],81:[2,39],82:[2,39],83:[2,39],84:[2,39],85:[2,39]},{23:[2,43],33:[2,43],54:[2,43],65:[2,43],68:[2,43],72:[2,43],75:[2,43],80:[2,43],81:[2,43],82:[2,43],83:[2,43],84:[2,43],85:[2,43],87:[1,50]},{72:[1,35],86:51},{23:[2,45],33:[2,45],54:[2,45],65:[2,45],68:[2,45],72:[2,45],75:[2,45],80:[2,45],81:[2,45],82:[2,45],83:[2,45],84:[2,45],85:[2,45],87:[2,45]},{52:52,54:[2,82],65:[2,82],72:[2,82],80:[2,82],81:[2,82],82:[2,82],83:[2,82],84:[2,82],85:[2,82]},{25:53,38:55,39:[1,57],43:56,44:[1,58],45:54,47:[2,54]},{28:59,43:60,44:[1,58],47:[2,56]},{13:62,15:[1,20],18:[1,61]},{33:[2,86],57:63,65:[2,86],72:[2,86],80:[2,86],81:[2,86],82:[2,86],83:[2,86],84:[2,86],85:[2,86]},{33:[2,40],65:[2,40],72:[2,40],80:[2,40],81:[2,40],82:[2,40],83:[2,40],84:[2,40],85:[2,40]},{33:[2,41],65:[2,41],72:[2,41],80:[2,41],81:[2,41],82:[2,41],83:[2,41],84:[2,41],85:[2,41]},{20:64,72:[1,35],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{26:65,47:[1,66]},{30:67,33:[2,58],65:[2,58],72:[2,58],75:[2,58],80:[2,58],81:[2,58],82:[2,58],83:[2,58],84:[2,58],85:[2,58]},{33:[2,64],35:68,65:[2,64],72:[2,64],75:[2,64],80:[2,64],81:[2,64],82:[2,64],83:[2,64],84:[2,64],85:[2,64]},{21:69,23:[2,50],65:[2,50],72:[2,50],80:[2,50],81:[2,50],82:[2,50],83:[2,50],84:[2,50],85:[2,50]},{33:[2,90],61:70,65:[2,90],72:[2,90],80:[2,90],81:[2,90],82:[2,90],83:[2,90],84:[2,90],85:[2,90]},{20:74,33:[2,80],50:71,63:72,64:75,65:[1,43],69:73,70:76,71:77,72:[1,78],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{72:[1,79]},{23:[2,42],33:[2,42],54:[2,42],65:[2,42],68:[2,42],72:[2,42],75:[2,42],80:[2,42],81:[2,42],82:[2,42],83:[2,42],84:[2,42],85:[2,42],87:[1,50]},{20:74,53:80,54:[2,84],63:81,64:75,65:[1,43],69:82,70:76,71:77,72:[1,78],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{26:83,47:[1,66]},{47:[2,55]},{4:84,6:3,14:[2,46],15:[2,46],19:[2,46],29:[2,46],34:[2,46],39:[2,46],44:[2,46],47:[2,46],48:[2,46],51:[2,46],55:[2,46],60:[2,46]},{47:[2,20]},{20:85,72:[1,35],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{4:86,6:3,14:[2,46],15:[2,46],19:[2,46],29:[2,46],34:[2,46],47:[2,46],48:[2,46],51:[2,46],55:[2,46],60:[2,46]},{26:87,47:[1,66]},{47:[2,57]},{5:[2,11],14:[2,11],15:[2,11],19:[2,11],29:[2,11],34:[2,11],39:[2,11],44:[2,11],47:[2,11],48:[2,11],51:[2,11],55:[2,11],60:[2,11]},{15:[2,49],18:[2,49]},{20:74,33:[2,88],58:88,63:89,64:75,65:[1,43],69:90,70:76,71:77,72:[1,78],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{65:[2,94],66:91,68:[2,94],72:[2,94],80:[2,94],81:[2,94],82:[2,94],83:[2,94],84:[2,94],85:[2,94]},{5:[2,25],14:[2,25],15:[2,25],19:[2,25],29:[2,25],34:[2,25],39:[2,25],44:[2,25],47:[2,25],48:[2,25],51:[2,25],55:[2,25],60:[2,25]},{20:92,72:[1,35],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{20:74,31:93,33:[2,60],63:94,64:75,65:[1,43],69:95,70:76,71:77,72:[1,78],75:[2,60],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{20:74,33:[2,66],36:96,63:97,64:75,65:[1,43],69:98,70:76,71:77,72:[1,78],75:[2,66],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{20:74,22:99,23:[2,52],63:100,64:75,65:[1,43],69:101,70:76,71:77,72:[1,78],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{20:74,33:[2,92],62:102,63:103,64:75,65:[1,43],69:104,70:76,71:77,72:[1,78],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{33:[1,105]},{33:[2,79],65:[2,79],72:[2,79],80:[2,79],81:[2,79],82:[2,79],83:[2,79],84:[2,79],85:[2,79]},{33:[2,81]},{23:[2,27],33:[2,27],54:[2,27],65:[2,27],68:[2,27],72:[2,27],75:[2,27],80:[2,27],81:[2,27],82:[2,27],83:[2,27],84:[2,27],85:[2,27]},{23:[2,28],33:[2,28],54:[2,28],65:[2,28],68:[2,28],72:[2,28],75:[2,28],80:[2,28],81:[2,28],82:[2,28],83:[2,28],84:[2,28],85:[2,28]},{23:[2,30],33:[2,30],54:[2,30],68:[2,30],71:106,72:[1,107],75:[2,30]},{23:[2,98],33:[2,98],54:[2,98],68:[2,98],72:[2,98],75:[2,98]},{23:[2,45],33:[2,45],54:[2,45],65:[2,45],68:[2,45],72:[2,45],73:[1,108],75:[2,45],80:[2,45],81:[2,45],82:[2,45],83:[2,45],84:[2,45],85:[2,45],87:[2,45]},{23:[2,44],33:[2,44],54:[2,44],65:[2,44],68:[2,44],72:[2,44],75:[2,44],80:[2,44],81:[2,44],82:[2,44],83:[2,44],84:[2,44],85:[2,44],87:[2,44]},{54:[1,109]},{54:[2,83],65:[2,83],72:[2,83],80:[2,83],81:[2,83],82:[2,83],83:[2,83],84:[2,83],85:[2,83]},{54:[2,85]},{5:[2,13],14:[2,13],15:[2,13],19:[2,13],29:[2,13],34:[2,13],39:[2,13],44:[2,13],47:[2,13],48:[2,13],51:[2,13],55:[2,13],60:[2,13]},{38:55,39:[1,57],43:56,44:[1,58],45:111,46:110,47:[2,76]},{33:[2,70],40:112,65:[2,70],72:[2,70],75:[2,70],80:[2,70],81:[2,70],82:[2,70],83:[2,70],84:[2,70],85:[2,70]},{47:[2,18]},{5:[2,14],14:[2,14],15:[2,14],19:[2,14],29:[2,14],34:[2,14],39:[2,14],44:[2,14],47:[2,14],48:[2,14],51:[2,14],55:[2,14],60:[2,14]},{33:[1,113]},{33:[2,87],65:[2,87],72:[2,87],80:[2,87],81:[2,87],82:[2,87],83:[2,87],84:[2,87],85:[2,87]},{33:[2,89]},{20:74,63:115,64:75,65:[1,43],67:114,68:[2,96],69:116,70:76,71:77,72:[1,78],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{33:[1,117]},{32:118,33:[2,62],74:119,75:[1,120]},{33:[2,59],65:[2,59],72:[2,59],75:[2,59],80:[2,59],81:[2,59],82:[2,59],83:[2,59],84:[2,59],85:[2,59]},{33:[2,61],75:[2,61]},{33:[2,68],37:121,74:122,75:[1,120]},{33:[2,65],65:[2,65],72:[2,65],75:[2,65],80:[2,65],81:[2,65],82:[2,65],83:[2,65],84:[2,65],85:[2,65]},{33:[2,67],75:[2,67]},{23:[1,123]},{23:[2,51],65:[2,51],72:[2,51],80:[2,51],81:[2,51],82:[2,51],83:[2,51],84:[2,51],85:[2,51]},{23:[2,53]},{33:[1,124]},{33:[2,91],65:[2,91],72:[2,91],80:[2,91],81:[2,91],82:[2,91],83:[2,91],84:[2,91],85:[2,91]},{33:[2,93]},{5:[2,22],14:[2,22],15:[2,22],19:[2,22],29:[2,22],34:[2,22],39:[2,22],44:[2,22],47:[2,22],48:[2,22],51:[2,22],55:[2,22],60:[2,22]},{23:[2,99],33:[2,99],54:[2,99],68:[2,99],72:[2,99],75:[2,99]},{73:[1,108]},{20:74,63:125,64:75,65:[1,43],72:[1,35],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{5:[2,23],14:[2,23],15:[2,23],19:[2,23],29:[2,23],34:[2,23],39:[2,23],44:[2,23],47:[2,23],48:[2,23],51:[2,23],55:[2,23],60:[2,23]},{47:[2,19]},{47:[2,77]},{20:74,33:[2,72],41:126,63:127,64:75,65:[1,43],69:128,70:76,71:77,72:[1,78],75:[2,72],78:26,79:27,80:[1,28],81:[1,29],82:[1,30],83:[1,31],84:[1,32],85:[1,34],86:33},{5:[2,24],14:[2,24],15:[2,24],19:[2,24],29:[2,24],34:[2,24],39:[2,24],44:[2,24],47:[2,24],48:[2,24],51:[2,24],55:[2,24],60:[2,24]},{68:[1,129]},{65:[2,95],68:[2,95],72:[2,95],80:[2,95],81:[2,95],82:[2,95],
-83:[2,95],84:[2,95],85:[2,95]},{68:[2,97]},{5:[2,21],14:[2,21],15:[2,21],19:[2,21],29:[2,21],34:[2,21],39:[2,21],44:[2,21],47:[2,21],48:[2,21],51:[2,21],55:[2,21],60:[2,21]},{33:[1,130]},{33:[2,63]},{72:[1,132],76:131},{33:[1,133]},{33:[2,69]},{15:[2,12],18:[2,12]},{14:[2,26],15:[2,26],19:[2,26],29:[2,26],34:[2,26],47:[2,26],48:[2,26],51:[2,26],55:[2,26],60:[2,26]},{23:[2,31],33:[2,31],54:[2,31],68:[2,31],72:[2,31],75:[2,31]},{33:[2,74],42:134,74:135,75:[1,120]},{33:[2,71],65:[2,71],72:[2,71],75:[2,71],80:[2,71],81:[2,71],82:[2,71],83:[2,71],84:[2,71],85:[2,71]},{33:[2,73],75:[2,73]},{23:[2,29],33:[2,29],54:[2,29],65:[2,29],68:[2,29],72:[2,29],75:[2,29],80:[2,29],81:[2,29],82:[2,29],83:[2,29],84:[2,29],85:[2,29]},{14:[2,15],15:[2,15],19:[2,15],29:[2,15],34:[2,15],39:[2,15],44:[2,15],47:[2,15],48:[2,15],51:[2,15],55:[2,15],60:[2,15]},{72:[1,137],77:[1,136]},{72:[2,100],77:[2,100]},{14:[2,16],15:[2,16],19:[2,16],29:[2,16],34:[2,16],44:[2,16],47:[2,16],48:[2,16],51:[2,16],55:[2,16],60:[2,16]},{33:[1,138]},{33:[2,75]},{33:[2,32]},{72:[2,101],77:[2,101]},{14:[2,17],15:[2,17],19:[2,17],29:[2,17],34:[2,17],39:[2,17],44:[2,17],47:[2,17],48:[2,17],51:[2,17],55:[2,17],60:[2,17]}],defaultActions:{4:[2,1],54:[2,55],56:[2,20],60:[2,57],73:[2,81],82:[2,85],86:[2,18],90:[2,89],101:[2,53],104:[2,93],110:[2,19],111:[2,77],116:[2,97],119:[2,63],122:[2,69],135:[2,75],136:[2,32]},parseError:function(a,b){throw new Error(a)},parse:function(a){function b(){var a;return a=c.lexer.lex()||1,"number"!=typeof a&&(a=c.symbols_[a]||a),a}var c=this,d=[0],e=[null],f=[],g=this.table,h="",i=0,j=0,k=0;this.lexer.setInput(a),this.lexer.yy=this.yy,this.yy.lexer=this.lexer,this.yy.parser=this,"undefined"==typeof this.lexer.yylloc&&(this.lexer.yylloc={});var l=this.lexer.yylloc;f.push(l);var m=this.lexer.options&&this.lexer.options.ranges;"function"==typeof this.yy.parseError&&(this.parseError=this.yy.parseError);for(var n,o,p,q,r,s,t,u,v,w={};;){if(p=d[d.length-1],this.defaultActions[p]?q=this.defaultActions[p]:(null!==n&&"undefined"!=typeof n||(n=b()),q=g[p]&&g[p][n]),"undefined"==typeof q||!q.length||!q[0]){var x="";if(!k){v=[];for(s in g[p])this.terminals_[s]&&s>2&&v.push("'"+this.terminals_[s]+"'");x=this.lexer.showPosition?"Parse error on line "+(i+1)+":\n"+this.lexer.showPosition()+"\nExpecting "+v.join(", ")+", got '"+(this.terminals_[n]||n)+"'":"Parse error on line "+(i+1)+": Unexpected "+(1==n?"end of input":"'"+(this.terminals_[n]||n)+"'"),this.parseError(x,{text:this.lexer.match,token:this.terminals_[n]||n,line:this.lexer.yylineno,loc:l,expected:v})}}if(q[0]instanceof Array&&q.length>1)throw new Error("Parse Error: multiple actions possible at state: "+p+", token: "+n);switch(q[0]){case 1:d.push(n),e.push(this.lexer.yytext),f.push(this.lexer.yylloc),d.push(q[1]),n=null,o?(n=o,o=null):(j=this.lexer.yyleng,h=this.lexer.yytext,i=this.lexer.yylineno,l=this.lexer.yylloc,k>0&&k--);break;case 2:if(t=this.productions_[q[1]][1],w.$=e[e.length-t],w._$={first_line:f[f.length-(t||1)].first_line,last_line:f[f.length-1].last_line,first_column:f[f.length-(t||1)].first_column,last_column:f[f.length-1].last_column},m&&(w._$.range=[f[f.length-(t||1)].range[0],f[f.length-1].range[1]]),r=this.performAction.call(w,h,j,i,this.yy,q[1],e,f),"undefined"!=typeof r)return r;t&&(d=d.slice(0,-1*t*2),e=e.slice(0,-1*t),f=f.slice(0,-1*t)),d.push(this.productions_[q[1]][0]),e.push(w.$),f.push(w._$),u=g[d[d.length-2]][d[d.length-1]],d.push(u);break;case 3:return!0}}return!0}},c=function(){var a={EOF:1,parseError:function(a,b){if(!this.yy.parser)throw new Error(a);this.yy.parser.parseError(a,b)},setInput:function(a){return this._input=a,this._more=this._less=this.done=!1,this.yylineno=this.yyleng=0,this.yytext=this.matched=this.match="",this.conditionStack=["INITIAL"],this.yylloc={first_line:1,first_column:0,last_line:1,last_column:0},this.options.ranges&&(this.yylloc.range=[0,0]),this.offset=0,this},input:function(){var a=this._input[0];this.yytext+=a,this.yyleng++,this.offset++,this.match+=a,this.matched+=a;var b=a.match(/(?:\r\n?|\n).*/g);return b?(this.yylineno++,this.yylloc.last_line++):this.yylloc.last_column++,this.options.ranges&&this.yylloc.range[1]++,this._input=this._input.slice(1),a},unput:function(a){var b=a.length,c=a.split(/(?:\r\n?|\n)/g);this._input=a+this._input,this.yytext=this.yytext.substr(0,this.yytext.length-b-1),this.offset-=b;var d=this.match.split(/(?:\r\n?|\n)/g);this.match=this.match.substr(0,this.match.length-1),this.matched=this.matched.substr(0,this.matched.length-1),c.length-1&&(this.yylineno-=c.length-1);var e=this.yylloc.range;return this.yylloc={first_line:this.yylloc.first_line,last_line:this.yylineno+1,first_column:this.yylloc.first_column,last_column:c?(c.length===d.length?this.yylloc.first_column:0)+d[d.length-c.length].length-c[0].length:this.yylloc.first_column-b},this.options.ranges&&(this.yylloc.range=[e[0],e[0]+this.yyleng-b]),this},more:function(){return this._more=!0,this},less:function(a){this.unput(this.match.slice(a))},pastInput:function(){var a=this.matched.substr(0,this.matched.length-this.match.length);return(a.length>20?"...":"")+a.substr(-20).replace(/\n/g,"")},upcomingInput:function(){var a=this.match;return a.length<20&&(a+=this._input.substr(0,20-a.length)),(a.substr(0,20)+(a.length>20?"...":"")).replace(/\n/g,"")},showPosition:function(){var a=this.pastInput(),b=new Array(a.length+1).join("-");return a+this.upcomingInput()+"\n"+b+"^"},next:function(){if(this.done)return this.EOF;this._input||(this.done=!0);var a,b,c,d,e;this._more||(this.yytext="",this.match="");for(var f=this._currentRules(),g=0;g<f.length&&(c=this._input.match(this.rules[f[g]]),!c||b&&!(c[0].length>b[0].length)||(b=c,d=g,this.options.flex));g++);return b?(e=b[0].match(/(?:\r\n?|\n).*/g),e&&(this.yylineno+=e.length),this.yylloc={first_line:this.yylloc.last_line,last_line:this.yylineno+1,first_column:this.yylloc.last_column,last_column:e?e[e.length-1].length-e[e.length-1].match(/\r?\n?/)[0].length:this.yylloc.last_column+b[0].length},this.yytext+=b[0],this.match+=b[0],this.matches=b,this.yyleng=this.yytext.length,this.options.ranges&&(this.yylloc.range=[this.offset,this.offset+=this.yyleng]),this._more=!1,this._input=this._input.slice(b[0].length),this.matched+=b[0],a=this.performAction.call(this,this.yy,this,f[d],this.conditionStack[this.conditionStack.length-1]),this.done&&this._input&&(this.done=!1),a?a:void 0):""===this._input?this.EOF:this.parseError("Lexical error on line "+(this.yylineno+1)+". Unrecognized text.\n"+this.showPosition(),{text:"",token:null,line:this.yylineno})},lex:function(){var a=this.next();return"undefined"!=typeof a?a:this.lex()},begin:function(a){this.conditionStack.push(a)},popState:function(){return this.conditionStack.pop()},_currentRules:function(){return this.conditions[this.conditionStack[this.conditionStack.length-1]].rules},topState:function(){return this.conditionStack[this.conditionStack.length-2]},pushState:function(a){this.begin(a)}};return a.options={},a.performAction=function(a,b,c,d){function e(a,c){return b.yytext=b.yytext.substring(a,b.yyleng-c+a)}switch(c){case 0:if("\\\\"===b.yytext.slice(-2)?(e(0,1),this.begin("mu")):"\\"===b.yytext.slice(-1)?(e(0,1),this.begin("emu")):this.begin("mu"),b.yytext)return 15;break;case 1:return 15;case 2:return this.popState(),15;case 3:return this.begin("raw"),15;case 4:return this.popState(),"raw"===this.conditionStack[this.conditionStack.length-1]?15:(e(5,9),"END_RAW_BLOCK");case 5:return 15;case 6:return this.popState(),14;case 7:return 65;case 8:return 68;case 9:return 19;case 10:return this.popState(),this.begin("raw"),23;case 11:return 55;case 12:return 60;case 13:return 29;case 14:return 47;case 15:return this.popState(),44;case 16:return this.popState(),44;case 17:return 34;case 18:return 39;case 19:return 51;case 20:return 48;case 21:this.unput(b.yytext),this.popState(),this.begin("com");break;case 22:return this.popState(),14;case 23:return 48;case 24:return 73;case 25:return 72;case 26:return 72;case 27:return 87;case 28:break;case 29:return this.popState(),54;case 30:return this.popState(),33;case 31:return b.yytext=e(1,2).replace(/\\"/g,'"'),80;case 32:return b.yytext=e(1,2).replace(/\\'/g,"'"),80;case 33:return 85;case 34:return 82;case 35:return 82;case 36:return 83;case 37:return 84;case 38:return 81;case 39:return 75;case 40:return 77;case 41:return 72;case 42:return b.yytext=b.yytext.replace(/\\([\\\]])/g,"$1"),72;case 43:return"INVALID";case 44:return 5}},a.rules=[/^(?:[^\x00]*?(?=(\{\{)))/,/^(?:[^\x00]+)/,/^(?:[^\x00]{2,}?(?=(\{\{|\\\{\{|\\\\\{\{|$)))/,/^(?:\{\{\{\{(?=[^\/]))/,/^(?:\{\{\{\{\/[^\s!"#%-,\.\/;->@\[-\^`\{-~]+(?=[=}\s\/.])\}\}\}\})/,/^(?:[^\x00]+?(?=(\{\{\{\{)))/,/^(?:[\s\S]*?--(~)?\}\})/,/^(?:\()/,/^(?:\))/,/^(?:\{\{\{\{)/,/^(?:\}\}\}\})/,/^(?:\{\{(~)?>)/,/^(?:\{\{(~)?#>)/,/^(?:\{\{(~)?#\*?)/,/^(?:\{\{(~)?\/)/,/^(?:\{\{(~)?\^\s*(~)?\}\})/,/^(?:\{\{(~)?\s*else\s*(~)?\}\})/,/^(?:\{\{(~)?\^)/,/^(?:\{\{(~)?\s*else\b)/,/^(?:\{\{(~)?\{)/,/^(?:\{\{(~)?&)/,/^(?:\{\{(~)?!--)/,/^(?:\{\{(~)?![\s\S]*?\}\})/,/^(?:\{\{(~)?\*?)/,/^(?:=)/,/^(?:\.\.)/,/^(?:\.(?=([=~}\s\/.)|])))/,/^(?:[\/.])/,/^(?:\s+)/,/^(?:\}(~)?\}\})/,/^(?:(~)?\}\})/,/^(?:"(\\["]|[^"])*")/,/^(?:'(\\[']|[^'])*')/,/^(?:@)/,/^(?:true(?=([~}\s)])))/,/^(?:false(?=([~}\s)])))/,/^(?:undefined(?=([~}\s)])))/,/^(?:null(?=([~}\s)])))/,/^(?:-?[0-9]+(?:\.[0-9]+)?(?=([~}\s)])))/,/^(?:as\s+\|)/,/^(?:\|)/,/^(?:([^\s!"#%-,\.\/;->@\[-\^`\{-~]+(?=([=~}\s\/.)|]))))/,/^(?:\[(\\\]|[^\]])*\])/,/^(?:.)/,/^(?:$)/],a.conditions={mu:{rules:[7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44],inclusive:!1},emu:{rules:[2],inclusive:!1},com:{rules:[6],inclusive:!1},raw:{rules:[3,4,5],inclusive:!1},INITIAL:{rules:[0,1,44],inclusive:!0}},a}();return b.lexer=c,a.prototype=b,b.Parser=a,new a}();b.exports=c}),define("handlebars/compiler/visitor",["exports","module","../exception"],function(a,b,c){"use strict";function d(a){return a&&a.__esModule?a:{"default":a}}function e(){this.parents=[]}function f(a){this.acceptRequired(a,"path"),this.acceptArray(a.params),this.acceptKey(a,"hash")}function g(a){f.call(this,a),this.acceptKey(a,"program"),this.acceptKey(a,"inverse")}function h(a){this.acceptRequired(a,"name"),this.acceptArray(a.params),this.acceptKey(a,"hash")}var i=d(c);e.prototype={constructor:e,mutating:!1,acceptKey:function(a,b){var c=this.accept(a[b]);if(this.mutating){if(c&&!e.prototype[c.type])throw new i["default"]('Unexpected node type "'+c.type+'" found when accepting '+b+" on "+a.type);a[b]=c}},acceptRequired:function(a,b){if(this.acceptKey(a,b),!a[b])throw new i["default"](a.type+" requires "+b)},acceptArray:function(a){for(var b=0,c=a.length;b<c;b++)this.acceptKey(a,b),a[b]||(a.splice(b,1),b--,c--)},accept:function(a){if(a){if(!this[a.type])throw new i["default"]("Unknown type: "+a.type,a);this.current&&this.parents.unshift(this.current),this.current=a;var b=this[a.type](a);return this.current=this.parents.shift(),!this.mutating||b?b:b!==!1?a:void 0}},Program:function(a){this.acceptArray(a.body)},MustacheStatement:f,Decorator:f,BlockStatement:g,DecoratorBlock:g,PartialStatement:h,PartialBlockStatement:function(a){h.call(this,a),this.acceptKey(a,"program")},ContentStatement:function(){},CommentStatement:function(){},SubExpression:f,PathExpression:function(){},StringLiteral:function(){},NumberLiteral:function(){},BooleanLiteral:function(){},UndefinedLiteral:function(){},NullLiteral:function(){},Hash:function(a){this.acceptArray(a.pairs)},HashPair:function(a){this.acceptRequired(a,"value")}},b.exports=e}),define("handlebars/compiler/whitespace-control",["exports","module","./visitor"],function(a,b,c){"use strict";function d(a){return a&&a.__esModule?a:{"default":a}}function e(){var a=arguments.length<=0||void 0===arguments[0]?{}:arguments[0];this.options=a}function f(a,b,c){void 0===b&&(b=a.length);var d=a[b-1],e=a[b-2];return d?"ContentStatement"===d.type?(e||!c?/\r?\n\s*?$/:/(^|\r?\n)\s*?$/).test(d.original):void 0:c}function g(a,b,c){void 0===b&&(b=-1);var d=a[b+1],e=a[b+2];return d?"ContentStatement"===d.type?(e||!c?/^\s*?\r?\n/:/^\s*?(\r?\n|$)/).test(d.original):void 0:c}function h(a,b,c){var d=a[null==b?0:b+1];if(d&&"ContentStatement"===d.type&&(c||!d.rightStripped)){var e=d.value;d.value=d.value.replace(c?/^\s+/:/^[ \t]*\r?\n?/,""),d.rightStripped=d.value!==e}}function i(a,b,c){var d=a[null==b?a.length-1:b-1];if(d&&"ContentStatement"===d.type&&(c||!d.leftStripped)){var e=d.value;return d.value=d.value.replace(c?/\s+$/:/[ \t]+$/,""),d.leftStripped=d.value!==e,d.leftStripped}}var j=d(c);e.prototype=new j["default"],e.prototype.Program=function(a){var b=!this.options.ignoreStandalone,c=!this.isRootSeen;this.isRootSeen=!0;for(var d=a.body,e=0,j=d.length;e<j;e++){var k=d[e],l=this.accept(k);if(l){var m=f(d,e,c),n=g(d,e,c),o=l.openStandalone&&m,p=l.closeStandalone&&n,q=l.inlineStandalone&&m&&n;l.close&&h(d,e,!0),l.open&&i(d,e,!0),b&&q&&(h(d,e),i(d,e)&&"PartialStatement"===k.type&&(k.indent=/([ \t]+$)/.exec(d[e-1].original)[1])),b&&o&&(h((k.program||k.inverse).body),i(d,e)),b&&p&&(h(d,e),i((k.inverse||k.program).body))}}return a},e.prototype.BlockStatement=e.prototype.DecoratorBlock=e.prototype.PartialBlockStatement=function(a){this.accept(a.program),this.accept(a.inverse);var b=a.program||a.inverse,c=a.program&&a.inverse,d=c,e=c;if(c&&c.chained)for(d=c.body[0].program;e.chained;)e=e.body[e.body.length-1].program;var j={open:a.openStrip.open,close:a.closeStrip.close,openStandalone:g(b.body),closeStandalone:f((d||b).body)};if(a.openStrip.close&&h(b.body,null,!0),c){var k=a.inverseStrip;k.open&&i(b.body,null,!0),k.close&&h(d.body,null,!0),a.closeStrip.open&&i(e.body,null,!0),!this.options.ignoreStandalone&&f(b.body)&&g(d.body)&&(i(b.body),h(d.body))}else a.closeStrip.open&&i(b.body,null,!0);return j},e.prototype.Decorator=e.prototype.MustacheStatement=function(a){return a.strip},e.prototype.PartialStatement=e.prototype.CommentStatement=function(a){var b=a.strip||{};return{inlineStandalone:!0,open:b.open,close:b.close}},b.exports=e}),define("handlebars/compiler/helpers",["exports","../exception"],function(a,b){"use strict";function c(a){return a&&a.__esModule?a:{"default":a}}function d(a,b){if(b=b.path?b.path.original:b,a.path.original!==b){var c={loc:a.path.loc};throw new o["default"](a.path.original+" doesn't match "+b,c)}}function e(a,b){this.source=a,this.start={line:b.first_line,column:b.first_column},this.end={line:b.last_line,column:b.last_column}}function f(a){return/^\[.*\]$/.test(a)?a.substring(1,a.length-1):a}function g(a,b){return{open:"~"===a.charAt(2),close:"~"===b.charAt(b.length-3)}}function h(a){return a.replace(/^\{\{~?!-?-?/,"").replace(/-?-?~?\}\}$/,"")}function i(a,b,c){c=this.locInfo(c);for(var d=a?"@":"",e=[],f=0,g=0,h=b.length;g<h;g++){var i=b[g].part,j=b[g].original!==i;if(d+=(b[g].separator||"")+i,j||".."!==i&&"."!==i&&"this"!==i)e.push(i);else{if(e.length>0)throw new o["default"]("Invalid path: "+d,{loc:c});".."===i&&f++}}return{type:"PathExpression",data:a,depth:f,parts:e,original:d,loc:c}}function j(a,b,c,d,e,f){var g=d.charAt(3)||d.charAt(2),h="{"!==g&&"&"!==g,i=/\*/.test(d);return{type:i?"Decorator":"MustacheStatement",path:a,params:b,hash:c,escaped:h,strip:e,loc:this.locInfo(f)}}function k(a,b,c,e){d(a,c),e=this.locInfo(e);var f={type:"Program",body:b,strip:{},loc:e};return{type:"BlockStatement",path:a.path,params:a.params,hash:a.hash,program:f,openStrip:{},inverseStrip:{},closeStrip:{},loc:e}}function l(a,b,c,e,f,g){e&&e.path&&d(a,e);var h=/\*/.test(a.open);b.blockParams=a.blockParams;var i=void 0,j=void 0;if(c){if(h)throw new o["default"]("Unexpected inverse block on decorator",c);c.chain&&(c.program.body[0].closeStrip=e.strip),j=c.strip,i=c.program}return f&&(f=i,i=b,b=f),{type:h?"DecoratorBlock":"BlockStatement",path:a.path,params:a.params,hash:a.hash,program:b,inverse:i,openStrip:a.strip,inverseStrip:j,closeStrip:e&&e.strip,loc:this.locInfo(g)}}function m(a,b){if(!b&&a.length){var c=a[0].loc,d=a[a.length-1].loc;c&&d&&(b={source:c.source,start:{line:c.start.line,column:c.start.column},end:{line:d.end.line,column:d.end.column}})}return{type:"Program",body:a,strip:{},loc:b}}function n(a,b,c,e){return d(a,c),{type:"PartialBlockStatement",name:a.path,params:a.params,hash:a.hash,program:b,openStrip:a.strip,closeStrip:c&&c.strip,loc:this.locInfo(e)}}a.__esModule=!0,a.SourceLocation=e,a.id=f,a.stripFlags=g,a.stripComment=h,a.preparePath=i,a.prepareMustache=j,a.prepareRawBlock=k,a.prepareBlock=l,a.prepareProgram=m,a.preparePartialBlock=n;var o=c(b)}),define("handlebars/compiler/base",["exports","./parser","./whitespace-control","./helpers","../utils"],function(a,b,c,d,e){"use strict";function f(a){return a&&a.__esModule?a:{"default":a}}function g(a,b){if("Program"===a.type)return a;i["default"].yy=k,k.locInfo=function(a){return new k.SourceLocation(b&&b.srcName,a)};var c=i["default"].parse(a);return c}function h(a,b){var c=g(a,b),d=new j["default"](b);return d.accept(c)}a.__esModule=!0,a.parseWithoutProcessing=g,a.parse=h;var i=f(b),j=f(c);a.parser=i["default"];var k={};e.extend(k,d)}),define("handlebars/compiler/compiler",["exports","../exception","../utils","./ast"],function(a,b,c,d){"use strict";function e(a){return a&&a.__esModule?a:{"default":a}}function f(){}function g(a,b,c){if(null==a||"string"!=typeof a&&"Program"!==a.type)throw new k["default"]("You must pass a string or Handlebars AST to Handlebars.precompile. You passed "+a);b=b||{},"data"in b||(b.data=!0),b.compat&&(b.useDepths=!0);var d=c.parse(a,b),e=(new c.Compiler).compile(d,b);return(new c.JavaScriptCompiler).compile(e,b)}function h(a,b,d){function e(){var c=d.parse(a,b),e=(new d.Compiler).compile(c,b),f=(new d.JavaScriptCompiler).compile(e,b,void 0,!0);return d.template(f)}function f(a,b){return g||(g=e()),g.call(this,a,b)}if(void 0===b&&(b={}),null==a||"string"!=typeof a&&"Program"!==a.type)throw new k["default"]("You must pass a string or Handlebars AST to Handlebars.compile. You passed "+a);b=c.extend({},b),"data"in b||(b.data=!0),b.compat&&(b.useDepths=!0);var g=void 0;return f._setup=function(a){return g||(g=e()),g._setup(a)},f._child=function(a,b,c,d){return g||(g=e()),g._child(a,b,c,d)},f}function i(a,b){if(a===b)return!0;if(c.isArray(a)&&c.isArray(b)&&a.length===b.length){for(var d=0;d<a.length;d++)if(!i(a[d],b[d]))return!1;return!0}}function j(a){if(!a.path.parts){var b=a.path;a.path={type:"PathExpression",data:!1,depth:0,parts:[b.original+""],original:b.original+"",loc:b.loc}}}a.__esModule=!0,a.Compiler=f,a.precompile=g,a.compile=h;var k=e(b),l=e(d),m=[].slice;f.prototype={compiler:f,equals:function(a){var b=this.opcodes.length;if(a.opcodes.length!==b)return!1;for(var c=0;c<b;c++){var d=this.opcodes[c],e=a.opcodes[c];if(d.opcode!==e.opcode||!i(d.args,e.args))return!1}b=this.children.length;for(var c=0;c<b;c++)if(!this.children[c].equals(a.children[c]))return!1;return!0},guid:0,compile:function(a,b){return this.sourceNode=[],this.opcodes=[],this.children=[],this.options=b,this.stringParams=b.stringParams,this.trackIds=b.trackIds,b.blockParams=b.blockParams||[],b.knownHelpers=c.extend(Object.create(null),{helperMissing:!0,blockHelperMissing:!0,each:!0,"if":!0,unless:!0,"with":!0,log:!0,lookup:!0},b.knownHelpers),this.accept(a)},compileProgram:function(a){var b=new this.compiler,c=b.compile(a,this.options),d=this.guid++;return this.usePartial=this.usePartial||c.usePartial,this.children[d]=c,this.useDepths=this.useDepths||c.useDepths,d},accept:function(a){if(!this[a.type])throw new k["default"]("Unknown type: "+a.type,a);this.sourceNode.unshift(a);var b=this[a.type](a);return this.sourceNode.shift(),b},Program:function(a){this.options.blockParams.unshift(a.blockParams);for(var b=a.body,c=b.length,d=0;d<c;d++)this.accept(b[d]);return this.options.blockParams.shift(),this.isSimple=1===c,this.blockParams=a.blockParams?a.blockParams.length:0,this},BlockStatement:function(a){j(a);var b=a.program,c=a.inverse;b=b&&this.compileProgram(b),c=c&&this.compileProgram(c);var d=this.classifySexpr(a);"helper"===d?this.helperSexpr(a,b,c):"simple"===d?(this.simpleSexpr(a),this.opcode("pushProgram",b),this.opcode("pushProgram",c),this.opcode("emptyHash"),this.opcode("blockValue",a.path.original)):(this.ambiguousSexpr(a,b,c),this.opcode("pushProgram",b),this.opcode("pushProgram",c),this.opcode("emptyHash"),this.opcode("ambiguousBlockValue")),this.opcode("append")},DecoratorBlock:function(a){var b=a.program&&this.compileProgram(a.program),c=this.setupFullMustacheParams(a,b,void 0),d=a.path;this.useDecorators=!0,this.opcode("registerDecorator",c.length,d.original)},PartialStatement:function(a){this.usePartial=!0;var b=a.program;b&&(b=this.compileProgram(a.program));var c=a.params;if(c.length>1)throw new k["default"]("Unsupported number of partial arguments: "+c.length,a);c.length||(this.options.explicitPartialContext?this.opcode("pushLiteral","undefined"):c.push({type:"PathExpression",parts:[],depth:0}));var d=a.name.original,e="SubExpression"===a.name.type;e&&this.accept(a.name),this.setupFullMustacheParams(a,b,void 0,!0);var f=a.indent||"";this.options.preventIndent&&f&&(this.opcode("appendContent",f),f=""),this.opcode("invokePartial",e,d,f),this.opcode("append")},PartialBlockStatement:function(a){this.PartialStatement(a)},MustacheStatement:function(a){this.SubExpression(a),a.escaped&&!this.options.noEscape?this.opcode("appendEscaped"):this.opcode("append")},Decorator:function(a){this.DecoratorBlock(a)},ContentStatement:function(a){a.value&&this.opcode("appendContent",a.value)},CommentStatement:function(){},SubExpression:function(a){j(a);var b=this.classifySexpr(a);"simple"===b?this.simpleSexpr(a):"helper"===b?this.helperSexpr(a):this.ambiguousSexpr(a)},ambiguousSexpr:function(a,b,c){var d=a.path,e=d.parts[0],f=null!=b||null!=c;this.opcode("getContext",d.depth),this.opcode("pushProgram",b),this.opcode("pushProgram",c),d.strict=!0,this.accept(d),this.opcode("invokeAmbiguous",e,f)},simpleSexpr:function(a){var b=a.path;b.strict=!0,this.accept(b),this.opcode("resolvePossibleLambda")},helperSexpr:function(a,b,c){var d=this.setupFullMustacheParams(a,b,c),e=a.path,f=e.parts[0];if(this.options.knownHelpers[f])this.opcode("invokeKnownHelper",d.length,f);else{if(this.options.knownHelpersOnly)throw new k["default"]("You specified knownHelpersOnly, but used the unknown helper "+f,a);e.strict=!0,e.falsy=!0,this.accept(e),this.opcode("invokeHelper",d.length,e.original,l["default"].helpers.simpleId(e))}},PathExpression:function(a){this.addDepth(a.depth),this.opcode("getContext",a.depth);var b=a.parts[0],c=l["default"].helpers.scopedId(a),d=!a.depth&&!c&&this.blockParamIndex(b);d?this.opcode("lookupBlockParam",d,a.parts):b?a.data?(this.options.data=!0,this.opcode("lookupData",a.depth,a.parts,a.strict)):this.opcode("lookupOnContext",a.parts,a.falsy,a.strict,c):this.opcode("pushContext")},StringLiteral:function(a){this.opcode("pushString",a.value)},NumberLiteral:function(a){this.opcode("pushLiteral",a.value)},BooleanLiteral:function(a){this.opcode("pushLiteral",a.value)},UndefinedLiteral:function(){this.opcode("pushLiteral","undefined")},NullLiteral:function(){this.opcode("pushLiteral","null")},Hash:function(a){var b=a.pairs,c=0,d=b.length;for(this.opcode("pushHash");c<d;c++)this.pushParam(b[c].value);for(;c--;)this.opcode("assignToHash",b[c].key);this.opcode("popHash")},opcode:function(a){this.opcodes.push({opcode:a,args:m.call(arguments,1),loc:this.sourceNode[0].loc})},addDepth:function(a){a&&(this.useDepths=!0)},classifySexpr:function(a){var b=l["default"].helpers.simpleId(a.path),c=b&&!!this.blockParamIndex(a.path.parts[0]),d=!c&&l["default"].helpers.helperExpression(a),e=!c&&(d||b);if(e&&!d){var f=a.path.parts[0],g=this.options;g.knownHelpers[f]?d=!0:g.knownHelpersOnly&&(e=!1)}return d?"helper":e?"ambiguous":"simple"},pushParams:function(a){for(var b=0,c=a.length;b<c;b++)this.pushParam(a[b])},pushParam:function(a){var b=null!=a.value?a.value:a.original||"";if(this.stringParams)b.replace&&(b=b.replace(/^(\.?\.\/)*/g,"").replace(/\//g,".")),a.depth&&this.addDepth(a.depth),this.opcode("getContext",a.depth||0),this.opcode("pushStringParam",b,a.type),"SubExpression"===a.type&&this.accept(a);else{if(this.trackIds){var c=void 0;if(!a.parts||l["default"].helpers.scopedId(a)||a.depth||(c=this.blockParamIndex(a.parts[0])),c){var d=a.parts.slice(1).join(".");this.opcode("pushId","BlockParam",c,d)}else b=a.original||b,b.replace&&(b=b.replace(/^this(?:\.|$)/,"").replace(/^\.\//,"").replace(/^\.$/,"")),this.opcode("pushId",a.type,b)}this.accept(a)}},setupFullMustacheParams:function(a,b,c,d){var e=a.params;return this.pushParams(e),this.opcode("pushProgram",b),this.opcode("pushProgram",c),a.hash?this.accept(a.hash):this.opcode("emptyHash",d),e},blockParamIndex:function(a){for(var b=0,d=this.options.blockParams.length;b<d;b++){var e=this.options.blockParams[b],f=e&&c.indexOf(e,a);if(e&&f>=0)return[b,f]}}}}),define("handlebars/compiler/code-gen",["exports","module","../utils"],function(a,b,c){"use strict";function d(a,b,d){if(c.isArray(a)){for(var e=[],f=0,g=a.length;f<g;f++)e.push(b.wrap(a[f],d));return e}return"boolean"==typeof a||"number"==typeof a?a+"":a}function e(a){this.srcFile=a,this.source=[]}var f=void 0;try{if("function"!=typeof define||!define.amd){var g=require("source-map");f=g.SourceNode}}catch(h){}f||(f=function(a,b,c,d){this.src="",d&&this.add(d)},f.prototype={add:function(a){c.isArray(a)&&(a=a.join("")),this.src+=a},prepend:function(a){c.isArray(a)&&(a=a.join("")),this.src=a+this.src},toStringWithSourceMap:function(){return{code:this.toString()}},toString:function(){return this.src}}),e.prototype={isEmpty:function(){return!this.source.length},prepend:function(a,b){this.source.unshift(this.wrap(a,b))},push:function(a,b){this.source.push(this.wrap(a,b))},merge:function(){var a=this.empty();return this.each(function(b){a.add(["  ",b,"\n"])}),a},each:function(a){for(var b=0,c=this.source.length;b<c;b++)a(this.source[b])},empty:function(){var a=this.currentLocation||{start:{}};return new f(a.start.line,a.start.column,this.srcFile)},wrap:function(a){var b=arguments.length<=1||void 0===arguments[1]?this.currentLocation||{start:{}}:arguments[1];return a instanceof f?a:(a=d(a,this,b),new f(b.start.line,b.start.column,this.srcFile,a))},functionCall:function(a,b,c){return c=this.generateList(c),this.wrap([a,b?"."+b+"(":"(",c,")"])},quotedString:function(a){return'"'+(a+"").replace(/\\/g,"\\\\").replace(/"/g,'\\"').replace(/\n/g,"\\n").replace(/\r/g,"\\r").replace(/\u2028/g,"\\u2028").replace(/\u2029/g,"\\u2029")+'"'},objectLiteral:function(a){var b=this,c=[];Object.keys(a).forEach(function(e){var f=d(a[e],b);"undefined"!==f&&c.push([b.quotedString(e),":",f])});var e=this.generateList(c);return e.prepend("{"),e.add("}"),e},generateList:function(a){for(var b=this.empty(),c=0,e=a.length;c<e;c++)c&&b.add(","),b.add(d(a[c],this));return b},generateArray:function(a){var b=this.generateList(a);return b.prepend("["),b.add("]"),b}},b.exports=e}),define("handlebars/compiler/javascript-compiler",["exports","module","../base","../exception","../utils","./code-gen","../helpers/lookup"],function(a,b,c,d,e,f,g){"use strict";function h(a){return a&&a.__esModule?a:{"default":a}}function i(a){this.value=a}function j(){}function k(a,b,c,d){var e=b.popStack(),f=0,g=c.length;for(a&&g--;f<g;f++)e=b.nameLookup(e,c[f],d);return a?[b.aliasable("container.strict"),"(",e,", ",b.quotedString(c[f]),", ",JSON.stringify(b.source.currentLocation)," )"]:e}var l=h(d),m=h(f);j.prototype={nameLookup:function(a,b){function c(){return j.isValidJavaScriptVariableName(b)?[a,".",b]:[a,"[",JSON.stringify(b),"]"]}if(g.dangerousPropertyRegex.test(b)){var d=[this.aliasable("container.propertyIsEnumerable"),".call(",a,",",JSON.stringify(b),")"];return["(",d,"?",c()," : undefined)"]}return c()},depthedLookup:function(a){return[this.aliasable("container.lookup"),'(depths, "',a,'")']},compilerInfo:function(){var a=c.COMPILER_REVISION,b=c.REVISION_CHANGES[a];return[a,b]},appendToBuffer:function(a,b,c){return e.isArray(a)||(a=[a]),a=this.source.wrap(a,b),this.environment.isSimple?["return ",a,";"]:c?["buffer += ",a,";"]:(a.appendToBuffer=!0,a)},initializeBuffer:function(){return this.quotedString("")},compile:function(a,b,c,d){this.environment=a,this.options=b,this.stringParams=this.options.stringParams,this.trackIds=this.options.trackIds,this.precompile=!d,this.name=this.environment.name,this.isChild=!!c,this.context=c||{decorators:[],programs:[],environments:[]},this.preamble(),this.stackSlot=0,this.stackVars=[],this.aliases={},this.registers={list:[]},this.hashes=[],this.compileStack=[],this.inlineStack=[],this.blockParams=[],this.compileChildren(a,b),this.useDepths=this.useDepths||a.useDepths||a.useDecorators||this.options.compat,this.useBlockParams=this.useBlockParams||a.useBlockParams;var e=a.opcodes,f=void 0,g=void 0,h=void 0,i=void 0;for(h=0,i=e.length;h<i;h++)f=e[h],this.source.currentLocation=f.loc,g=g||f.loc,this[f.opcode].apply(this,f.args);if(this.source.currentLocation=g,this.pushSource(""),this.stackSlot||this.inlineStack.length||this.compileStack.length)throw new l["default"]("Compile completed with content left on stack");this.decorators.isEmpty()?this.decorators=void 0:(this.useDecorators=!0,this.decorators.prepend("var decorators = container.decorators;\n"),this.decorators.push("return fn;"),d?this.decorators=Function.apply(this,["fn","props","container","depth0","data","blockParams","depths",this.decorators.merge()]):(this.decorators.prepend("function(fn, props, container, depth0, data, blockParams, depths) {\n"),this.decorators.push("}\n"),this.decorators=this.decorators.merge()));var j=this.createFunctionContext(d);if(this.isChild)return j;var k={compiler:this.compilerInfo(),main:j};this.decorators&&(k.main_d=this.decorators,k.useDecorators=!0);var m=this.context,n=m.programs,o=m.decorators;for(h=0,i=n.length;h<i;h++)n[h]&&(k[h]=n[h],o[h]&&(k[h+"_d"]=o[h],k.useDecorators=!0));return this.environment.usePartial&&(k.usePartial=!0),this.options.data&&(k.useData=!0),this.useDepths&&(k.useDepths=!0),this.useBlockParams&&(k.useBlockParams=!0),this.options.compat&&(k.compat=!0),d?k.compilerOptions=this.options:(k.compiler=JSON.stringify(k.compiler),this.source.currentLocation={start:{line:1,column:0}},k=this.objectLiteral(k),b.srcName?(k=k.toStringWithSourceMap({file:b.destName}),k.map=k.map&&k.map.toString()):k=k.toString()),k},preamble:function(){this.lastContext=0,this.source=new m["default"](this.options.srcName),this.decorators=new m["default"](this.options.srcName)},createFunctionContext:function(a){var b=this,c="",d=this.stackVars.concat(this.registers.list);d.length>0&&(c+=", "+d.join(", "));var e=0;Object.keys(this.aliases).forEach(function(a){var d=b.aliases[a];d.children&&d.referenceCount>1&&(c+=", alias"+ ++e+"="+a,d.children[0]="alias"+e)});var f=["container","depth0","helpers","partials","data"];(this.useBlockParams||this.useDepths)&&f.push("blockParams"),this.useDepths&&f.push("depths");var g=this.mergeSource(c);return a?(f.push(g),Function.apply(this,f)):this.source.wrap(["function(",f.join(","),") {\n  ",g,"}"])},mergeSource:function(a){var b=this.environment.isSimple,c=!this.forceBuffer,d=void 0,e=void 0,f=void 0,g=void 0;return this.source.each(function(a){a.appendToBuffer?(f?a.prepend("  + "):f=a,g=a):(f&&(e?f.prepend("buffer += "):d=!0,g.add(";"),f=g=void 0),e=!0,b||(c=!1))}),c?f?(f.prepend("return "),g.add(";")):e||this.source.push('return "";'):(a+=", buffer = "+(d?"":this.initializeBuffer()),f?(f.prepend("return buffer + "),g.add(";")):this.source.push("return buffer;")),a&&this.source.prepend("var "+a.substring(2)+(d?"":";\n")),this.source.merge()},blockValue:function(a){var b=this.aliasable("container.hooks.blockHelperMissing"),c=[this.contextName(0)];this.setupHelperArgs(a,0,c);var d=this.popStack();c.splice(1,0,d),this.push(this.source.functionCall(b,"call",c))},ambiguousBlockValue:function(){var a=this.aliasable("container.hooks.blockHelperMissing"),b=[this.contextName(0)];
-this.setupHelperArgs("",0,b,!0),this.flushInline();var c=this.topStack();b.splice(1,0,c),this.pushSource(["if (!",this.lastHelper,") { ",c," = ",this.source.functionCall(a,"call",b),"}"])},appendContent:function(a){this.pendingContent?a=this.pendingContent+a:this.pendingLocation=this.source.currentLocation,this.pendingContent=a},append:function(){if(this.isInline())this.replaceStack(function(a){return[" != null ? ",a,' : ""']}),this.pushSource(this.appendToBuffer(this.popStack()));else{var a=this.popStack();this.pushSource(["if (",a," != null) { ",this.appendToBuffer(a,void 0,!0)," }"]),this.environment.isSimple&&this.pushSource(["else { ",this.appendToBuffer("''",void 0,!0)," }"])}},appendEscaped:function(){this.pushSource(this.appendToBuffer([this.aliasable("container.escapeExpression"),"(",this.popStack(),")"]))},getContext:function(a){this.lastContext=a},pushContext:function(){this.pushStackLiteral(this.contextName(this.lastContext))},lookupOnContext:function(a,b,c,d){var e=0;d||!this.options.compat||this.lastContext?this.pushContext():this.push(this.depthedLookup(a[e++])),this.resolvePath("context",a,e,b,c)},lookupBlockParam:function(a,b){this.useBlockParams=!0,this.push(["blockParams[",a[0],"][",a[1],"]"]),this.resolvePath("context",b,1)},lookupData:function(a,b,c){a?this.pushStackLiteral("container.data(data, "+a+")"):this.pushStackLiteral("data"),this.resolvePath("data",b,0,!0,c)},resolvePath:function(a,b,c,d,e){var f=this;if(this.options.strict||this.options.assumeObjects)return void this.push(k(this.options.strict&&e,this,b,a));for(var g=b.length;c<g;c++)this.replaceStack(function(e){var g=f.nameLookup(e,b[c],a);return d?[" && ",g]:[" != null ? ",g," : ",e]})},resolvePossibleLambda:function(){this.push([this.aliasable("container.lambda"),"(",this.popStack(),", ",this.contextName(0),")"])},pushStringParam:function(a,b){this.pushContext(),this.pushString(b),"SubExpression"!==b&&("string"==typeof a?this.pushString(a):this.pushStackLiteral(a))},emptyHash:function(a){this.trackIds&&this.push("{}"),this.stringParams&&(this.push("{}"),this.push("{}")),this.pushStackLiteral(a?"undefined":"{}")},pushHash:function(){this.hash&&this.hashes.push(this.hash),this.hash={values:{},types:[],contexts:[],ids:[]}},popHash:function(){var a=this.hash;this.hash=this.hashes.pop(),this.trackIds&&this.push(this.objectLiteral(a.ids)),this.stringParams&&(this.push(this.objectLiteral(a.contexts)),this.push(this.objectLiteral(a.types))),this.push(this.objectLiteral(a.values))},pushString:function(a){this.pushStackLiteral(this.quotedString(a))},pushLiteral:function(a){this.pushStackLiteral(a)},pushProgram:function(a){null!=a?this.pushStackLiteral(this.programExpression(a)):this.pushStackLiteral(null)},registerDecorator:function(a,b){var c=this.nameLookup("decorators",b,"decorator"),d=this.setupHelperArgs(b,a);this.decorators.push(["fn = ",this.decorators.functionCall(c,"",["fn","props","container",d])," || fn;"])},invokeHelper:function(a,b,c){var d=this.popStack(),e=this.setupHelper(a,b),f=[];c&&f.push(e.name),f.push(d),this.options.strict||f.push(this.aliasable("container.hooks.helperMissing"));var g=["(",this.itemsSeparatedBy(f,"||"),")"],h=this.source.functionCall(g,"call",e.callParams);this.push(h)},itemsSeparatedBy:function(a,b){var c=[];c.push(a[0]);for(var d=1;d<a.length;d++)c.push(b,a[d]);return c},invokeKnownHelper:function(a,b){var c=this.setupHelper(a,b);this.push(this.source.functionCall(c.name,"call",c.callParams))},invokeAmbiguous:function(a,b){this.useRegister("helper");var c=this.popStack();this.emptyHash();var d=this.setupHelper(0,a,b),e=this.lastHelper=this.nameLookup("helpers",a,"helper"),f=["(","(helper = ",e," || ",c,")"];this.options.strict||(f[0]="(helper = ",f.push(" != null ? helper : ",this.aliasable("container.hooks.helperMissing"))),this.push(["(",f,d.paramsInit?["),(",d.paramsInit]:[],"),","(typeof helper === ",this.aliasable('"function"')," ? ",this.source.functionCall("helper","call",d.callParams)," : helper))"])},invokePartial:function(a,b,c){var d=[],e=this.setupParams(b,1,d);a&&(b=this.popStack(),delete e.name),c&&(e.indent=JSON.stringify(c)),e.helpers="helpers",e.partials="partials",e.decorators="container.decorators",a?d.unshift(b):d.unshift(this.nameLookup("partials",b,"partial")),this.options.compat&&(e.depths="depths"),e=this.objectLiteral(e),d.push(e),this.push(this.source.functionCall("container.invokePartial","",d))},assignToHash:function(a){var b=this.popStack(),c=void 0,d=void 0,e=void 0;this.trackIds&&(e=this.popStack()),this.stringParams&&(d=this.popStack(),c=this.popStack());var f=this.hash;c&&(f.contexts[a]=c),d&&(f.types[a]=d),e&&(f.ids[a]=e),f.values[a]=b},pushId:function(a,b,c){"BlockParam"===a?this.pushStackLiteral("blockParams["+b[0]+"].path["+b[1]+"]"+(c?" + "+JSON.stringify("."+c):"")):"PathExpression"===a?this.pushString(b):"SubExpression"===a?this.pushStackLiteral("true"):this.pushStackLiteral("null")},compiler:j,compileChildren:function(a,b){for(var c=a.children,d=void 0,e=void 0,f=0,g=c.length;f<g;f++){d=c[f],e=new this.compiler;var h=this.matchExistingProgram(d);if(null==h){this.context.programs.push("");var i=this.context.programs.length;d.index=i,d.name="program"+i,this.context.programs[i]=e.compile(d,b,this.context,!this.precompile),this.context.decorators[i]=e.decorators,this.context.environments[i]=d,this.useDepths=this.useDepths||e.useDepths,this.useBlockParams=this.useBlockParams||e.useBlockParams,d.useDepths=this.useDepths,d.useBlockParams=this.useBlockParams}else d.index=h.index,d.name="program"+h.index,this.useDepths=this.useDepths||h.useDepths,this.useBlockParams=this.useBlockParams||h.useBlockParams}},matchExistingProgram:function(a){for(var b=0,c=this.context.environments.length;b<c;b++){var d=this.context.environments[b];if(d&&d.equals(a))return d}},programExpression:function(a){var b=this.environment.children[a],c=[b.index,"data",b.blockParams];return(this.useBlockParams||this.useDepths)&&c.push("blockParams"),this.useDepths&&c.push("depths"),"container.program("+c.join(", ")+")"},useRegister:function(a){this.registers[a]||(this.registers[a]=!0,this.registers.list.push(a))},push:function(a){return a instanceof i||(a=this.source.wrap(a)),this.inlineStack.push(a),a},pushStackLiteral:function(a){this.push(new i(a))},pushSource:function(a){this.pendingContent&&(this.source.push(this.appendToBuffer(this.source.quotedString(this.pendingContent),this.pendingLocation)),this.pendingContent=void 0),a&&this.source.push(a)},replaceStack:function(a){var b=["("],c=void 0,d=void 0,e=void 0;if(!this.isInline())throw new l["default"]("replaceStack on non-inline");var f=this.popStack(!0);if(f instanceof i)c=[f.value],b=["(",c],e=!0;else{d=!0;var g=this.incrStack();b=["((",this.push(g)," = ",f,")"],c=this.topStack()}var h=a.call(this,c);e||this.popStack(),d&&this.stackSlot--,this.push(b.concat(h,")"))},incrStack:function(){return this.stackSlot++,this.stackSlot>this.stackVars.length&&this.stackVars.push("stack"+this.stackSlot),this.topStackName()},topStackName:function(){return"stack"+this.stackSlot},flushInline:function(){var a=this.inlineStack;this.inlineStack=[];for(var b=0,c=a.length;b<c;b++){var d=a[b];if(d instanceof i)this.compileStack.push(d);else{var e=this.incrStack();this.pushSource([e," = ",d,";"]),this.compileStack.push(e)}}},isInline:function(){return this.inlineStack.length},popStack:function(a){var b=this.isInline(),c=(b?this.inlineStack:this.compileStack).pop();if(!a&&c instanceof i)return c.value;if(!b){if(!this.stackSlot)throw new l["default"]("Invalid stack pop");this.stackSlot--}return c},topStack:function(){var a=this.isInline()?this.inlineStack:this.compileStack,b=a[a.length-1];return b instanceof i?b.value:b},contextName:function(a){return this.useDepths&&a?"depths["+a+"]":"depth"+a},quotedString:function(a){return this.source.quotedString(a)},objectLiteral:function(a){return this.source.objectLiteral(a)},aliasable:function(a){var b=this.aliases[a];return b?(b.referenceCount++,b):(b=this.aliases[a]=this.source.wrap(a),b.aliasable=!0,b.referenceCount=1,b)},setupHelper:function(a,b,c){var d=[],e=this.setupHelperArgs(b,a,d,c),f=this.nameLookup("helpers",b,"helper"),g=this.aliasable(this.contextName(0)+" != null ? "+this.contextName(0)+" : (container.nullContext || {})");return{params:d,paramsInit:e,name:f,callParams:[g].concat(d)}},setupParams:function(a,b,c){var d={},e=[],f=[],g=[],h=!c,i=void 0;h&&(c=[]),d.name=this.quotedString(a),d.hash=this.popStack(),this.trackIds&&(d.hashIds=this.popStack()),this.stringParams&&(d.hashTypes=this.popStack(),d.hashContexts=this.popStack());var j=this.popStack(),k=this.popStack();(k||j)&&(d.fn=k||"container.noop",d.inverse=j||"container.noop");for(var l=b;l--;)i=this.popStack(),c[l]=i,this.trackIds&&(g[l]=this.popStack()),this.stringParams&&(f[l]=this.popStack(),e[l]=this.popStack());return h&&(d.args=this.source.generateArray(c)),this.trackIds&&(d.ids=this.source.generateArray(g)),this.stringParams&&(d.types=this.source.generateArray(f),d.contexts=this.source.generateArray(e)),this.options.data&&(d.data="data"),this.useBlockParams&&(d.blockParams="blockParams"),d},setupHelperArgs:function(a,b,c,d){var e=this.setupParams(a,b,c);return e.loc=JSON.stringify(this.source.currentLocation),e=this.objectLiteral(e),d?(this.useRegister("options"),c.push("options"),["options=",e]):c?(c.push(e),""):e}},function(){for(var a="break else new var case finally return void catch for switch while continue function this with default if throw delete in try do instanceof typeof abstract enum int short boolean export interface static byte extends long super char final native synchronized class float package throws const goto private transient debugger implements protected volatile double import public let yield await null true false".split(" "),b=j.RESERVED_WORDS={},c=0,d=a.length;c<d;c++)b[a[c]]=!0}(),j.isValidJavaScriptVariableName=function(a){return!j.RESERVED_WORDS[a]&&/^[a-zA-Z_$][0-9a-zA-Z_$]*$/.test(a)},b.exports=j}),define("handlebars",["exports","module","./handlebars.runtime","./handlebars/compiler/ast","./handlebars/compiler/base","./handlebars/compiler/compiler","./handlebars/compiler/javascript-compiler","./handlebars/compiler/visitor","./handlebars/no-conflict"],function(a,b,c,d,e,f,g,h,i){"use strict";function j(a){return a&&a.__esModule?a:{"default":a}}function k(){var a=q();return a.compile=function(b,c){return f.compile(b,c,a)},a.precompile=function(b,c){return f.precompile(b,c,a)},a.AST=m["default"],a.Compiler=f.Compiler,a.JavaScriptCompiler=n["default"],a.Parser=e.parser,a.parse=e.parse,a.parseWithoutProcessing=e.parseWithoutProcessing,a}var l=j(c),m=j(d),n=j(g),o=j(h),p=j(i),q=l["default"].create,r=k();r.create=k,p["default"](r),r.Visitor=o["default"],r["default"]=r,b.exports=r});
+(function webpackUniversalModuleDefinition(root, factory) {
+        if(typeof exports === 'object' && typeof module === 'object')
+                module.exports = factory();
+        else if(typeof define === 'function' && define.amd)
+                define([], factory);
+        else if(typeof exports === 'object')
+                exports["Handlebars"] = factory();
+        else
+                root["Handlebars"] = factory();
+})(this, function() {
+return /******/ (function(modules) { // webpackBootstrap
+/******/        // The module cache
+/******/        var installedModules = {};
+
+/******/        // The require function
+/******/        function __webpack_require__(moduleId) {
+
+/******/                // Check if module is in cache
+/******/                if(installedModules[moduleId])
+/******/                        return installedModules[moduleId].exports;
+
+/******/                // Create a new module (and put it into the cache)
+/******/                var module = installedModules[moduleId] = {
+/******/                        exports: {},
+/******/                        id: moduleId,
+/******/                        loaded: false
+/******/                };
+
+/******/                // Execute the module function
+/******/                modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/                // Flag the module as loaded
+/******/                module.loaded = true;
+
+/******/                // Return the exports of the module
+/******/                return module.exports;
+/******/        }
+
+
+/******/        // expose the modules object (__webpack_modules__)
+/******/        __webpack_require__.m = modules;
+
+/******/        // expose the module cache
+/******/        __webpack_require__.c = installedModules;
+
+/******/        // __webpack_public_path__
+/******/        __webpack_require__.p = "";
+
+/******/        // Load entry module and return exports
+/******/        return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _interopRequireDefault = __webpack_require__(1)['default'];
+
+        exports.__esModule = true;
+
+        var _handlebarsRuntime = __webpack_require__(2);
+
+        var _handlebarsRuntime2 = _interopRequireDefault(_handlebarsRuntime);
+
+        // Compiler imports
+
+        var _handlebarsCompilerAst = __webpack_require__(45);
+
+        var _handlebarsCompilerAst2 = _interopRequireDefault(_handlebarsCompilerAst);
+
+        var _handlebarsCompilerBase = __webpack_require__(46);
+
+        var _handlebarsCompilerCompiler = __webpack_require__(51);
+
+        var _handlebarsCompilerJavascriptCompiler = __webpack_require__(52);
+
+        var _handlebarsCompilerJavascriptCompiler2 = _interopRequireDefault(_handlebarsCompilerJavascriptCompiler);
+
+        var _handlebarsCompilerVisitor = __webpack_require__(49);
+
+        var _handlebarsCompilerVisitor2 = _interopRequireDefault(_handlebarsCompilerVisitor);
+
+        var _handlebarsNoConflict = __webpack_require__(44);
+
+        var _handlebarsNoConflict2 = _interopRequireDefault(_handlebarsNoConflict);
+
+        var _create = _handlebarsRuntime2['default'].create;
+        function create() {
+          var hb = _create();
+
+          hb.compile = function (input, options) {
+            return _handlebarsCompilerCompiler.compile(input, options, hb);
+          };
+          hb.precompile = function (input, options) {
+            return _handlebarsCompilerCompiler.precompile(input, options, hb);
+          };
+
+          hb.AST = _handlebarsCompilerAst2['default'];
+          hb.Compiler = _handlebarsCompilerCompiler.Compiler;
+          hb.JavaScriptCompiler = _handlebarsCompilerJavascriptCompiler2['default'];
+          hb.Parser = _handlebarsCompilerBase.parser;
+          hb.parse = _handlebarsCompilerBase.parse;
+          hb.parseWithoutProcessing = _handlebarsCompilerBase.parseWithoutProcessing;
+
+          return hb;
+        }
+
+        var inst = create();
+        inst.create = create;
+
+        _handlebarsNoConflict2['default'](inst);
+
+        inst.Visitor = _handlebarsCompilerVisitor2['default'];
+
+        inst['default'] = inst;
+
+        exports['default'] = inst;
+        module.exports = exports['default'];
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports) {
+
+        "use strict";
+
+        exports["default"] = function (obj) {
+          return obj && obj.__esModule ? obj : {
+            "default": obj
+          };
+        };
+
+        exports.__esModule = true;
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _interopRequireWildcard = __webpack_require__(3)['default'];
+
+        var _interopRequireDefault = __webpack_require__(1)['default'];
+
+        exports.__esModule = true;
+
+        var _handlebarsBase = __webpack_require__(4);
+
+        var base = _interopRequireWildcard(_handlebarsBase);
+
+        // Each of these augment the Handlebars object. No need to setup here.
+        // (This is done to easily share code between commonjs and browse envs)
+
+        var _handlebarsSafeString = __webpack_require__(37);
+
+        var _handlebarsSafeString2 = _interopRequireDefault(_handlebarsSafeString);
+
+        var _handlebarsException = __webpack_require__(6);
+
+        var _handlebarsException2 = _interopRequireDefault(_handlebarsException);
+
+        var _handlebarsUtils = __webpack_require__(5);
+
+        var Utils = _interopRequireWildcard(_handlebarsUtils);
+
+        var _handlebarsRuntime = __webpack_require__(38);
+
+        var runtime = _interopRequireWildcard(_handlebarsRuntime);
+
+        var _handlebarsNoConflict = __webpack_require__(44);
+
+        var _handlebarsNoConflict2 = _interopRequireDefault(_handlebarsNoConflict);
+
+        // For compatibility and usage outside of module systems, make the Handlebars object a namespace
+        function create() {
+          var hb = new base.HandlebarsEnvironment();
+
+          Utils.extend(hb, base);
+          hb.SafeString = _handlebarsSafeString2['default'];
+          hb.Exception = _handlebarsException2['default'];
+          hb.Utils = Utils;
+          hb.escapeExpression = Utils.escapeExpression;
+
+          hb.VM = runtime;
+          hb.template = function (spec) {
+            return runtime.template(spec, hb);
+          };
+
+          return hb;
+        }
+
+        var inst = create();
+        inst.create = create;
+
+        _handlebarsNoConflict2['default'](inst);
+
+        inst['default'] = inst;
+
+        exports['default'] = inst;
+        module.exports = exports['default'];
+
+/***/ }),
+/* 3 */
+/***/ (function(module, exports) {
+
+        "use strict";
+
+        exports["default"] = function (obj) {
+          if (obj && obj.__esModule) {
+            return obj;
+          } else {
+            var newObj = {};
+
+            if (obj != null) {
+              for (var key in obj) {
+                if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key];
+              }
+            }
+
+            newObj["default"] = obj;
+            return newObj;
+          }
+        };
+
+        exports.__esModule = true;
+
+/***/ }),
+/* 4 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _interopRequireDefault = __webpack_require__(1)['default'];
+
+        exports.__esModule = true;
+        exports.HandlebarsEnvironment = HandlebarsEnvironment;
+
+        var _utils = __webpack_require__(5);
+
+        var _exception = __webpack_require__(6);
+
+        var _exception2 = _interopRequireDefault(_exception);
+
+        var _helpers = __webpack_require__(10);
+
+        var _decorators = __webpack_require__(30);
+
+        var _logger = __webpack_require__(32);
+
+        var _logger2 = _interopRequireDefault(_logger);
+
+        var _internalProtoAccess = __webpack_require__(33);
+
+        var VERSION = '4.7.6';
+        exports.VERSION = VERSION;
+        var COMPILER_REVISION = 8;
+        exports.COMPILER_REVISION = COMPILER_REVISION;
+        var LAST_COMPATIBLE_COMPILER_REVISION = 7;
+
+        exports.LAST_COMPATIBLE_COMPILER_REVISION = LAST_COMPATIBLE_COMPILER_REVISION;
+        var REVISION_CHANGES = {
+          1: '<= 1.0.rc.2', // 1.0.rc.2 is actually rev2 but doesn't report it
+          2: '== 1.0.0-rc.3',
+          3: '== 1.0.0-rc.4',
+          4: '== 1.x.x',
+          5: '== 2.0.0-alpha.x',
+          6: '>= 2.0.0-beta.1',
+          7: '>= 4.0.0 <4.3.0',
+          8: '>= 4.3.0'
+        };
+
+        exports.REVISION_CHANGES = REVISION_CHANGES;
+        var objectType = '[object Object]';
+
+        function HandlebarsEnvironment(helpers, partials, decorators) {
+          this.helpers = helpers || {};
+          this.partials = partials || {};
+          this.decorators = decorators || {};
+
+          _helpers.registerDefaultHelpers(this);
+          _decorators.registerDefaultDecorators(this);
+        }
+
+        HandlebarsEnvironment.prototype = {
+          constructor: HandlebarsEnvironment,
+
+          logger: _logger2['default'],
+          log: _logger2['default'].log,
+
+          registerHelper: function registerHelper(name, fn) {
+            if (_utils.toString.call(name) === objectType) {
+              if (fn) {
+                throw new _exception2['default']('Arg not supported with multiple helpers');
+              }
+              _utils.extend(this.helpers, name);
+            } else {
+              this.helpers[name] = fn;
+            }
+          },
+          unregisterHelper: function unregisterHelper(name) {
+            delete this.helpers[name];
+          },
+
+          registerPartial: function registerPartial(name, partial) {
+            if (_utils.toString.call(name) === objectType) {
+              _utils.extend(this.partials, name);
+            } else {
+              if (typeof partial === 'undefined') {
+                throw new _exception2['default']('Attempting to register a partial called "' + name + '" as undefined');
+              }
+              this.partials[name] = partial;
+            }
+          },
+          unregisterPartial: function unregisterPartial(name) {
+            delete this.partials[name];
+          },
+
+          registerDecorator: function registerDecorator(name, fn) {
+            if (_utils.toString.call(name) === objectType) {
+              if (fn) {
+                throw new _exception2['default']('Arg not supported with multiple decorators');
+              }
+              _utils.extend(this.decorators, name);
+            } else {
+              this.decorators[name] = fn;
+            }
+          },
+          unregisterDecorator: function unregisterDecorator(name) {
+            delete this.decorators[name];
+          },
+          /**
+           * Reset the memory of illegal property accesses that have already been logged.
+           * @deprecated should only be used in handlebars test-cases
+           */
+          resetLoggedPropertyAccesses: function resetLoggedPropertyAccesses() {
+            _internalProtoAccess.resetLoggedProperties();
+          }
+        };
+
+        var log = _logger2['default'].log;
+
+        exports.log = log;
+        exports.createFrame = _utils.createFrame;
+        exports.logger = _logger2['default'];
+
+/***/ }),
+/* 5 */
+/***/ (function(module, exports) {
+
+        'use strict';
+
+        exports.__esModule = true;
+        exports.extend = extend;
+        exports.indexOf = indexOf;
+        exports.escapeExpression = escapeExpression;
+        exports.isEmpty = isEmpty;
+        exports.createFrame = createFrame;
+        exports.blockParams = blockParams;
+        exports.appendContextPath = appendContextPath;
+        var escape = {
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#x27;',
+          '`': '&#x60;',
+          '=': '&#x3D;'
+        };
+
+        var badChars = /[&<>"'`=]/g,
+            possible = /[&<>"'`=]/;
+
+        function escapeChar(chr) {
+          return escape[chr];
+        }
+
+        function extend(obj /* , ...source */) {
+          for (var i = 1; i < arguments.length; i++) {
+            for (var key in arguments[i]) {
+              if (Object.prototype.hasOwnProperty.call(arguments[i], key)) {
+                obj[key] = arguments[i][key];
+              }
+            }
+          }
+
+          return obj;
+        }
+
+        var toString = Object.prototype.toString;
+
+        exports.toString = toString;
+        // Sourced from lodash
+        // https://github.com/bestiejs/lodash/blob/master/LICENSE.txt
+        /* eslint-disable func-style */
+        var isFunction = function isFunction(value) {
+          return typeof value === 'function';
+        };
+        // fallback for older versions of Chrome and Safari
+        /* istanbul ignore next */
+        if (isFunction(/x/)) {
+          exports.isFunction = isFunction = function (value) {
+            return typeof value === 'function' && toString.call(value) === '[object Function]';
+          };
+        }
+        exports.isFunction = isFunction;
+
+        /* eslint-enable func-style */
+
+        /* istanbul ignore next */
+        var isArray = Array.isArray || function (value) {
+          return value && typeof value === 'object' ? toString.call(value) === '[object Array]' : false;
+        };
+
+        exports.isArray = isArray;
+        // Older IE versions do not directly support indexOf so we must implement our own, sadly.
+
+        function indexOf(array, value) {
+          for (var i = 0, len = array.length; i < len; i++) {
+            if (array[i] === value) {
+              return i;
+            }
+          }
+          return -1;
+        }
+
+        function escapeExpression(string) {
+          if (typeof string !== 'string') {
+            // don't escape SafeStrings, since they're already safe
+            if (string && string.toHTML) {
+              return string.toHTML();
+            } else if (string == null) {
+              return '';
+            } else if (!string) {
+              return string + '';
+            }
+
+            // Force a string conversion as this will be done by the append regardless and
+            // the regex test will do this transparently behind the scenes, causing issues if
+            // an object's to string has escaped characters in it.
+            string = '' + string;
+          }
+
+          if (!possible.test(string)) {
+            return string;
+          }
+          return string.replace(badChars, escapeChar);
+        }
+
+        function isEmpty(value) {
+          if (!value && value !== 0) {
+            return true;
+          } else if (isArray(value) && value.length === 0) {
+            return true;
+          } else {
+            return false;
+          }
+        }
+
+        function createFrame(object) {
+          var frame = extend({}, object);
+          frame._parent = object;
+          return frame;
+        }
+
+        function blockParams(params, ids) {
+          params.path = ids;
+          return params;
+        }
+
+        function appendContextPath(contextPath, id) {
+          return (contextPath ? contextPath + '.' : '') + id;
+        }
+
+/***/ }),
+/* 6 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _Object$defineProperty = __webpack_require__(7)['default'];
+
+        exports.__esModule = true;
+        var errorProps = ['description', 'fileName', 'lineNumber', 'endLineNumber', 'message', 'name', 'number', 'stack'];
+
+        function Exception(message, node) {
+          var loc = node && node.loc,
+              line = undefined,
+              endLineNumber = undefined,
+              column = undefined,
+              endColumn = undefined;
+
+          if (loc) {
+            line = loc.start.line;
+            endLineNumber = loc.end.line;
+            column = loc.start.column;
+            endColumn = loc.end.column;
+
+            message += ' - ' + line + ':' + column;
+          }
+
+          var tmp = Error.prototype.constructor.call(this, message);
+
+          // Unfortunately errors are not enumerable in Chrome (at least), so `for prop in tmp` doesn't work.
+          for (var idx = 0; idx < errorProps.length; idx++) {
+            this[errorProps[idx]] = tmp[errorProps[idx]];
+          }
+
+          /* istanbul ignore else */
+          if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, Exception);
+          }
+
+          try {
+            if (loc) {
+              this.lineNumber = line;
+              this.endLineNumber = endLineNumber;
+
+              // Work around issue under safari where we can't directly set the column value
+              /* istanbul ignore next */
+              if (_Object$defineProperty) {
+                Object.defineProperty(this, 'column', {
+                  value: column,
+                  enumerable: true
+                });
+                Object.defineProperty(this, 'endColumn', {
+                  value: endColumn,
+                  enumerable: true
+                });
+              } else {
+                this.column = column;
+                this.endColumn = endColumn;
+              }
+            }
+          } catch (nop) {
+            /* Ignore if the browser is very particular */
+          }
+        }
+
+        Exception.prototype = new Error();
+
+        exports['default'] = Exception;
+        module.exports = exports['default'];
+
+/***/ }),
+/* 7 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        module.exports = { "default": __webpack_require__(8), __esModule: true };
+
+/***/ }),
+/* 8 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        var $ = __webpack_require__(9);
+        module.exports = function defineProperty(it, key, desc){
+          return $.setDesc(it, key, desc);
+        };
+
+/***/ }),
+/* 9 */
+/***/ (function(module, exports) {
+
+        var $Object = Object;
+        module.exports = {
+          create:     $Object.create,
+          getProto:   $Object.getPrototypeOf,
+          isEnum:     {}.propertyIsEnumerable,
+          getDesc:    $Object.getOwnPropertyDescriptor,
+          setDesc:    $Object.defineProperty,
+          setDescs:   $Object.defineProperties,
+          getKeys:    $Object.keys,
+          getNames:   $Object.getOwnPropertyNames,
+          getSymbols: $Object.getOwnPropertySymbols,
+          each:       [].forEach
+        };
+
+/***/ }),
+/* 10 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _interopRequireDefault = __webpack_require__(1)['default'];
+
+        exports.__esModule = true;
+        exports.registerDefaultHelpers = registerDefaultHelpers;
+        exports.moveHelperToHooks = moveHelperToHooks;
+
+        var _helpersBlockHelperMissing = __webpack_require__(11);
+
+        var _helpersBlockHelperMissing2 = _interopRequireDefault(_helpersBlockHelperMissing);
+
+        var _helpersEach = __webpack_require__(12);
+
+        var _helpersEach2 = _interopRequireDefault(_helpersEach);
+
+        var _helpersHelperMissing = __webpack_require__(25);
+
+        var _helpersHelperMissing2 = _interopRequireDefault(_helpersHelperMissing);
+
+        var _helpersIf = __webpack_require__(26);
+
+        var _helpersIf2 = _interopRequireDefault(_helpersIf);
+
+        var _helpersLog = __webpack_require__(27);
+
+        var _helpersLog2 = _interopRequireDefault(_helpersLog);
+
+        var _helpersLookup = __webpack_require__(28);
+
+        var _helpersLookup2 = _interopRequireDefault(_helpersLookup);
+
+        var _helpersWith = __webpack_require__(29);
+
+        var _helpersWith2 = _interopRequireDefault(_helpersWith);
+
+        function registerDefaultHelpers(instance) {
+          _helpersBlockHelperMissing2['default'](instance);
+          _helpersEach2['default'](instance);
+          _helpersHelperMissing2['default'](instance);
+          _helpersIf2['default'](instance);
+          _helpersLog2['default'](instance);
+          _helpersLookup2['default'](instance);
+          _helpersWith2['default'](instance);
+        }
+
+        function moveHelperToHooks(instance, helperName, keepHelper) {
+          if (instance.helpers[helperName]) {
+            instance.hooks[helperName] = instance.helpers[helperName];
+            if (!keepHelper) {
+              delete instance.helpers[helperName];
+            }
+          }
+        }
+
+/***/ }),
+/* 11 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        exports.__esModule = true;
+
+        var _utils = __webpack_require__(5);
+
+        exports['default'] = function (instance) {
+          instance.registerHelper('blockHelperMissing', function (context, options) {
+            var inverse = options.inverse,
+                fn = options.fn;
+
+            if (context === true) {
+              return fn(this);
+            } else if (context === false || context == null) {
+              return inverse(this);
+            } else if (_utils.isArray(context)) {
+              if (context.length > 0) {
+                if (options.ids) {
+                  options.ids = [options.name];
+                }
+
+                return instance.helpers.each(context, options);
+              } else {
+                return inverse(this);
+              }
+            } else {
+              if (options.data && options.ids) {
+                var data = _utils.createFrame(options.data);
+                data.contextPath = _utils.appendContextPath(options.data.contextPath, options.name);
+                options = { data: data };
+              }
+
+              return fn(context, options);
+            }
+          });
+        };
+
+        module.exports = exports['default'];
+
+/***/ }),
+/* 12 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        /* WEBPACK VAR INJECTION */(function(global) {'use strict';
+
+        var _Object$keys = __webpack_require__(13)['default'];
+
+        var _interopRequireDefault = __webpack_require__(1)['default'];
+
+        exports.__esModule = true;
+
+        var _utils = __webpack_require__(5);
+
+        var _exception = __webpack_require__(6);
+
+        var _exception2 = _interopRequireDefault(_exception);
+
+        exports['default'] = function (instance) {
+          instance.registerHelper('each', function (context, options) {
+            if (!options) {
+              throw new _exception2['default']('Must pass iterator to #each');
+            }
+
+            var fn = options.fn,
+                inverse = options.inverse,
+                i = 0,
+                ret = '',
+                data = undefined,
+                contextPath = undefined;
+
+            if (options.data && options.ids) {
+              contextPath = _utils.appendContextPath(options.data.contextPath, options.ids[0]) + '.';
+            }
+
+            if (_utils.isFunction(context)) {
+              context = context.call(this);
+            }
+
+            if (options.data) {
+              data = _utils.createFrame(options.data);
+            }
+
+            function execIteration(field, index, last) {
+              if (data) {
+                data.key = field;
+                data.index = index;
+                data.first = index === 0;
+                data.last = !!last;
+
+                if (contextPath) {
+                  data.contextPath = contextPath + field;
+                }
+              }
+
+              ret = ret + fn(context[field], {
+                data: data,
+                blockParams: _utils.blockParams([context[field], field], [contextPath + field, null])
+              });
+            }
+
+            if (context && typeof context === 'object') {
+              if (_utils.isArray(context)) {
+                for (var j = context.length; i < j; i++) {
+                  if (i in context) {
+                    execIteration(i, i, i === context.length - 1);
+                  }
+                }
+              } else if (global.Symbol && context[global.Symbol.iterator]) {
+                var newContext = [];
+                var iterator = context[global.Symbol.iterator]();
+                for (var it = iterator.next(); !it.done; it = iterator.next()) {
+                  newContext.push(it.value);
+                }
+                context = newContext;
+                for (var j = context.length; i < j; i++) {
+                  execIteration(i, i, i === context.length - 1);
+                }
+              } else {
+                (function () {
+                  var priorKey = undefined;
+
+                  _Object$keys(context).forEach(function (key) {
+                    // We're running the iterations one step out of sync so we can detect
+                    // the last iteration without have to scan the object twice and create
+                    // an itermediate keys array.
+                    if (priorKey !== undefined) {
+                      execIteration(priorKey, i - 1);
+                    }
+                    priorKey = key;
+                    i++;
+                  });
+                  if (priorKey !== undefined) {
+                    execIteration(priorKey, i - 1, true);
+                  }
+                })();
+              }
+            }
+
+            if (i === 0) {
+              ret = inverse(this);
+            }
+
+            return ret;
+          });
+        };
+
+        module.exports = exports['default'];
+        /* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
+
+/***/ }),
+/* 13 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        module.exports = { "default": __webpack_require__(14), __esModule: true };
+
+/***/ }),
+/* 14 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        __webpack_require__(15);
+        module.exports = __webpack_require__(21).Object.keys;
+
+/***/ }),
+/* 15 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        // 19.1.2.14 Object.keys(O)
+        var toObject = __webpack_require__(16);
+
+        __webpack_require__(18)('keys', function($keys){
+          return function keys(it){
+            return $keys(toObject(it));
+          };
+        });
+
+/***/ }),
+/* 16 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        // 7.1.13 ToObject(argument)
+        var defined = __webpack_require__(17);
+        module.exports = function(it){
+          return Object(defined(it));
+        };
+
+/***/ }),
+/* 17 */
+/***/ (function(module, exports) {
+
+        // 7.2.1 RequireObjectCoercible(argument)
+        module.exports = function(it){
+          if(it == undefined)throw TypeError("Can't call method on  " + it);
+          return it;
+        };
+
+/***/ }),
+/* 18 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        // most Object methods by ES6 should accept primitives
+        var $export = __webpack_require__(19)
+          , core    = __webpack_require__(21)
+          , fails   = __webpack_require__(24);
+        module.exports = function(KEY, exec){
+          var fn  = (core.Object || {})[KEY] || Object[KEY]
+            , exp = {};
+          exp[KEY] = exec(fn);
+          $export($export.S + $export.F * fails(function(){ fn(1); }), 'Object', exp);
+        };
+
+/***/ }),
+/* 19 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        var global    = __webpack_require__(20)
+          , core      = __webpack_require__(21)
+          , ctx       = __webpack_require__(22)
+          , PROTOTYPE = 'prototype';
+
+        var $export = function(type, name, source){
+          var IS_FORCED = type & $export.F
+            , IS_GLOBAL = type & $export.G
+            , IS_STATIC = type & $export.S
+            , IS_PROTO  = type & $export.P
+            , IS_BIND   = type & $export.B
+            , IS_WRAP   = type & $export.W
+            , exports   = IS_GLOBAL ? core : core[name] || (core[name] = {})
+            , target    = IS_GLOBAL ? global : IS_STATIC ? global[name] : (global[name] || {})[PROTOTYPE]
+            , key, own, out;
+          if(IS_GLOBAL)source = name;
+          for(key in source){
+            // contains in native
+            own = !IS_FORCED && target && key in target;
+            if(own && key in exports)continue;
+            // export native or passed
+            out = own ? target[key] : source[key];
+            // prevent global pollution for namespaces
+            exports[key] = IS_GLOBAL && typeof target[key] != 'function' ? source[key]
+            // bind timers to global for call from export context
+            : IS_BIND && own ? ctx(out, global)
+            // wrap global constructors for prevent change them in library
+            : IS_WRAP && target[key] == out ? (function(C){
+              var F = function(param){
+                return this instanceof C ? new C(param) : C(param);
+              };
+              F[PROTOTYPE] = C[PROTOTYPE];
+              return F;
+            // make static versions for prototype methods
+            })(out) : IS_PROTO && typeof out == 'function' ? ctx(Function.call, out) : out;
+            if(IS_PROTO)(exports[PROTOTYPE] || (exports[PROTOTYPE] = {}))[key] = out;
+          }
+        };
+        // type bitmap
+        $export.F = 1;  // forced
+        $export.G = 2;  // global
+        $export.S = 4;  // static
+        $export.P = 8;  // proto
+        $export.B = 16; // bind
+        $export.W = 32; // wrap
+        module.exports = $export;
+
+/***/ }),
+/* 20 */
+/***/ (function(module, exports) {
+
+        // https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
+        var global = module.exports = typeof window != 'undefined' && window.Math == Math
+          ? window : typeof self != 'undefined' && self.Math == Math ? self : Function('return this')();
+        if(typeof __g == 'number')__g = global; // eslint-disable-line no-undef
+
+/***/ }),
+/* 21 */
+/***/ (function(module, exports) {
+
+        var core = module.exports = {version: '1.2.6'};
+        if(typeof __e == 'number')__e = core; // eslint-disable-line no-undef
+
+/***/ }),
+/* 22 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        // optional / simple context binding
+        var aFunction = __webpack_require__(23);
+        module.exports = function(fn, that, length){
+          aFunction(fn);
+          if(that === undefined)return fn;
+          switch(length){
+            case 1: return function(a){
+              return fn.call(that, a);
+            };
+            case 2: return function(a, b){
+              return fn.call(that, a, b);
+            };
+            case 3: return function(a, b, c){
+              return fn.call(that, a, b, c);
+            };
+          }
+          return function(/* ...args */){
+            return fn.apply(that, arguments);
+          };
+        };
+
+/***/ }),
+/* 23 */
+/***/ (function(module, exports) {
+
+        module.exports = function(it){
+          if(typeof it != 'function')throw TypeError(it + ' is not a function!');
+          return it;
+        };
+
+/***/ }),
+/* 24 */
+/***/ (function(module, exports) {
+
+        module.exports = function(exec){
+          try {
+            return !!exec();
+          } catch(e){
+            return true;
+          }
+        };
+
+/***/ }),
+/* 25 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _interopRequireDefault = __webpack_require__(1)['default'];
+
+        exports.__esModule = true;
+
+        var _exception = __webpack_require__(6);
+
+        var _exception2 = _interopRequireDefault(_exception);
+
+        exports['default'] = function (instance) {
+          instance.registerHelper('helperMissing', function () /* [args, ]options */{
+            if (arguments.length === 1) {
+              // A missing field in a {{foo}} construct.
+              return undefined;
+            } else {
+              // Someone is actually trying to call something, blow up.
+              throw new _exception2['default']('Missing helper: "' + arguments[arguments.length - 1].name + '"');
+            }
+          });
+        };
+
+        module.exports = exports['default'];
+
+/***/ }),
+/* 26 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _interopRequireDefault = __webpack_require__(1)['default'];
+
+        exports.__esModule = true;
+
+        var _utils = __webpack_require__(5);
+
+        var _exception = __webpack_require__(6);
+
+        var _exception2 = _interopRequireDefault(_exception);
+
+        exports['default'] = function (instance) {
+          instance.registerHelper('if', function (conditional, options) {
+            if (arguments.length != 2) {
+              throw new _exception2['default']('#if requires exactly one argument');
+            }
+            if (_utils.isFunction(conditional)) {
+              conditional = conditional.call(this);
+            }
+
+            // Default behavior is to render the positive path if the value is truthy and not empty.
+            // The `includeZero` option may be set to treat the condtional as purely not empty based on the
+            // behavior of isEmpty. Effectively this determines if 0 is handled by the positive path or negative.
+            if (!options.hash.includeZero && !conditional || _utils.isEmpty(conditional)) {
+              return options.inverse(this);
+            } else {
+              return options.fn(this);
+            }
+          });
+
+          instance.registerHelper('unless', function (conditional, options) {
+            if (arguments.length != 2) {
+              throw new _exception2['default']('#unless requires exactly one argument');
+            }
+            return instance.helpers['if'].call(this, conditional, {
+              fn: options.inverse,
+              inverse: options.fn,
+              hash: options.hash
+            });
+          });
+        };
+
+        module.exports = exports['default'];
+
+/***/ }),
+/* 27 */
+/***/ (function(module, exports) {
+
+        'use strict';
+
+        exports.__esModule = true;
+
+        exports['default'] = function (instance) {
+          instance.registerHelper('log', function () /* message, options */{
+            var args = [undefined],
+                options = arguments[arguments.length - 1];
+            for (var i = 0; i < arguments.length - 1; i++) {
+              args.push(arguments[i]);
+            }
+
+            var level = 1;
+            if (options.hash.level != null) {
+              level = options.hash.level;
+            } else if (options.data && options.data.level != null) {
+              level = options.data.level;
+            }
+            args[0] = level;
+
+            instance.log.apply(instance, args);
+          });
+        };
+
+        module.exports = exports['default'];
+
+/***/ }),
+/* 28 */
+/***/ (function(module, exports) {
+
+        'use strict';
+
+        exports.__esModule = true;
+
+        exports['default'] = function (instance) {
+          instance.registerHelper('lookup', function (obj, field, options) {
+            if (!obj) {
+              // Note for 5.0: Change to "obj == null" in 5.0
+              return obj;
+            }
+            return options.lookupProperty(obj, field);
+          });
+        };
+
+        module.exports = exports['default'];
+
+/***/ }),
+/* 29 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _interopRequireDefault = __webpack_require__(1)['default'];
+
+        exports.__esModule = true;
+
+        var _utils = __webpack_require__(5);
+
+        var _exception = __webpack_require__(6);
+
+        var _exception2 = _interopRequireDefault(_exception);
+
+        exports['default'] = function (instance) {
+          instance.registerHelper('with', function (context, options) {
+            if (arguments.length != 2) {
+              throw new _exception2['default']('#with requires exactly one argument');
+            }
+            if (_utils.isFunction(context)) {
+              context = context.call(this);
+            }
+
+            var fn = options.fn;
+
+            if (!_utils.isEmpty(context)) {
+              var data = options.data;
+              if (options.data && options.ids) {
+                data = _utils.createFrame(options.data);
+                data.contextPath = _utils.appendContextPath(options.data.contextPath, options.ids[0]);
+              }
+
+              return fn(context, {
+                data: data,
+                blockParams: _utils.blockParams([context], [data && data.contextPath])
+              });
+            } else {
+              return options.inverse(this);
+            }
+          });
+        };
+
+        module.exports = exports['default'];
+
+/***/ }),
+/* 30 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _interopRequireDefault = __webpack_require__(1)['default'];
+
+        exports.__esModule = true;
+        exports.registerDefaultDecorators = registerDefaultDecorators;
+
+        var _decoratorsInline = __webpack_require__(31);
+
+        var _decoratorsInline2 = _interopRequireDefault(_decoratorsInline);
+
+        function registerDefaultDecorators(instance) {
+          _decoratorsInline2['default'](instance);
+        }
+
+/***/ }),
+/* 31 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        exports.__esModule = true;
+
+        var _utils = __webpack_require__(5);
+
+        exports['default'] = function (instance) {
+          instance.registerDecorator('inline', function (fn, props, container, options) {
+            var ret = fn;
+            if (!props.partials) {
+              props.partials = {};
+              ret = function (context, options) {
+                // Create a new partials stack frame prior to exec.
+                var original = container.partials;
+                container.partials = _utils.extend({}, original, props.partials);
+                var ret = fn(context, options);
+                container.partials = original;
+                return ret;
+              };
+            }
+
+            props.partials[options.args[0]] = options.fn;
+
+            return ret;
+          });
+        };
+
+        module.exports = exports['default'];
+
+/***/ }),
+/* 32 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        exports.__esModule = true;
+
+        var _utils = __webpack_require__(5);
+
+        var logger = {
+          methodMap: ['debug', 'info', 'warn', 'error'],
+          level: 'info',
+
+          // Maps a given level value to the `methodMap` indexes above.
+          lookupLevel: function lookupLevel(level) {
+            if (typeof level === 'string') {
+              var levelMap = _utils.indexOf(logger.methodMap, level.toLowerCase());
+              if (levelMap >= 0) {
+                level = levelMap;
+              } else {
+                level = parseInt(level, 10);
+              }
+            }
+
+            return level;
+          },
+
+          // Can be overridden in the host environment
+          log: function log(level) {
+            level = logger.lookupLevel(level);
+
+            if (typeof console !== 'undefined' && logger.lookupLevel(logger.level) <= level) {
+              var method = logger.methodMap[level];
+              // eslint-disable-next-line no-console
+              if (!console[method]) {
+                method = 'log';
+              }
+
+              for (var _len = arguments.length, message = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+                message[_key - 1] = arguments[_key];
+              }
+
+              console[method].apply(console, message); // eslint-disable-line no-console
+            }
+          }
+        };
+
+        exports['default'] = logger;
+        module.exports = exports['default'];
+
+/***/ }),
+/* 33 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _Object$create = __webpack_require__(34)['default'];
+
+        var _Object$keys = __webpack_require__(13)['default'];
+
+        var _interopRequireWildcard = __webpack_require__(3)['default'];
+
+        exports.__esModule = true;
+        exports.createProtoAccessControl = createProtoAccessControl;
+        exports.resultIsAllowed = resultIsAllowed;
+        exports.resetLoggedProperties = resetLoggedProperties;
+
+        var _createNewLookupObject = __webpack_require__(36);
+
+        var _logger = __webpack_require__(32);
+
+        var logger = _interopRequireWildcard(_logger);
+
+        var loggedProperties = _Object$create(null);
+
+        function createProtoAccessControl(runtimeOptions) {
+          var defaultMethodWhiteList = _Object$create(null);
+          defaultMethodWhiteList['constructor'] = false;
+          defaultMethodWhiteList['__defineGetter__'] = false;
+          defaultMethodWhiteList['__defineSetter__'] = false;
+          defaultMethodWhiteList['__lookupGetter__'] = false;
+
+          var defaultPropertyWhiteList = _Object$create(null);
+          // eslint-disable-next-line no-proto
+          defaultPropertyWhiteList['__proto__'] = false;
+
+          return {
+            properties: {
+              whitelist: _createNewLookupObject.createNewLookupObject(defaultPropertyWhiteList, runtimeOptions.allowedProtoProperties),
+              defaultValue: runtimeOptions.allowProtoPropertiesByDefault
+            },
+            methods: {
+              whitelist: _createNewLookupObject.createNewLookupObject(defaultMethodWhiteList, runtimeOptions.allowedProtoMethods),
+              defaultValue: runtimeOptions.allowProtoMethodsByDefault
+            }
+          };
+        }
+
+        function resultIsAllowed(result, protoAccessControl, propertyName) {
+          if (typeof result === 'function') {
+            return checkWhiteList(protoAccessControl.methods, propertyName);
+          } else {
+            return checkWhiteList(protoAccessControl.properties, propertyName);
+          }
+        }
+
+        function checkWhiteList(protoAccessControlForType, propertyName) {
+          if (protoAccessControlForType.whitelist[propertyName] !== undefined) {
+            return protoAccessControlForType.whitelist[propertyName] === true;
+          }
+          if (protoAccessControlForType.defaultValue !== undefined) {
+            return protoAccessControlForType.defaultValue;
+          }
+          logUnexpecedPropertyAccessOnce(propertyName);
+          return false;
+        }
+
+        function logUnexpecedPropertyAccessOnce(propertyName) {
+          if (loggedProperties[propertyName] !== true) {
+            loggedProperties[propertyName] = true;
+            logger.log('error', 'Handlebars: Access has been denied to resolve the property "' + propertyName + '" because it is not an "own property" of its parent.\n' + 'You can add a runtime option to disable the check or this warning:\n' + 'See https://handlebarsjs.com/api-reference/runtime-options.html#options-to-control-prototype-access for details');
+          }
+        }
+
+        function resetLoggedProperties() {
+          _Object$keys(loggedProperties).forEach(function (propertyName) {
+            delete loggedProperties[propertyName];
+          });
+        }
+
+/***/ }),
+/* 34 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        module.exports = { "default": __webpack_require__(35), __esModule: true };
+
+/***/ }),
+/* 35 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        var $ = __webpack_require__(9);
+        module.exports = function create(P, D){
+          return $.create(P, D);
+        };
+
+/***/ }),
+/* 36 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _Object$create = __webpack_require__(34)['default'];
+
+        exports.__esModule = true;
+        exports.createNewLookupObject = createNewLookupObject;
+
+        var _utils = __webpack_require__(5);
+
+        /**
+         * Create a new object with "null"-prototype to avoid truthy results on prototype properties.
+         * The resulting object can be used with "object[property]" to check if a property exists
+         * @param {...object} sources a varargs parameter of source objects that will be merged
+         * @returns {object}
+         */
+
+        function createNewLookupObject() {
+          for (var _len = arguments.length, sources = Array(_len), _key = 0; _key < _len; _key++) {
+            sources[_key] = arguments[_key];
+          }
+
+          return _utils.extend.apply(undefined, [_Object$create(null)].concat(sources));
+        }
+
+/***/ }),
+/* 37 */
+/***/ (function(module, exports) {
+
+        // Build out our basic SafeString type
+        'use strict';
+
+        exports.__esModule = true;
+        function SafeString(string) {
+          this.string = string;
+        }
+
+        SafeString.prototype.toString = SafeString.prototype.toHTML = function () {
+          return '' + this.string;
+        };
+
+        exports['default'] = SafeString;
+        module.exports = exports['default'];
+
+/***/ }),
+/* 38 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _Object$seal = __webpack_require__(39)['default'];
+
+        var _Object$keys = __webpack_require__(13)['default'];
+
+        var _interopRequireWildcard = __webpack_require__(3)['default'];
+
+        var _interopRequireDefault = __webpack_require__(1)['default'];
+
+        exports.__esModule = true;
+        exports.checkRevision = checkRevision;
+        exports.template = template;
+        exports.wrapProgram = wrapProgram;
+        exports.resolvePartial = resolvePartial;
+        exports.invokePartial = invokePartial;
+        exports.noop = noop;
+
+        var _utils = __webpack_require__(5);
+
+        var Utils = _interopRequireWildcard(_utils);
+
+        var _exception = __webpack_require__(6);
+
+        var _exception2 = _interopRequireDefault(_exception);
+
+        var _base = __webpack_require__(4);
+
+        var _helpers = __webpack_require__(10);
+
+        var _internalWrapHelper = __webpack_require__(43);
+
+        var _internalProtoAccess = __webpack_require__(33);
+
+        function checkRevision(compilerInfo) {
+          var compilerRevision = compilerInfo && compilerInfo[0] || 1,
+              currentRevision = _base.COMPILER_REVISION;
+
+          if (compilerRevision >= _base.LAST_COMPATIBLE_COMPILER_REVISION && compilerRevision <= _base.COMPILER_REVISION) {
+            return;
+          }
+
+          if (compilerRevision < _base.LAST_COMPATIBLE_COMPILER_REVISION) {
+            var runtimeVersions = _base.REVISION_CHANGES[currentRevision],
+                compilerVersions = _base.REVISION_CHANGES[compilerRevision];
+            throw new _exception2['default']('Template was precompiled with an older version of Handlebars than the current runtime. ' + 'Please update your precompiler to a newer version (' + runtimeVersions + ') or downgrade your runtime to an older version (' + compilerVersions + ').');
+          } else {
+            // Use the embedded version info since the runtime doesn't know about this revision yet
+            throw new _exception2['default']('Template was precompiled with a newer version of Handlebars than the current runtime. ' + 'Please update your runtime to a newer version (' + compilerInfo[1] + ').');
+          }
+        }
+
+        function template(templateSpec, env) {
+          /* istanbul ignore next */
+          if (!env) {
+            throw new _exception2['default']('No environment passed to template');
+          }
+          if (!templateSpec || !templateSpec.main) {
+            throw new _exception2['default']('Unknown template object: ' + typeof templateSpec);
+          }
+
+          templateSpec.main.decorator = templateSpec.main_d;
+
+          // Note: Using env.VM references rather than local var references throughout this section to allow
+          // for external users to override these as pseudo-supported APIs.
+          env.VM.checkRevision(templateSpec.compiler);
+
+          // backwards compatibility for precompiled templates with compiler-version 7 (<4.3.0)
+          var templateWasPrecompiledWithCompilerV7 = templateSpec.compiler && templateSpec.compiler[0] === 7;
+
+          function invokePartialWrapper(partial, context, options) {
+            if (options.hash) {
+              context = Utils.extend({}, context, options.hash);
+              if (options.ids) {
+                options.ids[0] = true;
+              }
+            }
+            partial = env.VM.resolvePartial.call(this, partial, context, options);
+
+            var extendedOptions = Utils.extend({}, options, {
+              hooks: this.hooks,
+              protoAccessControl: this.protoAccessControl
+            });
+
+            var result = env.VM.invokePartial.call(this, partial, context, extendedOptions);
+
+            if (result == null && env.compile) {
+              options.partials[options.name] = env.compile(partial, templateSpec.compilerOptions, env);
+              result = options.partials[options.name](context, extendedOptions);
+            }
+            if (result != null) {
+              if (options.indent) {
+                var lines = result.split('\n');
+                for (var i = 0, l = lines.length; i < l; i++) {
+                  if (!lines[i] && i + 1 === l) {
+                    break;
+                  }
+
+                  lines[i] = options.indent + lines[i];
+                }
+                result = lines.join('\n');
+              }
+              return result;
+            } else {
+              throw new _exception2['default']('The partial ' + options.name + ' could not be compiled when running in runtime-only mode');
+            }
+          }
+
+          // Just add water
+          var container = {
+            strict: function strict(obj, name, loc) {
+              if (!obj || !(name in obj)) {
+                throw new _exception2['default']('"' + name + '" not defined in ' + obj, {
+                  loc: loc
+                });
+              }
+              return obj[name];
+            },
+            lookupProperty: function lookupProperty(parent, propertyName) {
+              var result = parent[propertyName];
+              if (result == null) {
+                return result;
+              }
+              if (Object.prototype.hasOwnProperty.call(parent, propertyName)) {
+                return result;
+              }
+
+              if (_internalProtoAccess.resultIsAllowed(result, container.protoAccessControl, propertyName)) {
+                return result;
+              }
+              return undefined;
+            },
+            lookup: function lookup(depths, name) {
+              var len = depths.length;
+              for (var i = 0; i < len; i++) {
+                var result = depths[i] && container.lookupProperty(depths[i], name);
+                if (result != null) {
+                  return depths[i][name];
+                }
+              }
+            },
+            lambda: function lambda(current, context) {
+              return typeof current === 'function' ? current.call(context) : current;
+            },
+
+            escapeExpression: Utils.escapeExpression,
+            invokePartial: invokePartialWrapper,
+
+            fn: function fn(i) {
+              var ret = templateSpec[i];
+              ret.decorator = templateSpec[i + '_d'];
+              return ret;
+            },
+
+            programs: [],
+            program: function program(i, data, declaredBlockParams, blockParams, depths) {
+              var programWrapper = this.programs[i],
+                  fn = this.fn(i);
+              if (data || depths || blockParams || declaredBlockParams) {
+                programWrapper = wrapProgram(this, i, fn, data, declaredBlockParams, blockParams, depths);
+              } else if (!programWrapper) {
+                programWrapper = this.programs[i] = wrapProgram(this, i, fn);
+              }
+              return programWrapper;
+            },
+
+            data: function data(value, depth) {
+              while (value && depth--) {
+                value = value._parent;
+              }
+              return value;
+            },
+            mergeIfNeeded: function mergeIfNeeded(param, common) {
+              var obj = param || common;
+
+              if (param && common && param !== common) {
+                obj = Utils.extend({}, common, param);
+              }
+
+              return obj;
+            },
+            // An empty object to use as replacement for null-contexts
+            nullContext: _Object$seal({}),
+
+            noop: env.VM.noop,
+            compilerInfo: templateSpec.compiler
+          };
+
+          function ret(context) {
+            var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+            var data = options.data;
+
+            ret._setup(options);
+            if (!options.partial && templateSpec.useData) {
+              data = initData(context, data);
+            }
+            var depths = undefined,
+                blockParams = templateSpec.useBlockParams ? [] : undefined;
+            if (templateSpec.useDepths) {
+              if (options.depths) {
+                depths = context != options.depths[0] ? [context].concat(options.depths) : options.depths;
+              } else {
+                depths = [context];
+              }
+            }
+
+            function main(context /*, options*/) {
+              return '' + templateSpec.main(container, context, container.helpers, container.partials, data, blockParams, depths);
+            }
+
+            main = executeDecorators(templateSpec.main, main, container, options.depths || [], data, blockParams);
+            return main(context, options);
+          }
+
+          ret.isTop = true;
+
+          ret._setup = function (options) {
+            if (!options.partial) {
+              var mergedHelpers = Utils.extend({}, env.helpers, options.helpers);
+              wrapHelpersToPassLookupProperty(mergedHelpers, container);
+              container.helpers = mergedHelpers;
+
+              if (templateSpec.usePartial) {
+                // Use mergeIfNeeded here to prevent compiling global partials multiple times
+                container.partials = container.mergeIfNeeded(options.partials, env.partials);
+              }
+              if (templateSpec.usePartial || templateSpec.useDecorators) {
+                container.decorators = Utils.extend({}, env.decorators, options.decorators);
+              }
+
+              container.hooks = {};
+              container.protoAccessControl = _internalProtoAccess.createProtoAccessControl(options);
+
+              var keepHelperInHelpers = options.allowCallsToHelperMissing || templateWasPrecompiledWithCompilerV7;
+              _helpers.moveHelperToHooks(container, 'helperMissing', keepHelperInHelpers);
+              _helpers.moveHelperToHooks(container, 'blockHelperMissing', keepHelperInHelpers);
+            } else {
+              container.protoAccessControl = options.protoAccessControl; // internal option
+              container.helpers = options.helpers;
+              container.partials = options.partials;
+              container.decorators = options.decorators;
+              container.hooks = options.hooks;
+            }
+          };
+
+          ret._child = function (i, data, blockParams, depths) {
+            if (templateSpec.useBlockParams && !blockParams) {
+              throw new _exception2['default']('must pass block params');
+            }
+            if (templateSpec.useDepths && !depths) {
+              throw new _exception2['default']('must pass parent depths');
+            }
+
+            return wrapProgram(container, i, templateSpec[i], data, 0, blockParams, depths);
+          };
+          return ret;
+        }
+
+        function wrapProgram(container, i, fn, data, declaredBlockParams, blockParams, depths) {
+          function prog(context) {
+            var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+            var currentDepths = depths;
+            if (depths && context != depths[0] && !(context === container.nullContext && depths[0] === null)) {
+              currentDepths = [context].concat(depths);
+            }
+
+            return fn(container, context, container.helpers, container.partials, options.data || data, blockParams && [options.blockParams].concat(blockParams), currentDepths);
+          }
+
+          prog = executeDecorators(fn, prog, container, depths, data, blockParams);
+
+          prog.program = i;
+          prog.depth = depths ? depths.length : 0;
+          prog.blockParams = declaredBlockParams || 0;
+          return prog;
+        }
+
+        /**
+         * This is currently part of the official API, therefore implementation details should not be changed.
+         */
+
+        function resolvePartial(partial, context, options) {
+          if (!partial) {
+            if (options.name === '@partial-block') {
+              partial = options.data['partial-block'];
+            } else {
+              partial = options.partials[options.name];
+            }
+          } else if (!partial.call && !options.name) {
+            // This is a dynamic partial that returned a string
+            options.name = partial;
+            partial = options.partials[partial];
+          }
+          return partial;
+        }
+
+        function invokePartial(partial, context, options) {
+          // Use the current closure context to save the partial-block if this partial
+          var currentPartialBlock = options.data && options.data['partial-block'];
+          options.partial = true;
+          if (options.ids) {
+            options.data.contextPath = options.ids[0] || options.data.contextPath;
+          }
+
+          var partialBlock = undefined;
+          if (options.fn && options.fn !== noop) {
+            (function () {
+              options.data = _base.createFrame(options.data);
+              // Wrapper function to get access to currentPartialBlock from the closure
+              var fn = options.fn;
+              partialBlock = options.data['partial-block'] = function partialBlockWrapper(context) {
+                var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+                // Restore the partial-block from the closure for the execution of the block
+                // i.e. the part inside the block of the partial call.
+                options.data = _base.createFrame(options.data);
+                options.data['partial-block'] = currentPartialBlock;
+                return fn(context, options);
+              };
+              if (fn.partials) {
+                options.partials = Utils.extend({}, options.partials, fn.partials);
+              }
+            })();
+          }
+
+          if (partial === undefined && partialBlock) {
+            partial = partialBlock;
+          }
+
+          if (partial === undefined) {
+            throw new _exception2['default']('The partial ' + options.name + ' could not be found');
+          } else if (partial instanceof Function) {
+            return partial(context, options);
+          }
+        }
+
+        function noop() {
+          return '';
+        }
+
+        function initData(context, data) {
+          if (!data || !('root' in data)) {
+            data = data ? _base.createFrame(data) : {};
+            data.root = context;
+          }
+          return data;
+        }
+
+        function executeDecorators(fn, prog, container, depths, data, blockParams) {
+          if (fn.decorator) {
+            var props = {};
+            prog = fn.decorator(prog, props, container, depths && depths[0], data, blockParams, depths);
+            Utils.extend(prog, props);
+          }
+          return prog;
+        }
+
+        function wrapHelpersToPassLookupProperty(mergedHelpers, container) {
+          _Object$keys(mergedHelpers).forEach(function (helperName) {
+            var helper = mergedHelpers[helperName];
+            mergedHelpers[helperName] = passLookupPropertyOption(helper, container);
+          });
+        }
+
+        function passLookupPropertyOption(helper, container) {
+          var lookupProperty = container.lookupProperty;
+          return _internalWrapHelper.wrapHelper(helper, function (options) {
+            return Utils.extend({ lookupProperty: lookupProperty }, options);
+          });
+        }
+
+/***/ }),
+/* 39 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        module.exports = { "default": __webpack_require__(40), __esModule: true };
+
+/***/ }),
+/* 40 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        __webpack_require__(41);
+        module.exports = __webpack_require__(21).Object.seal;
+
+/***/ }),
+/* 41 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        // 19.1.2.17 Object.seal(O)
+        var isObject = __webpack_require__(42);
+
+        __webpack_require__(18)('seal', function($seal){
+          return function seal(it){
+            return $seal && isObject(it) ? $seal(it) : it;
+          };
+        });
+
+/***/ }),
+/* 42 */
+/***/ (function(module, exports) {
+
+        module.exports = function(it){
+          return typeof it === 'object' ? it !== null : typeof it === 'function';
+        };
+
+/***/ }),
+/* 43 */
+/***/ (function(module, exports) {
+
+        'use strict';
+
+        exports.__esModule = true;
+        exports.wrapHelper = wrapHelper;
+
+        function wrapHelper(helper, transformOptionsFn) {
+          if (typeof helper !== 'function') {
+            // This should not happen, but apparently it does in https://github.com/wycats/handlebars.js/issues/1639
+            // We try to make the wrapper least-invasive by not wrapping it, if the helper is not a function.
+            return helper;
+          }
+          var wrapper = function wrapper() /* dynamic arguments */{
+            var options = arguments[arguments.length - 1];
+            arguments[arguments.length - 1] = transformOptionsFn(options);
+            return helper.apply(this, arguments);
+          };
+          return wrapper;
+        }
+
+/***/ }),
+/* 44 */
+/***/ (function(module, exports) {
+
+        /* WEBPACK VAR INJECTION */(function(global) {'use strict';
+
+        exports.__esModule = true;
+
+        exports['default'] = function (Handlebars) {
+          /* istanbul ignore next */
+          var root = typeof global !== 'undefined' ? global : window,
+              $Handlebars = root.Handlebars;
+          /* istanbul ignore next */
+          Handlebars.noConflict = function () {
+            if (root.Handlebars === Handlebars) {
+              root.Handlebars = $Handlebars;
+            }
+            return Handlebars;
+          };
+        };
+
+        module.exports = exports['default'];
+        /* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
+
+/***/ }),
+/* 45 */
+/***/ (function(module, exports) {
+
+        'use strict';
+
+        exports.__esModule = true;
+        var AST = {
+          // Public API used to evaluate derived attributes regarding AST nodes
+          helpers: {
+            // a mustache is definitely a helper if:
+            // * it is an eligible helper, and
+            // * it has at least one parameter or hash segment
+            helperExpression: function helperExpression(node) {
+              return node.type === 'SubExpression' || (node.type === 'MustacheStatement' || node.type === 'BlockStatement') && !!(node.params && node.params.length || node.hash);
+            },
+
+            scopedId: function scopedId(path) {
+              return (/^\.|this\b/.test(path.original)
+              );
+            },
+
+            // an ID is simple if it only has one part, and that part is not
+            // `..` or `this`.
+            simpleId: function simpleId(path) {
+              return path.parts.length === 1 && !AST.helpers.scopedId(path) && !path.depth;
+            }
+          }
+        };
+
+        // Must be exported as an object rather than the root of the module as the jison lexer
+        // must modify the object to operate properly.
+        exports['default'] = AST;
+        module.exports = exports['default'];
+
+/***/ }),
+/* 46 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _interopRequireDefault = __webpack_require__(1)['default'];
+
+        var _interopRequireWildcard = __webpack_require__(3)['default'];
+
+        exports.__esModule = true;
+        exports.parseWithoutProcessing = parseWithoutProcessing;
+        exports.parse = parse;
+
+        var _parser = __webpack_require__(47);
+
+        var _parser2 = _interopRequireDefault(_parser);
+
+        var _whitespaceControl = __webpack_require__(48);
+
+        var _whitespaceControl2 = _interopRequireDefault(_whitespaceControl);
+
+        var _helpers = __webpack_require__(50);
+
+        var Helpers = _interopRequireWildcard(_helpers);
+
+        var _utils = __webpack_require__(5);
+
+        exports.parser = _parser2['default'];
+
+        var yy = {};
+        _utils.extend(yy, Helpers);
+
+        function parseWithoutProcessing(input, options) {
+          // Just return if an already-compiled AST was passed in.
+          if (input.type === 'Program') {
+            return input;
+          }
+
+          _parser2['default'].yy = yy;
+
+          // Altering the shared object here, but this is ok as parser is a sync operation
+          yy.locInfo = function (locInfo) {
+            return new yy.SourceLocation(options && options.srcName, locInfo);
+          };
+
+          var ast = _parser2['default'].parse(input);
+
+          return ast;
+        }
+
+        function parse(input, options) {
+          var ast = parseWithoutProcessing(input, options);
+          var strip = new _whitespaceControl2['default'](options);
+
+          return strip.accept(ast);
+        }
+
+/***/ }),
+/* 47 */
+/***/ (function(module, exports) {
+
+        // File ignored in coverage tests via setting in .istanbul.yml
+        /* Jison generated parser */
+        "use strict";
+
+        exports.__esModule = true;
+        var handlebars = (function () {
+            var parser = { trace: function trace() {},
+                yy: {},
+                symbols_: { "error": 2, "root": 3, "program": 4, "EOF": 5, "program_repetition0": 6, "statement": 7, "mustache": 8, "block": 9, "rawBlock": 10, "partial": 11, "partialBlock": 12, "content": 13, "COMMENT": 14, "CONTENT": 15, "openRawBlock": 16, "rawBlock_repetition0": 17, "END_RAW_BLOCK": 18, "OPEN_RAW_BLOCK": 19, "helperName": 20, "openRawBlock_repetition0": 21, "openRawBlock_option0": 22, "CLOSE_RAW_BLOCK": 23, "openBlock": 24, "block_option0": 25, "closeBlock": 26, "openInverse": 27, "block_option1": 28, "OPEN_BLOCK": 29, "openBlock_repetition0": 30, "openBlock_option0": 31, "openBlock_option1": 32, "CLOSE": 33, "OPEN_INVERSE": 34, "openInverse_repetition0": 35, "openInverse_option0": 36, "openInverse_option1": 37, "openInverseChain": 38, "OPEN_INVERSE_CHAIN": 39, "openInverseChain_repetition0": 40, "openInverseChain_option0": 41, "openInverseChain_option1": 42, "inverseAndProgram": 43, "INVERSE": 44, "inverseChain": 45, "inverseChain_option0": 46, "OPEN_ENDBLOCK": 47, "OPEN": 48, "mustache_repetition0": 49, "mustache_option0": 50, "OPEN_UNESCAPED": 51, "mustache_repetition1": 52, "mustache_option1": 53, "CLOSE_UNESCAPED": 54, "OPEN_PARTIAL": 55, "partialName": 56, "partial_repetition0": 57, "partial_option0": 58, "openPartialBlock": 59, "OPEN_PARTIAL_BLOCK": 60, "openPartialBlock_repetition0": 61, "openPartialBlock_option0": 62, "param": 63, "sexpr": 64, "OPEN_SEXPR": 65, "sexpr_repetition0": 66, "sexpr_option0": 67, "CLOSE_SEXPR": 68, "hash": 69, "hash_repetition_plus0": 70, "hashSegment": 71, "ID": 72, "EQUALS": 73, "blockParams": 74, "OPEN_BLOCK_PARAMS": 75, "blockParams_repetition_plus0": 76, "CLOSE_BLOCK_PARAMS": 77, "path": 78, "dataName": 79, "STRING": 80, "NUMBER": 81, "BOOLEAN": 82, "UNDEFINED": 83, "NULL": 84, "DATA": 85, "pathSegments": 86, "SEP": 87, "$accept": 0, "$end": 1 },
+                terminals_: { 2: "error", 5: "EOF", 14: "COMMENT", 15: "CONTENT", 18: "END_RAW_BLOCK", 19: "OPEN_RAW_BLOCK", 23: "CLOSE_RAW_BLOCK", 29: "OPEN_BLOCK", 33: "CLOSE", 34: "OPEN_INVERSE", 39: "OPEN_INVERSE_CHAIN", 44: "INVERSE", 47: "OPEN_ENDBLOCK", 48: "OPEN", 51: "OPEN_UNESCAPED", 54: "CLOSE_UNESCAPED", 55: "OPEN_PARTIAL", 60: "OPEN_PARTIAL_BLOCK", 65: "OPEN_SEXPR", 68: "CLOSE_SEXPR", 72: "ID", 73: "EQUALS", 75: "OPEN_BLOCK_PARAMS", 77: "CLOSE_BLOCK_PARAMS", 80: "STRING", 81: "NUMBER", 82: "BOOLEAN", 83: "UNDEFINED", 84: "NULL", 85: "DATA", 87: "SEP" },
+                productions_: [0, [3, 2], [4, 1], [7, 1], [7, 1], [7, 1], [7, 1], [7, 1], [7, 1], [7, 1], [13, 1], [10, 3], [16, 5], [9, 4], [9, 4], [24, 6], [27, 6], [38, 6], [43, 2], [45, 3], [45, 1], [26, 3], [8, 5], [8, 5], [11, 5], [12, 3], [59, 5], [63, 1], [63, 1], [64, 5], [69, 1], [71, 3], [74, 3], [20, 1], [20, 1], [20, 1], [20, 1], [20, 1], [20, 1], [20, 1], [56, 1], [56, 1], [79, 2], [78, 1], [86, 3], [86, 1], [6, 0], [6, 2], [17, 0], [17, 2], [21, 0], [21, 2], [22, 0], [22, 1], [25, 0], [25, 1], [28, 0], [28, 1], [30, 0], [30, 2], [31, 0], [31, 1], [32, 0], [32, 1], [35, 0], [35, 2], [36, 0], [36, 1], [37, 0], [37, 1], [40, 0], [40, 2], [41, 0], [41, 1], [42, 0], [42, 1], [46, 0], [46, 1], [49, 0], [49, 2], [50, 0], [50, 1], [52, 0], [52, 2], [53, 0], [53, 1], [57, 0], [57, 2], [58, 0], [58, 1], [61, 0], [61, 2], [62, 0], [62, 1], [66, 0], [66, 2], [67, 0], [67, 1], [70, 1], [70, 2], [76, 1], [76, 2]],
+                performAction: function anonymous(yytext, yyleng, yylineno, yy, yystate, $$, _$) {
+
+                    var $0 = $$.length - 1;
+                    switch (yystate) {
+                        case 1:
+                            return $$[$0 - 1];
+                            break;
+                        case 2:
+                            this.$ = yy.prepareProgram($$[$0]);
+                            break;
+                        case 3:
+                            this.$ = $$[$0];
+                            break;
+                        case 4:
+                            this.$ = $$[$0];
+                            break;
+                        case 5:
+                            this.$ = $$[$0];
+                            break;
+                        case 6:
+                            this.$ = $$[$0];
+                            break;
+                        case 7:
+                            this.$ = $$[$0];
+                            break;
+                        case 8:
+                            this.$ = $$[$0];
+                            break;
+                        case 9:
+                            this.$ = {
+                                type: 'CommentStatement',
+                                value: yy.stripComment($$[$0]),
+                                strip: yy.stripFlags($$[$0], $$[$0]),
+                                loc: yy.locInfo(this._$)
+                            };
+
+                            break;
+                        case 10:
+                            this.$ = {
+                                type: 'ContentStatement',
+                                original: $$[$0],
+                                value: $$[$0],
+                                loc: yy.locInfo(this._$)
+                            };
+
+                            break;
+                        case 11:
+                            this.$ = yy.prepareRawBlock($$[$0 - 2], $$[$0 - 1], $$[$0], this._$);
+                            break;
+                        case 12:
+                            this.$ = { path: $$[$0 - 3], params: $$[$0 - 2], hash: $$[$0 - 1] };
+                            break;
+                        case 13:
+                            this.$ = yy.prepareBlock($$[$0 - 3], $$[$0 - 2], $$[$0 - 1], $$[$0], false, this._$);
+                            break;
+                        case 14:
+                            this.$ = yy.prepareBlock($$[$0 - 3], $$[$0 - 2], $$[$0 - 1], $$[$0], true, this._$);
+                            break;
+                        case 15:
+                            this.$ = { open: $$[$0 - 5], path: $$[$0 - 4], params: $$[$0 - 3], hash: $$[$0 - 2], blockParams: $$[$0 - 1], strip: yy.stripFlags($$[$0 - 5], $$[$0]) };
+                            break;
+                        case 16:
+                            this.$ = { path: $$[$0 - 4], params: $$[$0 - 3], hash: $$[$0 - 2], blockParams: $$[$0 - 1], strip: yy.stripFlags($$[$0 - 5], $$[$0]) };
+                            break;
+                        case 17:
+                            this.$ = { path: $$[$0 - 4], params: $$[$0 - 3], hash: $$[$0 - 2], blockParams: $$[$0 - 1], strip: yy.stripFlags($$[$0 - 5], $$[$0]) };
+                            break;
+                        case 18:
+                            this.$ = { strip: yy.stripFlags($$[$0 - 1], $$[$0 - 1]), program: $$[$0] };
+                            break;
+                        case 19:
+                            var inverse = yy.prepareBlock($$[$0 - 2], $$[$0 - 1], $$[$0], $$[$0], false, this._$),
+                                program = yy.prepareProgram([inverse], $$[$0 - 1].loc);
+                            program.chained = true;
+
+                            this.$ = { strip: $$[$0 - 2].strip, program: program, chain: true };
+
+                            break;
+                        case 20:
+                            this.$ = $$[$0];
+                            break;
+                        case 21:
+                            this.$ = { path: $$[$0 - 1], strip: yy.stripFlags($$[$0 - 2], $$[$0]) };
+                            break;
+                        case 22:
+                            this.$ = yy.prepareMustache($$[$0 - 3], $$[$0 - 2], $$[$0 - 1], $$[$0 - 4], yy.stripFlags($$[$0 - 4], $$[$0]), this._$);
+                            break;
+                        case 23:
+                            this.$ = yy.prepareMustache($$[$0 - 3], $$[$0 - 2], $$[$0 - 1], $$[$0 - 4], yy.stripFlags($$[$0 - 4], $$[$0]), this._$);
+                            break;
+                        case 24:
+                            this.$ = {
+                                type: 'PartialStatement',
+                                name: $$[$0 - 3],
+                                params: $$[$0 - 2],
+                                hash: $$[$0 - 1],
+                                indent: '',
+                                strip: yy.stripFlags($$[$0 - 4], $$[$0]),
+                                loc: yy.locInfo(this._$)
+                            };
+
+                            break;
+                        case 25:
+                            this.$ = yy.preparePartialBlock($$[$0 - 2], $$[$0 - 1], $$[$0], this._$);
+                            break;
+                        case 26:
+                            this.$ = { path: $$[$0 - 3], params: $$[$0 - 2], hash: $$[$0 - 1], strip: yy.stripFlags($$[$0 - 4], $$[$0]) };
+                            break;
+                        case 27:
+                            this.$ = $$[$0];
+                            break;
+                        case 28:
+                            this.$ = $$[$0];
+                            break;
+                        case 29:
+                            this.$ = {
+                                type: 'SubExpression',
+                                path: $$[$0 - 3],
+                                params: $$[$0 - 2],
+                                hash: $$[$0 - 1],
+                                loc: yy.locInfo(this._$)
+                            };
+
+                            break;
+                        case 30:
+                            this.$ = { type: 'Hash', pairs: $$[$0], loc: yy.locInfo(this._$) };
+                            break;
+                        case 31:
+                            this.$ = { type: 'HashPair', key: yy.id($$[$0 - 2]), value: $$[$0], loc: yy.locInfo(this._$) };
+                            break;
+                        case 32:
+                            this.$ = yy.id($$[$0 - 1]);
+                            break;
+                        case 33:
+                            this.$ = $$[$0];
+                            break;
+                        case 34:
+                            this.$ = $$[$0];
+                            break;
+                        case 35:
+                            this.$ = { type: 'StringLiteral', value: $$[$0], original: $$[$0], loc: yy.locInfo(this._$) };
+                            break;
+                        case 36:
+                            this.$ = { type: 'NumberLiteral', value: Number($$[$0]), original: Number($$[$0]), loc: yy.locInfo(this._$) };
+                            break;
+                        case 37:
+                            this.$ = { type: 'BooleanLiteral', value: $$[$0] === 'true', original: $$[$0] === 'true', loc: yy.locInfo(this._$) };
+                            break;
+                        case 38:
+                            this.$ = { type: 'UndefinedLiteral', original: undefined, value: undefined, loc: yy.locInfo(this._$) };
+                            break;
+                        case 39:
+                            this.$ = { type: 'NullLiteral', original: null, value: null, loc: yy.locInfo(this._$) };
+                            break;
+                        case 40:
+                            this.$ = $$[$0];
+                            break;
+                        case 41:
+                            this.$ = $$[$0];
+                            break;
+                        case 42:
+                            this.$ = yy.preparePath(true, $$[$0], this._$);
+                            break;
+                        case 43:
+                            this.$ = yy.preparePath(false, $$[$0], this._$);
+                            break;
+                        case 44:
+                            $$[$0 - 2].push({ part: yy.id($$[$0]), original: $$[$0], separator: $$[$0 - 1] });this.$ = $$[$0 - 2];
+                            break;
+                        case 45:
+                            this.$ = [{ part: yy.id($$[$0]), original: $$[$0] }];
+                            break;
+                        case 46:
+                            this.$ = [];
+                            break;
+                        case 47:
+                            $$[$0 - 1].push($$[$0]);
+                            break;
+                        case 48:
+                            this.$ = [];
+                            break;
+                        case 49:
+                            $$[$0 - 1].push($$[$0]);
+                            break;
+                        case 50:
+                            this.$ = [];
+                            break;
+                        case 51:
+                            $$[$0 - 1].push($$[$0]);
+                            break;
+                        case 58:
+                            this.$ = [];
+                            break;
+                        case 59:
+                            $$[$0 - 1].push($$[$0]);
+                            break;
+                        case 64:
+                            this.$ = [];
+                            break;
+                        case 65:
+                            $$[$0 - 1].push($$[$0]);
+                            break;
+                        case 70:
+                            this.$ = [];
+                            break;
+                        case 71:
+                            $$[$0 - 1].push($$[$0]);
+                            break;
+                        case 78:
+                            this.$ = [];
+                            break;
+                        case 79:
+                            $$[$0 - 1].push($$[$0]);
+                            break;
+                        case 82:
+                            this.$ = [];
+                            break;
+                        case 83:
+                            $$[$0 - 1].push($$[$0]);
+                            break;
+                        case 86:
+                            this.$ = [];
+                            break;
+                        case 87:
+                            $$[$0 - 1].push($$[$0]);
+                            break;
+                        case 90:
+                            this.$ = [];
+                            break;
+                        case 91:
+                            $$[$0 - 1].push($$[$0]);
+                            break;
+                        case 94:
+                            this.$ = [];
+                            break;
+                        case 95:
+                            $$[$0 - 1].push($$[$0]);
+                            break;
+                        case 98:
+                            this.$ = [$$[$0]];
+                            break;
+                        case 99:
+                            $$[$0 - 1].push($$[$0]);
+                            break;
+                        case 100:
+                            this.$ = [$$[$0]];
+                            break;
+                        case 101:
+                            $$[$0 - 1].push($$[$0]);
+                            break;
+                    }
+                },
+                table: [{ 3: 1, 4: 2, 5: [2, 46], 6: 3, 14: [2, 46], 15: [2, 46], 19: [2, 46], 29: [2, 46], 34: [2, 46], 48: [2, 46], 51: [2, 46], 55: [2, 46], 60: [2, 46] }, { 1: [3] }, { 5: [1, 4] }, { 5: [2, 2], 7: 5, 8: 6, 9: 7, 10: 8, 11: 9, 12: 10, 13: 11, 14: [1, 12], 15: [1, 20], 16: 17, 19: [1, 23], 24: 15, 27: 16, 29: [1, 21], 34: [1, 22], 39: [2, 2], 44: [2, 2], 47: [2, 2], 48: [1, 13], 51: [1, 14], 55: [1, 18], 59: 19, 60: [1, 24] }, { 1: [2, 1] }, { 5: [2, 47], 14: [2, 47], 15: [2, 47], 19: [2, 47], 29: [2, 47], 34: [2, 47], 39: [2, 47], 44: [2, 47], 47: [2, 47], 48: [2, 47], 51: [2, 47], 55: [2, 47], 60: [2, 47] }, { 5: [2, 3], 14: [2, 3], 15: [2, 3], 19: [2, 3], 29: [2, 3], 34: [2, 3], 39: [2, 3], 44: [2, 3], 47: [2, 3], 48: [2, 3], 51: [2, 3], 55: [2, 3], 60: [2, 3] }, { 5: [2, 4], 14: [2, 4], 15: [2, 4], 19: [2, 4], 29: [2, 4], 34: [2, 4], 39: [2, 4], 44: [2, 4], 47: [2, 4], 48: [2, 4], 51: [2, 4], 55: [2, 4], 60: [2, 4] }, { 5: [2, 5], 14: [2, 5], 15: [2, 5], 19: [2, 5], 29: [2, 5], 34: [2, 5], 39: [2, 5], 44: [2, 5], 47: [2, 5], 48: [2, 5], 51: [2, 5], 55: [2, 5], 60: [2, 5] }, { 5: [2, 6], 14: [2, 6], 15: [2, 6], 19: [2, 6], 29: [2, 6], 34: [2, 6], 39: [2, 6], 44: [2, 6], 47: [2, 6], 48: [2, 6], 51: [2, 6], 55: [2, 6], 60: [2, 6] }, { 5: [2, 7], 14: [2, 7], 15: [2, 7], 19: [2, 7], 29: [2, 7], 34: [2, 7], 39: [2, 7], 44: [2, 7], 47: [2, 7], 48: [2, 7], 51: [2, 7], 55: [2, 7], 60: [2, 7] }, { 5: [2, 8], 14: [2, 8], 15: [2, 8], 19: [2, 8], 29: [2, 8], 34: [2, 8], 39: [2, 8], 44: [2, 8], 47: [2, 8], 48: [2, 8], 51: [2, 8], 55: [2, 8], 60: [2, 8] }, { 5: [2, 9], 14: [2, 9], 15: [2, 9], 19: [2, 9], 29: [2, 9], 34: [2, 9], 39: [2, 9], 44: [2, 9], 47: [2, 9], 48: [2, 9], 51: [2, 9], 55: [2, 9], 60: [2, 9] }, { 20: 25, 72: [1, 35], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 20: 36, 72: [1, 35], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 4: 37, 6: 3, 14: [2, 46], 15: [2, 46], 19: [2, 46], 29: [2, 46], 34: [2, 46], 39: [2, 46], 44: [2, 46], 47: [2, 46], 48: [2, 46], 51: [2, 46], 55: [2, 46], 60: [2, 46] }, { 4: 38, 6: 3, 14: [2, 46], 15: [2, 46], 19: [2, 46], 29: [2, 46], 34: [2, 46], 44: [2, 46], 47: [2, 46], 48: [2, 46], 51: [2, 46], 55: [2, 46], 60: [2, 46] }, { 15: [2, 48], 17: 39, 18: [2, 48] }, { 20: 41, 56: 40, 64: 42, 65: [1, 43], 72: [1, 35], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 4: 44, 6: 3, 14: [2, 46], 15: [2, 46], 19: [2, 46], 29: [2, 46], 34: [2, 46], 47: [2, 46], 48: [2, 46], 51: [2, 46], 55: [2, 46], 60: [2, 46] }, { 5: [2, 10], 14: [2, 10], 15: [2, 10], 18: [2, 10], 19: [2, 10], 29: [2, 10], 34: [2, 10], 39: [2, 10], 44: [2, 10], 47: [2, 10], 48: [2, 10], 51: [2, 10], 55: [2, 10], 60: [2, 10] }, { 20: 45, 72: [1, 35], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 20: 46, 72: [1, 35], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 20: 47, 72: [1, 35], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 20: 41, 56: 48, 64: 42, 65: [1, 43], 72: [1, 35], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 33: [2, 78], 49: 49, 65: [2, 78], 72: [2, 78], 80: [2, 78], 81: [2, 78], 82: [2, 78], 83: [2, 78], 84: [2, 78], 85: [2, 78] }, { 23: [2, 33], 33: [2, 33], 54: [2, 33], 65: [2, 33], 68: [2, 33], 72: [2, 33], 75: [2, 33], 80: [2, 33], 81: [2, 33], 82: [2, 33], 83: [2, 33], 84: [2, 33], 85: [2, 33] }, { 23: [2, 34], 33: [2, 34], 54: [2, 34], 65: [2, 34], 68: [2, 34], 72: [2, 34], 75: [2, 34], 80: [2, 34], 81: [2, 34], 82: [2, 34], 83: [2, 34], 84: [2, 34], 85: [2, 34] }, { 23: [2, 35], 33: [2, 35], 54: [2, 35], 65: [2, 35], 68: [2, 35], 72: [2, 35], 75: [2, 35], 80: [2, 35], 81: [2, 35], 82: [2, 35], 83: [2, 35], 84: [2, 35], 85: [2, 35] }, { 23: [2, 36], 33: [2, 36], 54: [2, 36], 65: [2, 36], 68: [2, 36], 72: [2, 36], 75: [2, 36], 80: [2, 36], 81: [2, 36], 82: [2, 36], 83: [2, 36], 84: [2, 36], 85: [2, 36] }, { 23: [2, 37], 33: [2, 37], 54: [2, 37], 65: [2, 37], 68: [2, 37], 72: [2, 37], 75: [2, 37], 80: [2, 37], 81: [2, 37], 82: [2, 37], 83: [2, 37], 84: [2, 37], 85: [2, 37] }, { 23: [2, 38], 33: [2, 38], 54: [2, 38], 65: [2, 38], 68: [2, 38], 72: [2, 38], 75: [2, 38], 80: [2, 38], 81: [2, 38], 82: [2, 38], 83: [2, 38], 84: [2, 38], 85: [2, 38] }, { 23: [2, 39], 33: [2, 39], 54: [2, 39], 65: [2, 39], 68: [2, 39], 72: [2, 39], 75: [2, 39], 80: [2, 39], 81: [2, 39], 82: [2, 39], 83: [2, 39], 84: [2, 39], 85: [2, 39] }, { 23: [2, 43], 33: [2, 43], 54: [2, 43], 65: [2, 43], 68: [2, 43], 72: [2, 43], 75: [2, 43], 80: [2, 43], 81: [2, 43], 82: [2, 43], 83: [2, 43], 84: [2, 43], 85: [2, 43], 87: [1, 50] }, { 72: [1, 35], 86: 51 }, { 23: [2, 45], 33: [2, 45], 54: [2, 45], 65: [2, 45], 68: [2, 45], 72: [2, 45], 75: [2, 45], 80: [2, 45], 81: [2, 45], 82: [2, 45], 83: [2, 45], 84: [2, 45], 85: [2, 45], 87: [2, 45] }, { 52: 52, 54: [2, 82], 65: [2, 82], 72: [2, 82], 80: [2, 82], 81: [2, 82], 82: [2, 82], 83: [2, 82], 84: [2, 82], 85: [2, 82] }, { 25: 53, 38: 55, 39: [1, 57], 43: 56, 44: [1, 58], 45: 54, 47: [2, 54] }, { 28: 59, 43: 60, 44: [1, 58], 47: [2, 56] }, { 13: 62, 15: [1, 20], 18: [1, 61] }, { 33: [2, 86], 57: 63, 65: [2, 86], 72: [2, 86], 80: [2, 86], 81: [2, 86], 82: [2, 86], 83: [2, 86], 84: [2, 86], 85: [2, 86] }, { 33: [2, 40], 65: [2, 40], 72: [2, 40], 80: [2, 40], 81: [2, 40], 82: [2, 40], 83: [2, 40], 84: [2, 40], 85: [2, 40] }, { 33: [2, 41], 65: [2, 41], 72: [2, 41], 80: [2, 41], 81: [2, 41], 82: [2, 41], 83: [2, 41], 84: [2, 41], 85: [2, 41] }, { 20: 64, 72: [1, 35], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 26: 65, 47: [1, 66] }, { 30: 67, 33: [2, 58], 65: [2, 58], 72: [2, 58], 75: [2, 58], 80: [2, 58], 81: [2, 58], 82: [2, 58], 83: [2, 58], 84: [2, 58], 85: [2, 58] }, { 33: [2, 64], 35: 68, 65: [2, 64], 72: [2, 64], 75: [2, 64], 80: [2, 64], 81: [2, 64], 82: [2, 64], 83: [2, 64], 84: [2, 64], 85: [2, 64] }, { 21: 69, 23: [2, 50], 65: [2, 50], 72: [2, 50], 80: [2, 50], 81: [2, 50], 82: [2, 50], 83: [2, 50], 84: [2, 50], 85: [2, 50] }, { 33: [2, 90], 61: 70, 65: [2, 90], 72: [2, 90], 80: [2, 90], 81: [2, 90], 82: [2, 90], 83: [2, 90], 84: [2, 90], 85: [2, 90] }, { 20: 74, 33: [2, 80], 50: 71, 63: 72, 64: 75, 65: [1, 43], 69: 73, 70: 76, 71: 77, 72: [1, 78], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 72: [1, 79] }, { 23: [2, 42], 33: [2, 42], 54: [2, 42], 65: [2, 42], 68: [2, 42], 72: [2, 42], 75: [2, 42], 80: [2, 42], 81: [2, 42], 82: [2, 42], 83: [2, 42], 84: [2, 42], 85: [2, 42], 87: [1, 50] }, { 20: 74, 53: 80, 54: [2, 84], 63: 81, 64: 75, 65: [1, 43], 69: 82, 70: 76, 71: 77, 72: [1, 78], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 26: 83, 47: [1, 66] }, { 47: [2, 55] }, { 4: 84, 6: 3, 14: [2, 46], 15: [2, 46], 19: [2, 46], 29: [2, 46], 34: [2, 46], 39: [2, 46], 44: [2, 46], 47: [2, 46], 48: [2, 46], 51: [2, 46], 55: [2, 46], 60: [2, 46] }, { 47: [2, 20] }, { 20: 85, 72: [1, 35], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 4: 86, 6: 3, 14: [2, 46], 15: [2, 46], 19: [2, 46], 29: [2, 46], 34: [2, 46], 47: [2, 46], 48: [2, 46], 51: [2, 46], 55: [2, 46], 60: [2, 46] }, { 26: 87, 47: [1, 66] }, { 47: [2, 57] }, { 5: [2, 11], 14: [2, 11], 15: [2, 11], 19: [2, 11], 29: [2, 11], 34: [2, 11], 39: [2, 11], 44: [2, 11], 47: [2, 11], 48: [2, 11], 51: [2, 11], 55: [2, 11], 60: [2, 11] }, { 15: [2, 49], 18: [2, 49] }, { 20: 74, 33: [2, 88], 58: 88, 63: 89, 64: 75, 65: [1, 43], 69: 90, 70: 76, 71: 77, 72: [1, 78], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 65: [2, 94], 66: 91, 68: [2, 94], 72: [2, 94], 80: [2, 94], 81: [2, 94], 82: [2, 94], 83: [2, 94], 84: [2, 94], 85: [2, 94] }, { 5: [2, 25], 14: [2, 25], 15: [2, 25], 19: [2, 25], 29: [2, 25], 34: [2, 25], 39: [2, 25], 44: [2, 25], 47: [2, 25], 48: [2, 25], 51: [2, 25], 55: [2, 25], 60: [2, 25] }, { 20: 92, 72: [1, 35], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 20: 74, 31: 93, 33: [2, 60], 63: 94, 64: 75, 65: [1, 43], 69: 95, 70: 76, 71: 77, 72: [1, 78], 75: [2, 60], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 20: 74, 33: [2, 66], 36: 96, 63: 97, 64: 75, 65: [1, 43], 69: 98, 70: 76, 71: 77, 72: [1, 78], 75: [2, 66], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 20: 74, 22: 99, 23: [2, 52], 63: 100, 64: 75, 65: [1, 43], 69: 101, 70: 76, 71: 77, 72: [1, 78], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 20: 74, 33: [2, 92], 62: 102, 63: 103, 64: 75, 65: [1, 43], 69: 104, 70: 76, 71: 77, 72: [1, 78], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 33: [1, 105] }, { 33: [2, 79], 65: [2, 79], 72: [2, 79], 80: [2, 79], 81: [2, 79], 82: [2, 79], 83: [2, 79], 84: [2, 79], 85: [2, 79] }, { 33: [2, 81] }, { 23: [2, 27], 33: [2, 27], 54: [2, 27], 65: [2, 27], 68: [2, 27], 72: [2, 27], 75: [2, 27], 80: [2, 27], 81: [2, 27], 82: [2, 27], 83: [2, 27], 84: [2, 27], 85: [2, 27] }, { 23: [2, 28], 33: [2, 28], 54: [2, 28], 65: [2, 28], 68: [2, 28], 72: [2, 28], 75: [2, 28], 80: [2, 28], 81: [2, 28], 82: [2, 28], 83: [2, 28], 84: [2, 28], 85: [2, 28] }, { 23: [2, 30], 33: [2, 30], 54: [2, 30], 68: [2, 30], 71: 106, 72: [1, 107], 75: [2, 30] }, { 23: [2, 98], 33: [2, 98], 54: [2, 98], 68: [2, 98], 72: [2, 98], 75: [2, 98] }, { 23: [2, 45], 33: [2, 45], 54: [2, 45], 65: [2, 45], 68: [2, 45], 72: [2, 45], 73: [1, 108], 75: [2, 45], 80: [2, 45], 81: [2, 45], 82: [2, 45], 83: [2, 45], 84: [2, 45], 85: [2, 45], 87: [2, 45] }, { 23: [2, 44], 33: [2, 44], 54: [2, 44], 65: [2, 44], 68: [2, 44], 72: [2, 44], 75: [2, 44], 80: [2, 44], 81: [2, 44], 82: [2, 44], 83: [2, 44], 84: [2, 44], 85: [2, 44], 87: [2, 44] }, { 54: [1, 109] }, { 54: [2, 83], 65: [2, 83], 72: [2, 83], 80: [2, 83], 81: [2, 83], 82: [2, 83], 83: [2, 83], 84: [2, 83], 85: [2, 83] }, { 54: [2, 85] }, { 5: [2, 13], 14: [2, 13], 15: [2, 13], 19: [2, 13], 29: [2, 13], 34: [2, 13], 39: [2, 13], 44: [2, 13], 47: [2, 13], 48: [2, 13], 51: [2, 13], 55: [2, 13], 60: [2, 13] }, { 38: 55, 39: [1, 57], 43: 56, 44: [1, 58], 45: 111, 46: 110, 47: [2, 76] }, { 33: [2, 70], 40: 112, 65: [2, 70], 72: [2, 70], 75: [2, 70], 80: [2, 70], 81: [2, 70], 82: [2, 70], 83: [2, 70], 84: [2, 70], 85: [2, 70] }, { 47: [2, 18] }, { 5: [2, 14], 14: [2, 14], 15: [2, 14], 19: [2, 14], 29: [2, 14], 34: [2, 14], 39: [2, 14], 44: [2, 14], 47: [2, 14], 48: [2, 14], 51: [2, 14], 55: [2, 14], 60: [2, 14] }, { 33: [1, 113] }, { 33: [2, 87], 65: [2, 87], 72: [2, 87], 80: [2, 87], 81: [2, 87], 82: [2, 87], 83: [2, 87], 84: [2, 87], 85: [2, 87] }, { 33: [2, 89] }, { 20: 74, 63: 115, 64: 75, 65: [1, 43], 67: 114, 68: [2, 96], 69: 116, 70: 76, 71: 77, 72: [1, 78], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 33: [1, 117] }, { 32: 118, 33: [2, 62], 74: 119, 75: [1, 120] }, { 33: [2, 59], 65: [2, 59], 72: [2, 59], 75: [2, 59], 80: [2, 59], 81: [2, 59], 82: [2, 59], 83: [2, 59], 84: [2, 59], 85: [2, 59] }, { 33: [2, 61], 75: [2, 61] }, { 33: [2, 68], 37: 121, 74: 122, 75: [1, 120] }, { 33: [2, 65], 65: [2, 65], 72: [2, 65], 75: [2, 65], 80: [2, 65], 81: [2, 65], 82: [2, 65], 83: [2, 65], 84: [2, 65], 85: [2, 65] }, { 33: [2, 67], 75: [2, 67] }, { 23: [1, 123] }, { 23: [2, 51], 65: [2, 51], 72: [2, 51], 80: [2, 51], 81: [2, 51], 82: [2, 51], 83: [2, 51], 84: [2, 51], 85: [2, 51] }, { 23: [2, 53] }, { 33: [1, 124] }, { 33: [2, 91], 65: [2, 91], 72: [2, 91], 80: [2, 91], 81: [2, 91], 82: [2, 91], 83: [2, 91], 84: [2, 91], 85: [2, 91] }, { 33: [2, 93] }, { 5: [2, 22], 14: [2, 22], 15: [2, 22], 19: [2, 22], 29: [2, 22], 34: [2, 22], 39: [2, 22], 44: [2, 22], 47: [2, 22], 48: [2, 22], 51: [2, 22], 55: [2, 22], 60: [2, 22] }, { 23: [2, 99], 33: [2, 99], 54: [2, 99], 68: [2, 99], 72: [2, 99], 75: [2, 99] }, { 73: [1, 108] }, { 20: 74, 63: 125, 64: 75, 65: [1, 43], 72: [1, 35], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 5: [2, 23], 14: [2, 23], 15: [2, 23], 19: [2, 23], 29: [2, 23], 34: [2, 23], 39: [2, 23], 44: [2, 23], 47: [2, 23], 48: [2, 23], 51: [2, 23], 55: [2, 23], 60: [2, 23] }, { 47: [2, 19] }, { 47: [2, 77] }, { 20: 74, 33: [2, 72], 41: 126, 63: 127, 64: 75, 65: [1, 43], 69: 128, 70: 76, 71: 77, 72: [1, 78], 75: [2, 72], 78: 26, 79: 27, 80: [1, 28], 81: [1, 29], 82: [1, 30], 83: [1, 31], 84: [1, 32], 85: [1, 34], 86: 33 }, { 5: [2, 24], 14: [2, 24], 15: [2, 24], 19: [2, 24], 29: [2, 24], 34: [2, 24], 39: [2, 24], 44: [2, 24], 47: [2, 24], 48: [2, 24], 51: [2, 24], 55: [2, 24], 60: [2, 24] }, { 68: [1, 129] }, { 65: [2, 95], 68: [2, 95], 72: [2, 95], 80: [2, 95], 81: [2, 95], 82: [2, 95], 83: [2, 95], 84: [2, 95], 85: [2, 95] }, { 68: [2, 97] }, { 5: [2, 21], 14: [2, 21], 15: [2, 21], 19: [2, 21], 29: [2, 21], 34: [2, 21], 39: [2, 21], 44: [2, 21], 47: [2, 21], 48: [2, 21], 51: [2, 21], 55: [2, 21], 60: [2, 21] }, { 33: [1, 130] }, { 33: [2, 63] }, { 72: [1, 132], 76: 131 }, { 33: [1, 133] }, { 33: [2, 69] }, { 15: [2, 12], 18: [2, 12] }, { 14: [2, 26], 15: [2, 26], 19: [2, 26], 29: [2, 26], 34: [2, 26], 47: [2, 26], 48: [2, 26], 51: [2, 26], 55: [2, 26], 60: [2, 26] }, { 23: [2, 31], 33: [2, 31], 54: [2, 31], 68: [2, 31], 72: [2, 31], 75: [2, 31] }, { 33: [2, 74], 42: 134, 74: 135, 75: [1, 120] }, { 33: [2, 71], 65: [2, 71], 72: [2, 71], 75: [2, 71], 80: [2, 71], 81: [2, 71], 82: [2, 71], 83: [2, 71], 84: [2, 71], 85: [2, 71] }, { 33: [2, 73], 75: [2, 73] }, { 23: [2, 29], 33: [2, 29], 54: [2, 29], 65: [2, 29], 68: [2, 29], 72: [2, 29], 75: [2, 29], 80: [2, 29], 81: [2, 29], 82: [2, 29], 83: [2, 29], 84: [2, 29], 85: [2, 29] }, { 14: [2, 15], 15: [2, 15], 19: [2, 15], 29: [2, 15], 34: [2, 15], 39: [2, 15], 44: [2, 15], 47: [2, 15], 48: [2, 15], 51: [2, 15], 55: [2, 15], 60: [2, 15] }, { 72: [1, 137], 77: [1, 136] }, { 72: [2, 100], 77: [2, 100] }, { 14: [2, 16], 15: [2, 16], 19: [2, 16], 29: [2, 16], 34: [2, 16], 44: [2, 16], 47: [2, 16], 48: [2, 16], 51: [2, 16], 55: [2, 16], 60: [2, 16] }, { 33: [1, 138] }, { 33: [2, 75] }, { 33: [2, 32] }, { 72: [2, 101], 77: [2, 101] }, { 14: [2, 17], 15: [2, 17], 19: [2, 17], 29: [2, 17], 34: [2, 17], 39: [2, 17], 44: [2, 17], 47: [2, 17], 48: [2, 17], 51: [2, 17], 55: [2, 17], 60: [2, 17] }],
+                defaultActions: { 4: [2, 1], 54: [2, 55], 56: [2, 20], 60: [2, 57], 73: [2, 81], 82: [2, 85], 86: [2, 18], 90: [2, 89], 101: [2, 53], 104: [2, 93], 110: [2, 19], 111: [2, 77], 116: [2, 97], 119: [2, 63], 122: [2, 69], 135: [2, 75], 136: [2, 32] },
+                parseError: function parseError(str, hash) {
+                    throw new Error(str);
+                },
+                parse: function parse(input) {
+                    var self = this,
+                        stack = [0],
+                        vstack = [null],
+                        lstack = [],
+                        table = this.table,
+                        yytext = "",
+                        yylineno = 0,
+                        yyleng = 0,
+                        recovering = 0,
+                        TERROR = 2,
+                        EOF = 1;
+                    this.lexer.setInput(input);
+                    this.lexer.yy = this.yy;
+                    this.yy.lexer = this.lexer;
+                    this.yy.parser = this;
+                    if (typeof this.lexer.yylloc == "undefined") this.lexer.yylloc = {};
+                    var yyloc = this.lexer.yylloc;
+                    lstack.push(yyloc);
+                    var ranges = this.lexer.options && this.lexer.options.ranges;
+                    if (typeof this.yy.parseError === "function") this.parseError = this.yy.parseError;
+                    function popStack(n) {
+                        stack.length = stack.length - 2 * n;
+                        vstack.length = vstack.length - n;
+                        lstack.length = lstack.length - n;
+                    }
+                    function lex() {
+                        var token;
+                        token = self.lexer.lex() || 1;
+                        if (typeof token !== "number") {
+                            token = self.symbols_[token] || token;
+                        }
+                        return token;
+                    }
+                    var symbol,
+                        preErrorSymbol,
+                        state,
+                        action,
+                        a,
+                        r,
+                        yyval = {},
+                        p,
+                        len,
+                        newState,
+                        expected;
+                    while (true) {
+                        state = stack[stack.length - 1];
+                        if (this.defaultActions[state]) {
+                            action = this.defaultActions[state];
+                        } else {
+                            if (symbol === null || typeof symbol == "undefined") {
+                                symbol = lex();
+                            }
+                            action = table[state] && table[state][symbol];
+                        }
+                        if (typeof action === "undefined" || !action.length || !action[0]) {
+                            var errStr = "";
+                            if (!recovering) {
+                                expected = [];
+                                for (p in table[state]) if (this.terminals_[p] && p > 2) {
+                                    expected.push("'" + this.terminals_[p] + "'");
+                                }
+                                if (this.lexer.showPosition) {
+                                    errStr = "Parse error on line " + (yylineno + 1) + ":\n" + this.lexer.showPosition() + "\nExpecting " + expected.join(", ") + ", got '" + (this.terminals_[symbol] || symbol) + "'";
+                                } else {
+                                    errStr = "Parse error on line " + (yylineno + 1) + ": Unexpected " + (symbol == 1 ? "end of input" : "'" + (this.terminals_[symbol] || symbol) + "'");
+                                }
+                                this.parseError(errStr, { text: this.lexer.match, token: this.terminals_[symbol] || symbol, line: this.lexer.yylineno, loc: yyloc, expected: expected });
+                            }
+                        }
+                        if (action[0] instanceof Array && action.length > 1) {
+                            throw new Error("Parse Error: multiple actions possible at state: " + state + ", token: " + symbol);
+                        }
+                        switch (action[0]) {
+                            case 1:
+                                stack.push(symbol);
+                                vstack.push(this.lexer.yytext);
+                                lstack.push(this.lexer.yylloc);
+                                stack.push(action[1]);
+                                symbol = null;
+                                if (!preErrorSymbol) {
+                                    yyleng = this.lexer.yyleng;
+                                    yytext = this.lexer.yytext;
+                                    yylineno = this.lexer.yylineno;
+                                    yyloc = this.lexer.yylloc;
+                                    if (recovering > 0) recovering--;
+                                } else {
+                                    symbol = preErrorSymbol;
+                                    preErrorSymbol = null;
+                                }
+                                break;
+                            case 2:
+                                len = this.productions_[action[1]][1];
+                                yyval.$ = vstack[vstack.length - len];
+                                yyval._$ = { first_line: lstack[lstack.length - (len || 1)].first_line, last_line: lstack[lstack.length - 1].last_line, first_column: lstack[lstack.length - (len || 1)].first_column, last_column: lstack[lstack.length - 1].last_column };
+                                if (ranges) {
+                                    yyval._$.range = [lstack[lstack.length - (len || 1)].range[0], lstack[lstack.length - 1].range[1]];
+                                }
+                                r = this.performAction.call(yyval, yytext, yyleng, yylineno, this.yy, action[1], vstack, lstack);
+                                if (typeof r !== "undefined") {
+                                    return r;
+                                }
+                                if (len) {
+                                    stack = stack.slice(0, -1 * len * 2);
+                                    vstack = vstack.slice(0, -1 * len);
+                                    lstack = lstack.slice(0, -1 * len);
+                                }
+                                stack.push(this.productions_[action[1]][0]);
+                                vstack.push(yyval.$);
+                                lstack.push(yyval._$);
+                                newState = table[stack[stack.length - 2]][stack[stack.length - 1]];
+                                stack.push(newState);
+                                break;
+                            case 3:
+                                return true;
+                        }
+                    }
+                    return true;
+                }
+            };
+            /* Jison generated lexer */
+            var lexer = (function () {
+                var lexer = { EOF: 1,
+                    parseError: function parseError(str, hash) {
+                        if (this.yy.parser) {
+                            this.yy.parser.parseError(str, hash);
+                        } else {
+                            throw new Error(str);
+                        }
+                    },
+                    setInput: function setInput(input) {
+                        this._input = input;
+                        this._more = this._less = this.done = false;
+                        this.yylineno = this.yyleng = 0;
+                        this.yytext = this.matched = this.match = '';
+                        this.conditionStack = ['INITIAL'];
+                        this.yylloc = { first_line: 1, first_column: 0, last_line: 1, last_column: 0 };
+                        if (this.options.ranges) this.yylloc.range = [0, 0];
+                        this.offset = 0;
+                        return this;
+                    },
+                    input: function input() {
+                        var ch = this._input[0];
+                        this.yytext += ch;
+                        this.yyleng++;
+                        this.offset++;
+                        this.match += ch;
+                        this.matched += ch;
+                        var lines = ch.match(/(?:\r\n?|\n).*/g);
+                        if (lines) {
+                            this.yylineno++;
+                            this.yylloc.last_line++;
+                        } else {
+                            this.yylloc.last_column++;
+                        }
+                        if (this.options.ranges) this.yylloc.range[1]++;
+
+                        this._input = this._input.slice(1);
+                        return ch;
+                    },
+                    unput: function unput(ch) {
+                        var len = ch.length;
+                        var lines = ch.split(/(?:\r\n?|\n)/g);
+
+                        this._input = ch + this._input;
+                        this.yytext = this.yytext.substr(0, this.yytext.length - len - 1);
+                        //this.yyleng -= len;
+                        this.offset -= len;
+                        var oldLines = this.match.split(/(?:\r\n?|\n)/g);
+                        this.match = this.match.substr(0, this.match.length - 1);
+                        this.matched = this.matched.substr(0, this.matched.length - 1);
+
+                        if (lines.length - 1) this.yylineno -= lines.length - 1;
+                        var r = this.yylloc.range;
+
+                        this.yylloc = { first_line: this.yylloc.first_line,
+                            last_line: this.yylineno + 1,
+                            first_column: this.yylloc.first_column,
+                            last_column: lines ? (lines.length === oldLines.length ? this.yylloc.first_column : 0) + oldLines[oldLines.length - lines.length].length - lines[0].length : this.yylloc.first_column - len
+                        };
+
+                        if (this.options.ranges) {
+                            this.yylloc.range = [r[0], r[0] + this.yyleng - len];
+                        }
+                        return this;
+                    },
+                    more: function more() {
+                        this._more = true;
+                        return this;
+                    },
+                    less: function less(n) {
+                        this.unput(this.match.slice(n));
+                    },
+                    pastInput: function pastInput() {
+                        var past = this.matched.substr(0, this.matched.length - this.match.length);
+                        return (past.length > 20 ? '...' : '') + past.substr(-20).replace(/\n/g, "");
+                    },
+                    upcomingInput: function upcomingInput() {
+                        var next = this.match;
+                        if (next.length < 20) {
+                            next += this._input.substr(0, 20 - next.length);
+                        }
+                        return (next.substr(0, 20) + (next.length > 20 ? '...' : '')).replace(/\n/g, "");
+                    },
+                    showPosition: function showPosition() {
+                        var pre = this.pastInput();
+                        var c = new Array(pre.length + 1).join("-");
+                        return pre + this.upcomingInput() + "\n" + c + "^";
+                    },
+                    next: function next() {
+                        if (this.done) {
+                            return this.EOF;
+                        }
+                        if (!this._input) this.done = true;
+
+                        var token, match, tempMatch, index, col, lines;
+                        if (!this._more) {
+                            this.yytext = '';
+                            this.match = '';
+                        }
+                        var rules = this._currentRules();
+                        for (var i = 0; i < rules.length; i++) {
+                            tempMatch = this._input.match(this.rules[rules[i]]);
+                            if (tempMatch && (!match || tempMatch[0].length > match[0].length)) {
+                                match = tempMatch;
+                                index = i;
+                                if (!this.options.flex) break;
+                            }
+                        }
+                        if (match) {
+                            lines = match[0].match(/(?:\r\n?|\n).*/g);
+                            if (lines) this.yylineno += lines.length;
+                            this.yylloc = { first_line: this.yylloc.last_line,
+                                last_line: this.yylineno + 1,
+                                first_column: this.yylloc.last_column,
+                                last_column: lines ? lines[lines.length - 1].length - lines[lines.length - 1].match(/\r?\n?/)[0].length : this.yylloc.last_column + match[0].length };
+                            this.yytext += match[0];
+                            this.match += match[0];
+                            this.matches = match;
+                            this.yyleng = this.yytext.length;
+                            if (this.options.ranges) {
+                                this.yylloc.range = [this.offset, this.offset += this.yyleng];
+                            }
+                            this._more = false;
+                            this._input = this._input.slice(match[0].length);
+                            this.matched += match[0];
+                            token = this.performAction.call(this, this.yy, this, rules[index], this.conditionStack[this.conditionStack.length - 1]);
+                            if (this.done && this._input) this.done = false;
+                            if (token) return token;else return;
+                        }
+                        if (this._input === "") {
+                            return this.EOF;
+                        } else {
+                            return this.parseError('Lexical error on line ' + (this.yylineno + 1) + '. Unrecognized text.\n' + this.showPosition(), { text: "", token: null, line: this.yylineno });
+                        }
+                    },
+                    lex: function lex() {
+                        var r = this.next();
+                        if (typeof r !== 'undefined') {
+                            return r;
+                        } else {
+                            return this.lex();
+                        }
+                    },
+                    begin: function begin(condition) {
+                        this.conditionStack.push(condition);
+                    },
+                    popState: function popState() {
+                        return this.conditionStack.pop();
+                    },
+                    _currentRules: function _currentRules() {
+                        return this.conditions[this.conditionStack[this.conditionStack.length - 1]].rules;
+                    },
+                    topState: function topState() {
+                        return this.conditionStack[this.conditionStack.length - 2];
+                    },
+                    pushState: function begin(condition) {
+                        this.begin(condition);
+                    } };
+                lexer.options = {};
+                lexer.performAction = function anonymous(yy, yy_, $avoiding_name_collisions, YY_START) {
+
+                    function strip(start, end) {
+                        return yy_.yytext = yy_.yytext.substring(start, yy_.yyleng - end + start);
+                    }
+
+                    var YYSTATE = YY_START;
+                    switch ($avoiding_name_collisions) {
+                        case 0:
+                            if (yy_.yytext.slice(-2) === "\\\\") {
+                                strip(0, 1);
+                                this.begin("mu");
+                            } else if (yy_.yytext.slice(-1) === "\\") {
+                                strip(0, 1);
+                                this.begin("emu");
+                            } else {
+                                this.begin("mu");
+                            }
+                            if (yy_.yytext) return 15;
+
+                            break;
+                        case 1:
+                            return 15;
+                            break;
+                        case 2:
+                            this.popState();
+                            return 15;
+
+                            break;
+                        case 3:
+                            this.begin('raw');return 15;
+                            break;
+                        case 4:
+                            this.popState();
+                            // Should be using `this.topState()` below, but it currently
+                            // returns the second top instead of the first top. Opened an
+                            // issue about it at https://github.com/zaach/jison/issues/291
+                            if (this.conditionStack[this.conditionStack.length - 1] === 'raw') {
+                                return 15;
+                            } else {
+                                strip(5, 9);
+                                return 'END_RAW_BLOCK';
+                            }
+
+                            break;
+                        case 5:
+                            return 15;
+                            break;
+                        case 6:
+                            this.popState();
+                            return 14;
+
+                            break;
+                        case 7:
+                            return 65;
+                            break;
+                        case 8:
+                            return 68;
+                            break;
+                        case 9:
+                            return 19;
+                            break;
+                        case 10:
+                            this.popState();
+                            this.begin('raw');
+                            return 23;
+
+                            break;
+                        case 11:
+                            return 55;
+                            break;
+                        case 12:
+                            return 60;
+                            break;
+                        case 13:
+                            return 29;
+                            break;
+                        case 14:
+                            return 47;
+                            break;
+                        case 15:
+                            this.popState();return 44;
+                            break;
+                        case 16:
+                            this.popState();return 44;
+                            break;
+                        case 17:
+                            return 34;
+                            break;
+                        case 18:
+                            return 39;
+                            break;
+                        case 19:
+                            return 51;
+                            break;
+                        case 20:
+                            return 48;
+                            break;
+                        case 21:
+                            this.unput(yy_.yytext);
+                            this.popState();
+                            this.begin('com');
+
+                            break;
+                        case 22:
+                            this.popState();
+                            return 14;
+
+                            break;
+                        case 23:
+                            return 48;
+                            break;
+                        case 24:
+                            return 73;
+                            break;
+                        case 25:
+                            return 72;
+                            break;
+                        case 26:
+                            return 72;
+                            break;
+                        case 27:
+                            return 87;
+                            break;
+                        case 28:
+                            // ignore whitespace
+                            break;
+                        case 29:
+                            this.popState();return 54;
+                            break;
+                        case 30:
+                            this.popState();return 33;
+                            break;
+                        case 31:
+                            yy_.yytext = strip(1, 2).replace(/\\"/g, '"');return 80;
+                            break;
+                        case 32:
+                            yy_.yytext = strip(1, 2).replace(/\\'/g, "'");return 80;
+                            break;
+                        case 33:
+                            return 85;
+                            break;
+                        case 34:
+                            return 82;
+                            break;
+                        case 35:
+                            return 82;
+                            break;
+                        case 36:
+                            return 83;
+                            break;
+                        case 37:
+                            return 84;
+                            break;
+                        case 38:
+                            return 81;
+                            break;
+                        case 39:
+                            return 75;
+                            break;
+                        case 40:
+                            return 77;
+                            break;
+                        case 41:
+                            return 72;
+                            break;
+                        case 42:
+                            yy_.yytext = yy_.yytext.replace(/\\([\\\]])/g, '$1');return 72;
+                            break;
+                        case 43:
+                            return 'INVALID';
+                            break;
+                        case 44:
+                            return 5;
+                            break;
+                    }
+                };
+                lexer.rules = [/^(?:[^\x00]*?(?=(\{\{)))/, /^(?:[^\x00]+)/, /^(?:[^\x00]{2,}?(?=(\{\{|\\\{\{|\\\\\{\{|$)))/, /^(?:\{\{\{\{(?=[^\/]))/, /^(?:\{\{\{\{\/[^\s!"#%-,\.\/;->@\[-\^`\{-~]+(?=[=}\s\/.])\}\}\}\})/, /^(?:[^\x00]+?(?=(\{\{\{\{)))/, /^(?:[\s\S]*?--(~)?\}\})/, /^(?:\()/, /^(?:\))/, /^(?:\{\{\{\{)/, /^(?:\}\}\}\})/, /^(?:\{\{(~)?>)/, /^(?:\{\{(~)?#>)/, /^(?:\{\{(~)?#\*?)/, /^(?:\{\{(~)?\/)/, /^(?:\{\{(~)?\^\s*(~)?\}\})/, /^(?:\{\{(~)?\s*else\s*(~)?\}\})/, /^(?:\{\{(~)?\^)/, /^(?:\{\{(~)?\s*else\b)/, /^(?:\{\{(~)?\{)/, /^(?:\{\{(~)?&)/, /^(?:\{\{(~)?!--)/, /^(?:\{\{(~)?![\s\S]*?\}\})/, /^(?:\{\{(~)?\*?)/, /^(?:=)/, /^(?:\.\.)/, /^(?:\.(?=([=~}\s\/.)|])))/, /^(?:[\/.])/, /^(?:\s+)/, /^(?:\}(~)?\}\})/, /^(?:(~)?\}\})/, /^(?:"(\\["]|[^"])*")/, /^(?:'(\\[']|[^'])*')/, /^(?:@)/, /^(?:true(?=([~}\s)])))/, /^(?:false(?=([~}\s)])))/, /^(?:undefined(?=([~}\s)])))/, /^(?:null(?=([~}\s)])))/, /^(?:-?[0-9]+(?:\.[0-9]+)?(?=([~}\s)])))/, /^(?:as\s+\|)/, /^(?:\|)/, /^(?:([^\s!"#%-,\.\/;->@\[-\^`\{-~]+(?=([=~}\s\/.)|]))))/, /^(?:\[(\\\]|[^\]])*\])/, /^(?:.)/, /^(?:$)/];
+                lexer.conditions = { "mu": { "rules": [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44], "inclusive": false }, "emu": { "rules": [2], "inclusive": false }, "com": { "rules": [6], "inclusive": false }, "raw": { "rules": [3, 4, 5], "inclusive": false }, "INITIAL": { "rules": [0, 1, 44], "inclusive": true } };
+                return lexer;
+            })();
+            parser.lexer = lexer;
+            function Parser() {
+                this.yy = {};
+            }Parser.prototype = parser;parser.Parser = Parser;
+            return new Parser();
+        })();exports["default"] = handlebars;
+        module.exports = exports["default"];
+
+/***/ }),
+/* 48 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _interopRequireDefault = __webpack_require__(1)['default'];
+
+        exports.__esModule = true;
+
+        var _visitor = __webpack_require__(49);
+
+        var _visitor2 = _interopRequireDefault(_visitor);
+
+        function WhitespaceControl() {
+          var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+
+          this.options = options;
+        }
+        WhitespaceControl.prototype = new _visitor2['default']();
+
+        WhitespaceControl.prototype.Program = function (program) {
+          var doStandalone = !this.options.ignoreStandalone;
+
+          var isRoot = !this.isRootSeen;
+          this.isRootSeen = true;
+
+          var body = program.body;
+          for (var i = 0, l = body.length; i < l; i++) {
+            var current = body[i],
+                strip = this.accept(current);
+
+            if (!strip) {
+              continue;
+            }
+
+            var _isPrevWhitespace = isPrevWhitespace(body, i, isRoot),
+                _isNextWhitespace = isNextWhitespace(body, i, isRoot),
+                openStandalone = strip.openStandalone && _isPrevWhitespace,
+                closeStandalone = strip.closeStandalone && _isNextWhitespace,
+                inlineStandalone = strip.inlineStandalone && _isPrevWhitespace && _isNextWhitespace;
+
+            if (strip.close) {
+              omitRight(body, i, true);
+            }
+            if (strip.open) {
+              omitLeft(body, i, true);
+            }
+
+            if (doStandalone && inlineStandalone) {
+              omitRight(body, i);
+
+              if (omitLeft(body, i)) {
+                // If we are on a standalone node, save the indent info for partials
+                if (current.type === 'PartialStatement') {
+                  // Pull out the whitespace from the final line
+                  current.indent = /([ \t]+$)/.exec(body[i - 1].original)[1];
+                }
+              }
+            }
+            if (doStandalone && openStandalone) {
+              omitRight((current.program || current.inverse).body);
+
+              // Strip out the previous content node if it's whitespace only
+              omitLeft(body, i);
+            }
+            if (doStandalone && closeStandalone) {
+              // Always strip the next node
+              omitRight(body, i);
+
+              omitLeft((current.inverse || current.program).body);
+            }
+          }
+
+          return program;
+        };
+
+        WhitespaceControl.prototype.BlockStatement = WhitespaceControl.prototype.DecoratorBlock = WhitespaceControl.prototype.PartialBlockStatement = function (block) {
+          this.accept(block.program);
+          this.accept(block.inverse);
+
+          // Find the inverse program that is involed with whitespace stripping.
+          var program = block.program || block.inverse,
+              inverse = block.program && block.inverse,
+              firstInverse = inverse,
+              lastInverse = inverse;
+
+          if (inverse && inverse.chained) {
+            firstInverse = inverse.body[0].program;
+
+            // Walk the inverse chain to find the last inverse that is actually in the chain.
+            while (lastInverse.chained) {
+              lastInverse = lastInverse.body[lastInverse.body.length - 1].program;
+            }
+          }
+
+          var strip = {
+            open: block.openStrip.open,
+            close: block.closeStrip.close,
+
+            // Determine the standalone candiacy. Basically flag our content as being possibly standalone
+            // so our parent can determine if we actually are standalone
+            openStandalone: isNextWhitespace(program.body),
+            closeStandalone: isPrevWhitespace((firstInverse || program).body)
+          };
+
+          if (block.openStrip.close) {
+            omitRight(program.body, null, true);
+          }
+
+          if (inverse) {
+            var inverseStrip = block.inverseStrip;
+
+            if (inverseStrip.open) {
+              omitLeft(program.body, null, true);
+            }
+
+            if (inverseStrip.close) {
+              omitRight(firstInverse.body, null, true);
+            }
+            if (block.closeStrip.open) {
+              omitLeft(lastInverse.body, null, true);
+            }
+
+            // Find standalone else statments
+            if (!this.options.ignoreStandalone && isPrevWhitespace(program.body) && isNextWhitespace(firstInverse.body)) {
+              omitLeft(program.body);
+              omitRight(firstInverse.body);
+            }
+          } else if (block.closeStrip.open) {
+            omitLeft(program.body, null, true);
+          }
+
+          return strip;
+        };
+
+        WhitespaceControl.prototype.Decorator = WhitespaceControl.prototype.MustacheStatement = function (mustache) {
+          return mustache.strip;
+        };
+
+        WhitespaceControl.prototype.PartialStatement = WhitespaceControl.prototype.CommentStatement = function (node) {
+          /* istanbul ignore next */
+          var strip = node.strip || {};
+          return {
+            inlineStandalone: true,
+            open: strip.open,
+            close: strip.close
+          };
+        };
+
+        function isPrevWhitespace(body, i, isRoot) {
+          if (i === undefined) {
+            i = body.length;
+          }
+
+          // Nodes that end with newlines are considered whitespace (but are special
+          // cased for strip operations)
+          var prev = body[i - 1],
+              sibling = body[i - 2];
+          if (!prev) {
+            return isRoot;
+          }
+
+          if (prev.type === 'ContentStatement') {
+            return (sibling || !isRoot ? /\r?\n\s*?$/ : /(^|\r?\n)\s*?$/).test(prev.original);
+          }
+        }
+        function isNextWhitespace(body, i, isRoot) {
+          if (i === undefined) {
+            i = -1;
+          }
+
+          var next = body[i + 1],
+              sibling = body[i + 2];
+          if (!next) {
+            return isRoot;
+          }
+
+          if (next.type === 'ContentStatement') {
+            return (sibling || !isRoot ? /^\s*?\r?\n/ : /^\s*?(\r?\n|$)/).test(next.original);
+          }
+        }
+
+        // Marks the node to the right of the position as omitted.
+        // I.e. {{foo}}' ' will mark the ' ' node as omitted.
+        //
+        // If i is undefined, then the first child will be marked as such.
+        //
+        // If mulitple is truthy then all whitespace will be stripped out until non-whitespace
+        // content is met.
+        function omitRight(body, i, multiple) {
+          var current = body[i == null ? 0 : i + 1];
+          if (!current || current.type !== 'ContentStatement' || !multiple && current.rightStripped) {
+            return;
+          }
+
+          var original = current.value;
+          current.value = current.value.replace(multiple ? /^\s+/ : /^[ \t]*\r?\n?/, '');
+          current.rightStripped = current.value !== original;
+        }
+
+        // Marks the node to the left of the position as omitted.
+        // I.e. ' '{{foo}} will mark the ' ' node as omitted.
+        //
+        // If i is undefined then the last child will be marked as such.
+        //
+        // If mulitple is truthy then all whitespace will be stripped out until non-whitespace
+        // content is met.
+        function omitLeft(body, i, multiple) {
+          var current = body[i == null ? body.length - 1 : i - 1];
+          if (!current || current.type !== 'ContentStatement' || !multiple && current.leftStripped) {
+            return;
+          }
+
+          // We omit the last node if it's whitespace only and not preceded by a non-content node.
+          var original = current.value;
+          current.value = current.value.replace(multiple ? /\s+$/ : /[ \t]+$/, '');
+          current.leftStripped = current.value !== original;
+          return current.leftStripped;
+        }
+
+        exports['default'] = WhitespaceControl;
+        module.exports = exports['default'];
+
+/***/ }),
+/* 49 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _interopRequireDefault = __webpack_require__(1)['default'];
+
+        exports.__esModule = true;
+
+        var _exception = __webpack_require__(6);
+
+        var _exception2 = _interopRequireDefault(_exception);
+
+        function Visitor() {
+          this.parents = [];
+        }
+
+        Visitor.prototype = {
+          constructor: Visitor,
+          mutating: false,
+
+          // Visits a given value. If mutating, will replace the value if necessary.
+          acceptKey: function acceptKey(node, name) {
+            var value = this.accept(node[name]);
+            if (this.mutating) {
+              // Hacky sanity check: This may have a few false positives for type for the helper
+              // methods but will generally do the right thing without a lot of overhead.
+              if (value && !Visitor.prototype[value.type]) {
+                throw new _exception2['default']('Unexpected node type "' + value.type + '" found when accepting ' + name + ' on ' + node.type);
+              }
+              node[name] = value;
+            }
+          },
+
+          // Performs an accept operation with added sanity check to ensure
+          // required keys are not removed.
+          acceptRequired: function acceptRequired(node, name) {
+            this.acceptKey(node, name);
+
+            if (!node[name]) {
+              throw new _exception2['default'](node.type + ' requires ' + name);
+            }
+          },
+
+          // Traverses a given array. If mutating, empty respnses will be removed
+          // for child elements.
+          acceptArray: function acceptArray(array) {
+            for (var i = 0, l = array.length; i < l; i++) {
+              this.acceptKey(array, i);
+
+              if (!array[i]) {
+                array.splice(i, 1);
+                i--;
+                l--;
+              }
+            }
+          },
+
+          accept: function accept(object) {
+            if (!object) {
+              return;
+            }
+
+            /* istanbul ignore next: Sanity code */
+            if (!this[object.type]) {
+              throw new _exception2['default']('Unknown type: ' + object.type, object);
+            }
+
+            if (this.current) {
+              this.parents.unshift(this.current);
+            }
+            this.current = object;
+
+            var ret = this[object.type](object);
+
+            this.current = this.parents.shift();
+
+            if (!this.mutating || ret) {
+              return ret;
+            } else if (ret !== false) {
+              return object;
+            }
+          },
+
+          Program: function Program(program) {
+            this.acceptArray(program.body);
+          },
+
+          MustacheStatement: visitSubExpression,
+          Decorator: visitSubExpression,
+
+          BlockStatement: visitBlock,
+          DecoratorBlock: visitBlock,
+
+          PartialStatement: visitPartial,
+          PartialBlockStatement: function PartialBlockStatement(partial) {
+            visitPartial.call(this, partial);
+
+            this.acceptKey(partial, 'program');
+          },
+
+          ContentStatement: function ContentStatement() /* content */{},
+          CommentStatement: function CommentStatement() /* comment */{},
+
+          SubExpression: visitSubExpression,
+
+          PathExpression: function PathExpression() /* path */{},
+
+          StringLiteral: function StringLiteral() /* string */{},
+          NumberLiteral: function NumberLiteral() /* number */{},
+          BooleanLiteral: function BooleanLiteral() /* bool */{},
+          UndefinedLiteral: function UndefinedLiteral() /* literal */{},
+          NullLiteral: function NullLiteral() /* literal */{},
+
+          Hash: function Hash(hash) {
+            this.acceptArray(hash.pairs);
+          },
+          HashPair: function HashPair(pair) {
+            this.acceptRequired(pair, 'value');
+          }
+        };
+
+        function visitSubExpression(mustache) {
+          this.acceptRequired(mustache, 'path');
+          this.acceptArray(mustache.params);
+          this.acceptKey(mustache, 'hash');
+        }
+        function visitBlock(block) {
+          visitSubExpression.call(this, block);
+
+          this.acceptKey(block, 'program');
+          this.acceptKey(block, 'inverse');
+        }
+        function visitPartial(partial) {
+          this.acceptRequired(partial, 'name');
+          this.acceptArray(partial.params);
+          this.acceptKey(partial, 'hash');
+        }
+
+        exports['default'] = Visitor;
+        module.exports = exports['default'];
+
+/***/ }),
+/* 50 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _interopRequireDefault = __webpack_require__(1)['default'];
+
+        exports.__esModule = true;
+        exports.SourceLocation = SourceLocation;
+        exports.id = id;
+        exports.stripFlags = stripFlags;
+        exports.stripComment = stripComment;
+        exports.preparePath = preparePath;
+        exports.prepareMustache = prepareMustache;
+        exports.prepareRawBlock = prepareRawBlock;
+        exports.prepareBlock = prepareBlock;
+        exports.prepareProgram = prepareProgram;
+        exports.preparePartialBlock = preparePartialBlock;
+
+        var _exception = __webpack_require__(6);
+
+        var _exception2 = _interopRequireDefault(_exception);
+
+        function validateClose(open, close) {
+          close = close.path ? close.path.original : close;
+
+          if (open.path.original !== close) {
+            var errorNode = { loc: open.path.loc };
+
+            throw new _exception2['default'](open.path.original + " doesn't match " + close, errorNode);
+          }
+        }
+
+        function SourceLocation(source, locInfo) {
+          this.source = source;
+          this.start = {
+            line: locInfo.first_line,
+            column: locInfo.first_column
+          };
+          this.end = {
+            line: locInfo.last_line,
+            column: locInfo.last_column
+          };
+        }
+
+        function id(token) {
+          if (/^\[.*\]$/.test(token)) {
+            return token.substring(1, token.length - 1);
+          } else {
+            return token;
+          }
+        }
+
+        function stripFlags(open, close) {
+          return {
+            open: open.charAt(2) === '~',
+            close: close.charAt(close.length - 3) === '~'
+          };
+        }
+
+        function stripComment(comment) {
+          return comment.replace(/^\{\{~?!-?-?/, '').replace(/-?-?~?\}\}$/, '');
+        }
+
+        function preparePath(data, parts, loc) {
+          loc = this.locInfo(loc);
+
+          var original = data ? '@' : '',
+              dig = [],
+              depth = 0;
+
+          for (var i = 0, l = parts.length; i < l; i++) {
+            var part = parts[i].part,
+
+            // If we have [] syntax then we do not treat path references as operators,
+            // i.e. foo.[this] resolves to approximately context.foo['this']
+            isLiteral = parts[i].original !== part;
+            original += (parts[i].separator || '') + part;
+
+            if (!isLiteral && (part === '..' || part === '.' || part === 'this')) {
+              if (dig.length > 0) {
+                throw new _exception2['default']('Invalid path: ' + original, { loc: loc });
+              } else if (part === '..') {
+                depth++;
+              }
+            } else {
+              dig.push(part);
+            }
+          }
+
+          return {
+            type: 'PathExpression',
+            data: data,
+            depth: depth,
+            parts: dig,
+            original: original,
+            loc: loc
+          };
+        }
+
+        function prepareMustache(path, params, hash, open, strip, locInfo) {
+          // Must use charAt to support IE pre-10
+          var escapeFlag = open.charAt(3) || open.charAt(2),
+              escaped = escapeFlag !== '{' && escapeFlag !== '&';
+
+          var decorator = /\*/.test(open);
+          return {
+            type: decorator ? 'Decorator' : 'MustacheStatement',
+            path: path,
+            params: params,
+            hash: hash,
+            escaped: escaped,
+            strip: strip,
+            loc: this.locInfo(locInfo)
+          };
+        }
+
+        function prepareRawBlock(openRawBlock, contents, close, locInfo) {
+          validateClose(openRawBlock, close);
+
+          locInfo = this.locInfo(locInfo);
+          var program = {
+            type: 'Program',
+            body: contents,
+            strip: {},
+            loc: locInfo
+          };
+
+          return {
+            type: 'BlockStatement',
+            path: openRawBlock.path,
+            params: openRawBlock.params,
+            hash: openRawBlock.hash,
+            program: program,
+            openStrip: {},
+            inverseStrip: {},
+            closeStrip: {},
+            loc: locInfo
+          };
+        }
+
+        function prepareBlock(openBlock, program, inverseAndProgram, close, inverted, locInfo) {
+          if (close && close.path) {
+            validateClose(openBlock, close);
+          }
+
+          var decorator = /\*/.test(openBlock.open);
+
+          program.blockParams = openBlock.blockParams;
+
+          var inverse = undefined,
+              inverseStrip = undefined;
+
+          if (inverseAndProgram) {
+            if (decorator) {
+              throw new _exception2['default']('Unexpected inverse block on decorator', inverseAndProgram);
+            }
+
+            if (inverseAndProgram.chain) {
+              inverseAndProgram.program.body[0].closeStrip = close.strip;
+            }
+
+            inverseStrip = inverseAndProgram.strip;
+            inverse = inverseAndProgram.program;
+          }
+
+          if (inverted) {
+            inverted = inverse;
+            inverse = program;
+            program = inverted;
+          }
+
+          return {
+            type: decorator ? 'DecoratorBlock' : 'BlockStatement',
+            path: openBlock.path,
+            params: openBlock.params,
+            hash: openBlock.hash,
+            program: program,
+            inverse: inverse,
+            openStrip: openBlock.strip,
+            inverseStrip: inverseStrip,
+            closeStrip: close && close.strip,
+            loc: this.locInfo(locInfo)
+          };
+        }
+
+        function prepareProgram(statements, loc) {
+          if (!loc && statements.length) {
+            var firstLoc = statements[0].loc,
+                lastLoc = statements[statements.length - 1].loc;
+
+            /* istanbul ignore else */
+            if (firstLoc && lastLoc) {
+              loc = {
+                source: firstLoc.source,
+                start: {
+                  line: firstLoc.start.line,
+                  column: firstLoc.start.column
+                },
+                end: {
+                  line: lastLoc.end.line,
+                  column: lastLoc.end.column
+                }
+              };
+            }
+          }
+
+          return {
+            type: 'Program',
+            body: statements,
+            strip: {},
+            loc: loc
+          };
+        }
+
+        function preparePartialBlock(open, program, close, locInfo) {
+          validateClose(open, close);
+
+          return {
+            type: 'PartialBlockStatement',
+            name: open.path,
+            params: open.params,
+            hash: open.hash,
+            program: program,
+            openStrip: open.strip,
+            closeStrip: close && close.strip,
+            loc: this.locInfo(locInfo)
+          };
+        }
+
+/***/ }),
+/* 51 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        /* eslint-disable new-cap */
+
+        'use strict';
+
+        var _Object$create = __webpack_require__(34)['default'];
+
+        var _interopRequireDefault = __webpack_require__(1)['default'];
+
+        exports.__esModule = true;
+        exports.Compiler = Compiler;
+        exports.precompile = precompile;
+        exports.compile = compile;
+
+        var _exception = __webpack_require__(6);
+
+        var _exception2 = _interopRequireDefault(_exception);
+
+        var _utils = __webpack_require__(5);
+
+        var _ast = __webpack_require__(45);
+
+        var _ast2 = _interopRequireDefault(_ast);
+
+        var slice = [].slice;
+
+        function Compiler() {}
+
+        // the foundHelper register will disambiguate helper lookup from finding a
+        // function in a context. This is necessary for mustache compatibility, which
+        // requires that context functions in blocks are evaluated by blockHelperMissing,
+        // and then proceed as if the resulting value was provided to blockHelperMissing.
+
+        Compiler.prototype = {
+          compiler: Compiler,
+
+          equals: function equals(other) {
+            var len = this.opcodes.length;
+            if (other.opcodes.length !== len) {
+              return false;
+            }
+
+            for (var i = 0; i < len; i++) {
+              var opcode = this.opcodes[i],
+                  otherOpcode = other.opcodes[i];
+              if (opcode.opcode !== otherOpcode.opcode || !argEquals(opcode.args, otherOpcode.args)) {
+                return false;
+              }
+            }
+
+            // We know that length is the same between the two arrays because they are directly tied
+            // to the opcode behavior above.
+            len = this.children.length;
+            for (var i = 0; i < len; i++) {
+              if (!this.children[i].equals(other.children[i])) {
+                return false;
+              }
+            }
+
+            return true;
+          },
+
+          guid: 0,
+
+          compile: function compile(program, options) {
+            this.sourceNode = [];
+            this.opcodes = [];
+            this.children = [];
+            this.options = options;
+            this.stringParams = options.stringParams;
+            this.trackIds = options.trackIds;
+
+            options.blockParams = options.blockParams || [];
+
+            options.knownHelpers = _utils.extend(_Object$create(null), {
+              helperMissing: true,
+              blockHelperMissing: true,
+              each: true,
+              'if': true,
+              unless: true,
+              'with': true,
+              log: true,
+              lookup: true
+            }, options.knownHelpers);
+
+            return this.accept(program);
+          },
+
+          compileProgram: function compileProgram(program) {
+            var childCompiler = new this.compiler(),
+                // eslint-disable-line new-cap
+            result = childCompiler.compile(program, this.options),
+                guid = this.guid++;
+
+            this.usePartial = this.usePartial || result.usePartial;
+
+            this.children[guid] = result;
+            this.useDepths = this.useDepths || result.useDepths;
+
+            return guid;
+          },
+
+          accept: function accept(node) {
+            /* istanbul ignore next: Sanity code */
+            if (!this[node.type]) {
+              throw new _exception2['default']('Unknown type: ' + node.type, node);
+            }
+
+            this.sourceNode.unshift(node);
+            var ret = this[node.type](node);
+            this.sourceNode.shift();
+            return ret;
+          },
+
+          Program: function Program(program) {
+            this.options.blockParams.unshift(program.blockParams);
+
+            var body = program.body,
+                bodyLength = body.length;
+            for (var i = 0; i < bodyLength; i++) {
+              this.accept(body[i]);
+            }
+
+            this.options.blockParams.shift();
+
+            this.isSimple = bodyLength === 1;
+            this.blockParams = program.blockParams ? program.blockParams.length : 0;
+
+            return this;
+          },
+
+          BlockStatement: function BlockStatement(block) {
+            transformLiteralToPath(block);
+
+            var program = block.program,
+                inverse = block.inverse;
+
+            program = program && this.compileProgram(program);
+            inverse = inverse && this.compileProgram(inverse);
+
+            var type = this.classifySexpr(block);
+
+            if (type === 'helper') {
+              this.helperSexpr(block, program, inverse);
+            } else if (type === 'simple') {
+              this.simpleSexpr(block);
+
+              // now that the simple mustache is resolved, we need to
+              // evaluate it by executing `blockHelperMissing`
+              this.opcode('pushProgram', program);
+              this.opcode('pushProgram', inverse);
+              this.opcode('emptyHash');
+              this.opcode('blockValue', block.path.original);
+            } else {
+              this.ambiguousSexpr(block, program, inverse);
+
+              // now that the simple mustache is resolved, we need to
+              // evaluate it by executing `blockHelperMissing`
+              this.opcode('pushProgram', program);
+              this.opcode('pushProgram', inverse);
+              this.opcode('emptyHash');
+              this.opcode('ambiguousBlockValue');
+            }
+
+            this.opcode('append');
+          },
+
+          DecoratorBlock: function DecoratorBlock(decorator) {
+            var program = decorator.program && this.compileProgram(decorator.program);
+            var params = this.setupFullMustacheParams(decorator, program, undefined),
+                path = decorator.path;
+
+            this.useDecorators = true;
+            this.opcode('registerDecorator', params.length, path.original);
+          },
+
+          PartialStatement: function PartialStatement(partial) {
+            this.usePartial = true;
+
+            var program = partial.program;
+            if (program) {
+              program = this.compileProgram(partial.program);
+            }
+
+            var params = partial.params;
+            if (params.length > 1) {
+              throw new _exception2['default']('Unsupported number of partial arguments: ' + params.length, partial);
+            } else if (!params.length) {
+              if (this.options.explicitPartialContext) {
+                this.opcode('pushLiteral', 'undefined');
+              } else {
+                params.push({ type: 'PathExpression', parts: [], depth: 0 });
+              }
+            }
+
+            var partialName = partial.name.original,
+                isDynamic = partial.name.type === 'SubExpression';
+            if (isDynamic) {
+              this.accept(partial.name);
+            }
+
+            this.setupFullMustacheParams(partial, program, undefined, true);
+
+            var indent = partial.indent || '';
+            if (this.options.preventIndent && indent) {
+              this.opcode('appendContent', indent);
+              indent = '';
+            }
+
+            this.opcode('invokePartial', isDynamic, partialName, indent);
+            this.opcode('append');
+          },
+          PartialBlockStatement: function PartialBlockStatement(partialBlock) {
+            this.PartialStatement(partialBlock);
+          },
+
+          MustacheStatement: function MustacheStatement(mustache) {
+            this.SubExpression(mustache);
+
+            if (mustache.escaped && !this.options.noEscape) {
+              this.opcode('appendEscaped');
+            } else {
+              this.opcode('append');
+            }
+          },
+          Decorator: function Decorator(decorator) {
+            this.DecoratorBlock(decorator);
+          },
+
+          ContentStatement: function ContentStatement(content) {
+            if (content.value) {
+              this.opcode('appendContent', content.value);
+            }
+          },
+
+          CommentStatement: function CommentStatement() {},
+
+          SubExpression: function SubExpression(sexpr) {
+            transformLiteralToPath(sexpr);
+            var type = this.classifySexpr(sexpr);
+
+            if (type === 'simple') {
+              this.simpleSexpr(sexpr);
+            } else if (type === 'helper') {
+              this.helperSexpr(sexpr);
+            } else {
+              this.ambiguousSexpr(sexpr);
+            }
+          },
+          ambiguousSexpr: function ambiguousSexpr(sexpr, program, inverse) {
+            var path = sexpr.path,
+                name = path.parts[0],
+                isBlock = program != null || inverse != null;
+
+            this.opcode('getContext', path.depth);
+
+            this.opcode('pushProgram', program);
+            this.opcode('pushProgram', inverse);
+
+            path.strict = true;
+            this.accept(path);
+
+            this.opcode('invokeAmbiguous', name, isBlock);
+          },
+
+          simpleSexpr: function simpleSexpr(sexpr) {
+            var path = sexpr.path;
+            path.strict = true;
+            this.accept(path);
+            this.opcode('resolvePossibleLambda');
+          },
+
+          helperSexpr: function helperSexpr(sexpr, program, inverse) {
+            var params = this.setupFullMustacheParams(sexpr, program, inverse),
+                path = sexpr.path,
+                name = path.parts[0];
+
+            if (this.options.knownHelpers[name]) {
+              this.opcode('invokeKnownHelper', params.length, name);
+            } else if (this.options.knownHelpersOnly) {
+              throw new _exception2['default']('You specified knownHelpersOnly, but used the unknown helper ' + name, sexpr);
+            } else {
+              path.strict = true;
+              path.falsy = true;
+
+              this.accept(path);
+              this.opcode('invokeHelper', params.length, path.original, _ast2['default'].helpers.simpleId(path));
+            }
+          },
+
+          PathExpression: function PathExpression(path) {
+            this.addDepth(path.depth);
+            this.opcode('getContext', path.depth);
+
+            var name = path.parts[0],
+                scoped = _ast2['default'].helpers.scopedId(path),
+                blockParamId = !path.depth && !scoped && this.blockParamIndex(name);
+
+            if (blockParamId) {
+              this.opcode('lookupBlockParam', blockParamId, path.parts);
+            } else if (!name) {
+              // Context reference, i.e. `{{foo .}}` or `{{foo ..}}`
+              this.opcode('pushContext');
+            } else if (path.data) {
+              this.options.data = true;
+              this.opcode('lookupData', path.depth, path.parts, path.strict);
+            } else {
+              this.opcode('lookupOnContext', path.parts, path.falsy, path.strict, scoped);
+            }
+          },
+
+          StringLiteral: function StringLiteral(string) {
+            this.opcode('pushString', string.value);
+          },
+
+          NumberLiteral: function NumberLiteral(number) {
+            this.opcode('pushLiteral', number.value);
+          },
+
+          BooleanLiteral: function BooleanLiteral(bool) {
+            this.opcode('pushLiteral', bool.value);
+          },
+
+          UndefinedLiteral: function UndefinedLiteral() {
+            this.opcode('pushLiteral', 'undefined');
+          },
+
+          NullLiteral: function NullLiteral() {
+            this.opcode('pushLiteral', 'null');
+          },
+
+          Hash: function Hash(hash) {
+            var pairs = hash.pairs,
+                i = 0,
+                l = pairs.length;
+
+            this.opcode('pushHash');
+
+            for (; i < l; i++) {
+              this.pushParam(pairs[i].value);
+            }
+            while (i--) {
+              this.opcode('assignToHash', pairs[i].key);
+            }
+            this.opcode('popHash');
+          },
+
+          // HELPERS
+          opcode: function opcode(name) {
+            this.opcodes.push({
+              opcode: name,
+              args: slice.call(arguments, 1),
+              loc: this.sourceNode[0].loc
+            });
+          },
+
+          addDepth: function addDepth(depth) {
+            if (!depth) {
+              return;
+            }
+
+            this.useDepths = true;
+          },
+
+          classifySexpr: function classifySexpr(sexpr) {
+            var isSimple = _ast2['default'].helpers.simpleId(sexpr.path);
+
+            var isBlockParam = isSimple && !!this.blockParamIndex(sexpr.path.parts[0]);
+
+            // a mustache is an eligible helper if:
+            // * its id is simple (a single part, not `this` or `..`)
+            var isHelper = !isBlockParam && _ast2['default'].helpers.helperExpression(sexpr);
+
+            // if a mustache is an eligible helper but not a definite
+            // helper, it is ambiguous, and will be resolved in a later
+            // pass or at runtime.
+            var isEligible = !isBlockParam && (isHelper || isSimple);
+
+            // if ambiguous, we can possibly resolve the ambiguity now
+            // An eligible helper is one that does not have a complex path, i.e. `this.foo`, `../foo` etc.
+            if (isEligible && !isHelper) {
+              var _name = sexpr.path.parts[0],
+                  options = this.options;
+              if (options.knownHelpers[_name]) {
+                isHelper = true;
+              } else if (options.knownHelpersOnly) {
+                isEligible = false;
+              }
+            }
+
+            if (isHelper) {
+              return 'helper';
+            } else if (isEligible) {
+              return 'ambiguous';
+            } else {
+              return 'simple';
+            }
+          },
+
+          pushParams: function pushParams(params) {
+            for (var i = 0, l = params.length; i < l; i++) {
+              this.pushParam(params[i]);
+            }
+          },
+
+          pushParam: function pushParam(val) {
+            var value = val.value != null ? val.value : val.original || '';
+
+            if (this.stringParams) {
+              if (value.replace) {
+                value = value.replace(/^(\.?\.\/)*/g, '').replace(/\//g, '.');
+              }
+
+              if (val.depth) {
+                this.addDepth(val.depth);
+              }
+              this.opcode('getContext', val.depth || 0);
+              this.opcode('pushStringParam', value, val.type);
+
+              if (val.type === 'SubExpression') {
+                // SubExpressions get evaluated and passed in
+                // in string params mode.
+                this.accept(val);
+              }
+            } else {
+              if (this.trackIds) {
+                var blockParamIndex = undefined;
+                if (val.parts && !_ast2['default'].helpers.scopedId(val) && !val.depth) {
+                  blockParamIndex = this.blockParamIndex(val.parts[0]);
+                }
+                if (blockParamIndex) {
+                  var blockParamChild = val.parts.slice(1).join('.');
+                  this.opcode('pushId', 'BlockParam', blockParamIndex, blockParamChild);
+                } else {
+                  value = val.original || value;
+                  if (value.replace) {
+                    value = value.replace(/^this(?:\.|$)/, '').replace(/^\.\//, '').replace(/^\.$/, '');
+                  }
+
+                  this.opcode('pushId', val.type, value);
+                }
+              }
+              this.accept(val);
+            }
+          },
+
+          setupFullMustacheParams: function setupFullMustacheParams(sexpr, program, inverse, omitEmpty) {
+            var params = sexpr.params;
+            this.pushParams(params);
+
+            this.opcode('pushProgram', program);
+            this.opcode('pushProgram', inverse);
+
+            if (sexpr.hash) {
+              this.accept(sexpr.hash);
+            } else {
+              this.opcode('emptyHash', omitEmpty);
+            }
+
+            return params;
+          },
+
+          blockParamIndex: function blockParamIndex(name) {
+            for (var depth = 0, len = this.options.blockParams.length; depth < len; depth++) {
+              var blockParams = this.options.blockParams[depth],
+                  param = blockParams && _utils.indexOf(blockParams, name);
+              if (blockParams && param >= 0) {
+                return [depth, param];
+              }
+            }
+          }
+        };
+
+        function precompile(input, options, env) {
+          if (input == null || typeof input !== 'string' && input.type !== 'Program') {
+            throw new _exception2['default']('You must pass a string or Handlebars AST to Handlebars.precompile. You passed ' + input);
+          }
+
+          options = options || {};
+          if (!('data' in options)) {
+            options.data = true;
+          }
+          if (options.compat) {
+            options.useDepths = true;
+          }
+
+          var ast = env.parse(input, options),
+              environment = new env.Compiler().compile(ast, options);
+          return new env.JavaScriptCompiler().compile(environment, options);
+        }
+
+        function compile(input, options, env) {
+          if (options === undefined) options = {};
+
+          if (input == null || typeof input !== 'string' && input.type !== 'Program') {
+            throw new _exception2['default']('You must pass a string or Handlebars AST to Handlebars.compile. You passed ' + input);
+          }
+
+          options = _utils.extend({}, options);
+          if (!('data' in options)) {
+            options.data = true;
+          }
+          if (options.compat) {
+            options.useDepths = true;
+          }
+
+          var compiled = undefined;
+
+          function compileInput() {
+            var ast = env.parse(input, options),
+                environment = new env.Compiler().compile(ast, options),
+                templateSpec = new env.JavaScriptCompiler().compile(environment, options, undefined, true);
+            return env.template(templateSpec);
+          }
+
+          // Template is only compiled on first use and cached after that point.
+          function ret(context, execOptions) {
+            if (!compiled) {
+              compiled = compileInput();
+            }
+            return compiled.call(this, context, execOptions);
+          }
+          ret._setup = function (setupOptions) {
+            if (!compiled) {
+              compiled = compileInput();
+            }
+            return compiled._setup(setupOptions);
+          };
+          ret._child = function (i, data, blockParams, depths) {
+            if (!compiled) {
+              compiled = compileInput();
+            }
+            return compiled._child(i, data, blockParams, depths);
+          };
+          return ret;
+        }
+
+        function argEquals(a, b) {
+          if (a === b) {
+            return true;
+          }
+
+          if (_utils.isArray(a) && _utils.isArray(b) && a.length === b.length) {
+            for (var i = 0; i < a.length; i++) {
+              if (!argEquals(a[i], b[i])) {
+                return false;
+              }
+            }
+            return true;
+          }
+        }
+
+        function transformLiteralToPath(sexpr) {
+          if (!sexpr.path.parts) {
+            var literal = sexpr.path;
+            // Casting to string here to make false and 0 literal values play nicely with the rest
+            // of the system.
+            sexpr.path = {
+              type: 'PathExpression',
+              data: false,
+              depth: 0,
+              parts: [literal.original + ''],
+              original: literal.original + '',
+              loc: literal.loc
+            };
+          }
+        }
+
+/***/ }),
+/* 52 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        'use strict';
+
+        var _Object$keys = __webpack_require__(13)['default'];
+
+        var _interopRequireDefault = __webpack_require__(1)['default'];
+
+        exports.__esModule = true;
+
+        var _base = __webpack_require__(4);
+
+        var _exception = __webpack_require__(6);
+
+        var _exception2 = _interopRequireDefault(_exception);
+
+        var _utils = __webpack_require__(5);
+
+        var _codeGen = __webpack_require__(53);
+
+        var _codeGen2 = _interopRequireDefault(_codeGen);
+
+        function Literal(value) {
+          this.value = value;
+        }
+
+        function JavaScriptCompiler() {}
+
+        JavaScriptCompiler.prototype = {
+          // PUBLIC API: You can override these methods in a subclass to provide
+          // alternative compiled forms for name lookup and buffering semantics
+          nameLookup: function nameLookup(parent, name /*,  type */) {
+            return this.internalNameLookup(parent, name);
+          },
+          depthedLookup: function depthedLookup(name) {
+            return [this.aliasable('container.lookup'), '(depths, "', name, '")'];
+          },
+
+          compilerInfo: function compilerInfo() {
+            var revision = _base.COMPILER_REVISION,
+                versions = _base.REVISION_CHANGES[revision];
+            return [revision, versions];
+          },
+
+          appendToBuffer: function appendToBuffer(source, location, explicit) {
+            // Force a source as this simplifies the merge logic.
+            if (!_utils.isArray(source)) {
+              source = [source];
+            }
+            source = this.source.wrap(source, location);
+
+            if (this.environment.isSimple) {
+              return ['return ', source, ';'];
+            } else if (explicit) {
+              // This is a case where the buffer operation occurs as a child of another
+              // construct, generally braces. We have to explicitly output these buffer
+              // operations to ensure that the emitted code goes in the correct location.
+              return ['buffer += ', source, ';'];
+            } else {
+              source.appendToBuffer = true;
+              return source;
+            }
+          },
+
+          initializeBuffer: function initializeBuffer() {
+            return this.quotedString('');
+          },
+          // END PUBLIC API
+          internalNameLookup: function internalNameLookup(parent, name) {
+            this.lookupPropertyFunctionIsUsed = true;
+            return ['lookupProperty(', parent, ',', JSON.stringify(name), ')'];
+          },
+
+          lookupPropertyFunctionIsUsed: false,
+
+          compile: function compile(environment, options, context, asObject) {
+            this.environment = environment;
+            this.options = options;
+            this.stringParams = this.options.stringParams;
+            this.trackIds = this.options.trackIds;
+            this.precompile = !asObject;
+
+            this.name = this.environment.name;
+            this.isChild = !!context;
+            this.context = context || {
+              decorators: [],
+              programs: [],
+              environments: []
+            };
+
+            this.preamble();
+
+            this.stackSlot = 0;
+            this.stackVars = [];
+            this.aliases = {};
+            this.registers = { list: [] };
+            this.hashes = [];
+            this.compileStack = [];
+            this.inlineStack = [];
+            this.blockParams = [];
+
+            this.compileChildren(environment, options);
+
+            this.useDepths = this.useDepths || environment.useDepths || environment.useDecorators || this.options.compat;
+            this.useBlockParams = this.useBlockParams || environment.useBlockParams;
+
+            var opcodes = environment.opcodes,
+                opcode = undefined,
+                firstLoc = undefined,
+                i = undefined,
+                l = undefined;
+
+            for (i = 0, l = opcodes.length; i < l; i++) {
+              opcode = opcodes[i];
+
+              this.source.currentLocation = opcode.loc;
+              firstLoc = firstLoc || opcode.loc;
+              this[opcode.opcode].apply(this, opcode.args);
+            }
+
+            // Flush any trailing content that might be pending.
+            this.source.currentLocation = firstLoc;
+            this.pushSource('');
+
+            /* istanbul ignore next */
+            if (this.stackSlot || this.inlineStack.length || this.compileStack.length) {
+              throw new _exception2['default']('Compile completed with content left on stack');
+            }
+
+            if (!this.decorators.isEmpty()) {
+              this.useDecorators = true;
+
+              this.decorators.prepend(['var decorators = container.decorators, ', this.lookupPropertyFunctionVarDeclaration(), ';\n']);
+              this.decorators.push('return fn;');
+
+              if (asObject) {
+                this.decorators = Function.apply(this, ['fn', 'props', 'container', 'depth0', 'data', 'blockParams', 'depths', this.decorators.merge()]);
+              } else {
+                this.decorators.prepend('function(fn, props, container, depth0, data, blockParams, depths) {\n');
+                this.decorators.push('}\n');
+                this.decorators = this.decorators.merge();
+              }
+            } else {
+              this.decorators = undefined;
+            }
+
+            var fn = this.createFunctionContext(asObject);
+            if (!this.isChild) {
+              var ret = {
+                compiler: this.compilerInfo(),
+                main: fn
+              };
+
+              if (this.decorators) {
+                ret.main_d = this.decorators; // eslint-disable-line camelcase
+                ret.useDecorators = true;
+              }
+
+              var _context = this.context;
+              var programs = _context.programs;
+              var decorators = _context.decorators;
+
+              for (i = 0, l = programs.length; i < l; i++) {
+                if (programs[i]) {
+                  ret[i] = programs[i];
+                  if (decorators[i]) {
+                    ret[i + '_d'] = decorators[i];
+                    ret.useDecorators = true;
+                  }
+                }
+              }
+
+              if (this.environment.usePartial) {
+                ret.usePartial = true;
+              }
+              if (this.options.data) {
+                ret.useData = true;
+              }
+              if (this.useDepths) {
+                ret.useDepths = true;
+              }
+              if (this.useBlockParams) {
+                ret.useBlockParams = true;
+              }
+              if (this.options.compat) {
+                ret.compat = true;
+              }
+
+              if (!asObject) {
+                ret.compiler = JSON.stringify(ret.compiler);
+
+                this.source.currentLocation = { start: { line: 1, column: 0 } };
+                ret = this.objectLiteral(ret);
+
+                if (options.srcName) {
+                  ret = ret.toStringWithSourceMap({ file: options.destName });
+                  ret.map = ret.map && ret.map.toString();
+                } else {
+                  ret = ret.toString();
+                }
+              } else {
+                ret.compilerOptions = this.options;
+              }
+
+              return ret;
+            } else {
+              return fn;
+            }
+          },
+
+          preamble: function preamble() {
+            // track the last context pushed into place to allow skipping the
+            // getContext opcode when it would be a noop
+            this.lastContext = 0;
+            this.source = new _codeGen2['default'](this.options.srcName);
+            this.decorators = new _codeGen2['default'](this.options.srcName);
+          },
+
+          createFunctionContext: function createFunctionContext(asObject) {
+            // istanbul ignore next
+
+            var _this = this;
+
+            var varDeclarations = '';
+
+            var locals = this.stackVars.concat(this.registers.list);
+            if (locals.length > 0) {
+              varDeclarations += ', ' + locals.join(', ');
+            }
+
+            // Generate minimizer alias mappings
+            //
+            // When using true SourceNodes, this will update all references to the given alias
+            // as the source nodes are reused in situ. For the non-source node compilation mode,
+            // aliases will not be used, but this case is already being run on the client and
+            // we aren't concern about minimizing the template size.
+            var aliasCount = 0;
+            _Object$keys(this.aliases).forEach(function (alias) {
+              var node = _this.aliases[alias];
+              if (node.children && node.referenceCount > 1) {
+                varDeclarations += ', alias' + ++aliasCount + '=' + alias;
+                node.children[0] = 'alias' + aliasCount;
+              }
+            });
+
+            if (this.lookupPropertyFunctionIsUsed) {
+              varDeclarations += ', ' + this.lookupPropertyFunctionVarDeclaration();
+            }
+
+            var params = ['container', 'depth0', 'helpers', 'partials', 'data'];
+
+            if (this.useBlockParams || this.useDepths) {
+              params.push('blockParams');
+            }
+            if (this.useDepths) {
+              params.push('depths');
+            }
+
+            // Perform a second pass over the output to merge content when possible
+            var source = this.mergeSource(varDeclarations);
+
+            if (asObject) {
+              params.push(source);
+
+              return Function.apply(this, params);
+            } else {
+              return this.source.wrap(['function(', params.join(','), ') {\n  ', source, '}']);
+            }
+          },
+          mergeSource: function mergeSource(varDeclarations) {
+            var isSimple = this.environment.isSimple,
+                appendOnly = !this.forceBuffer,
+                appendFirst = undefined,
+                sourceSeen = undefined,
+                bufferStart = undefined,
+                bufferEnd = undefined;
+            this.source.each(function (line) {
+              if (line.appendToBuffer) {
+                if (bufferStart) {
+                  line.prepend('  + ');
+                } else {
+                  bufferStart = line;
+                }
+                bufferEnd = line;
+              } else {
+                if (bufferStart) {
+                  if (!sourceSeen) {
+                    appendFirst = true;
+                  } else {
+                    bufferStart.prepend('buffer += ');
+                  }
+                  bufferEnd.add(';');
+                  bufferStart = bufferEnd = undefined;
+                }
+
+                sourceSeen = true;
+                if (!isSimple) {
+                  appendOnly = false;
+                }
+              }
+            });
+
+            if (appendOnly) {
+              if (bufferStart) {
+                bufferStart.prepend('return ');
+                bufferEnd.add(';');
+              } else if (!sourceSeen) {
+                this.source.push('return "";');
+              }
+            } else {
+              varDeclarations += ', buffer = ' + (appendFirst ? '' : this.initializeBuffer());
+
+              if (bufferStart) {
+                bufferStart.prepend('return buffer + ');
+                bufferEnd.add(';');
+              } else {
+                this.source.push('return buffer;');
+              }
+            }
+
+            if (varDeclarations) {
+              this.source.prepend('var ' + varDeclarations.substring(2) + (appendFirst ? '' : ';\n'));
+            }
+
+            return this.source.merge();
+          },
+
+          lookupPropertyFunctionVarDeclaration: function lookupPropertyFunctionVarDeclaration() {
+            return '\n      lookupProperty = container.lookupProperty || function(parent, propertyName) {\n        if (Object.prototype.hasOwnProperty.call(parent, propertyName)) {\n          return parent[propertyName];\n        }\n        return undefined\n    }\n    '.trim();
+          },
+
+          // [blockValue]
+          //
+          // On stack, before: hash, inverse, program, value
+          // On stack, after: return value of blockHelperMissing
+          //
+          // The purpose of this opcode is to take a block of the form
+          // `{{#this.foo}}...{{/this.foo}}`, resolve the value of `foo`, and
+          // replace it on the stack with the result of properly
+          // invoking blockHelperMissing.
+          blockValue: function blockValue(name) {
+            var blockHelperMissing = this.aliasable('container.hooks.blockHelperMissing'),
+                params = [this.contextName(0)];
+            this.setupHelperArgs(name, 0, params);
+
+            var blockName = this.popStack();
+            params.splice(1, 0, blockName);
+
+            this.push(this.source.functionCall(blockHelperMissing, 'call', params));
+          },
+
+          // [ambiguousBlockValue]
+          //
+          // On stack, before: hash, inverse, program, value
+          // Compiler value, before: lastHelper=value of last found helper, if any
+          // On stack, after, if no lastHelper: same as [blockValue]
+          // On stack, after, if lastHelper: value
+          ambiguousBlockValue: function ambiguousBlockValue() {
+            // We're being a bit cheeky and reusing the options value from the prior exec
+            var blockHelperMissing = this.aliasable('container.hooks.blockHelperMissing'),
+                params = [this.contextName(0)];
+            this.setupHelperArgs('', 0, params, true);
+
+            this.flushInline();
+
+            var current = this.topStack();
+            params.splice(1, 0, current);
+
+            this.pushSource(['if (!', this.lastHelper, ') { ', current, ' = ', this.source.functionCall(blockHelperMissing, 'call', params), '}']);
+          },
+
+          // [appendContent]
+          //
+          // On stack, before: ...
+          // On stack, after: ...
+          //
+          // Appends the string value of `content` to the current buffer
+          appendContent: function appendContent(content) {
+            if (this.pendingContent) {
+              content = this.pendingContent + content;
+            } else {
+              this.pendingLocation = this.source.currentLocation;
+            }
+
+            this.pendingContent = content;
+          },
+
+          // [append]
+          //
+          // On stack, before: value, ...
+          // On stack, after: ...
+          //
+          // Coerces `value` to a String and appends it to the current buffer.
+          //
+          // If `value` is truthy, or 0, it is coerced into a string and appended
+          // Otherwise, the empty string is appended
+          append: function append() {
+            if (this.isInline()) {
+              this.replaceStack(function (current) {
+                return [' != null ? ', current, ' : ""'];
+              });
+
+              this.pushSource(this.appendToBuffer(this.popStack()));
+            } else {
+              var local = this.popStack();
+              this.pushSource(['if (', local, ' != null) { ', this.appendToBuffer(local, undefined, true), ' }']);
+              if (this.environment.isSimple) {
+                this.pushSource(['else { ', this.appendToBuffer("''", undefined, true), ' }']);
+              }
+            }
+          },
+
+          // [appendEscaped]
+          //
+          // On stack, before: value, ...
+          // On stack, after: ...
+          //
+          // Escape `value` and append it to the buffer
+          appendEscaped: function appendEscaped() {
+            this.pushSource(this.appendToBuffer([this.aliasable('container.escapeExpression'), '(', this.popStack(), ')']));
+          },
+
+          // [getContext]
+          //
+          // On stack, before: ...
+          // On stack, after: ...
+          // Compiler value, after: lastContext=depth
+          //
+          // Set the value of the `lastContext` compiler value to the depth
+          getContext: function getContext(depth) {
+            this.lastContext = depth;
+          },
+
+          // [pushContext]
+          //
+          // On stack, before: ...
+          // On stack, after: currentContext, ...
+          //
+          // Pushes the value of the current context onto the stack.
+          pushContext: function pushContext() {
+            this.pushStackLiteral(this.contextName(this.lastContext));
+          },
+
+          // [lookupOnContext]
+          //
+          // On stack, before: ...
+          // On stack, after: currentContext[name], ...
+          //
+          // Looks up the value of `name` on the current context and pushes
+          // it onto the stack.
+          lookupOnContext: function lookupOnContext(parts, falsy, strict, scoped) {
+            var i = 0;
+
+            if (!scoped && this.options.compat && !this.lastContext) {
+              // The depthed query is expected to handle the undefined logic for the root level that
+              // is implemented below, so we evaluate that directly in compat mode
+              this.push(this.depthedLookup(parts[i++]));
+            } else {
+              this.pushContext();
+            }
+
+            this.resolvePath('context', parts, i, falsy, strict);
+          },
+
+          // [lookupBlockParam]
+          //
+          // On stack, before: ...
+          // On stack, after: blockParam[name], ...
+          //
+          // Looks up the value of `parts` on the given block param and pushes
+          // it onto the stack.
+          lookupBlockParam: function lookupBlockParam(blockParamId, parts) {
+            this.useBlockParams = true;
+
+            this.push(['blockParams[', blockParamId[0], '][', blockParamId[1], ']']);
+            this.resolvePath('context', parts, 1);
+          },
+
+          // [lookupData]
+          //
+          // On stack, before: ...
+          // On stack, after: data, ...
+          //
+          // Push the data lookup operator
+          lookupData: function lookupData(depth, parts, strict) {
+            if (!depth) {
+              this.pushStackLiteral('data');
+            } else {
+              this.pushStackLiteral('container.data(data, ' + depth + ')');
+            }
+
+            this.resolvePath('data', parts, 0, true, strict);
+          },
+
+          resolvePath: function resolvePath(type, parts, i, falsy, strict) {
+            // istanbul ignore next
+
+            var _this2 = this;
+
+            if (this.options.strict || this.options.assumeObjects) {
+              this.push(strictLookup(this.options.strict && strict, this, parts, type));
+              return;
+            }
+
+            var len = parts.length;
+            for (; i < len; i++) {
+              /* eslint-disable no-loop-func */
+              this.replaceStack(function (current) {
+                var lookup = _this2.nameLookup(current, parts[i], type);
+                // We want to ensure that zero and false are handled properly if the context (falsy flag)
+                // needs to have the special handling for these values.
+                if (!falsy) {
+                  return [' != null ? ', lookup, ' : ', current];
+                } else {
+                  // Otherwise we can use generic falsy handling
+                  return [' && ', lookup];
+                }
+              });
+              /* eslint-enable no-loop-func */
+            }
+          },
+
+          // [resolvePossibleLambda]
+          //
+          // On stack, before: value, ...
+          // On stack, after: resolved value, ...
+          //
+          // If the `value` is a lambda, replace it on the stack by
+          // the return value of the lambda
+          resolvePossibleLambda: function resolvePossibleLambda() {
+            this.push([this.aliasable('container.lambda'), '(', this.popStack(), ', ', this.contextName(0), ')']);
+          },
+
+          // [pushStringParam]
+          //
+          // On stack, before: ...
+          // On stack, after: string, currentContext, ...
+          //
+          // This opcode is designed for use in string mode, which
+          // provides the string value of a parameter along with its
+          // depth rather than resolving it immediately.
+          pushStringParam: function pushStringParam(string, type) {
+            this.pushContext();
+            this.pushString(type);
+
+            // If it's a subexpression, the string result
+            // will be pushed after this opcode.
+            if (type !== 'SubExpression') {
+              if (typeof string === 'string') {
+                this.pushString(string);
+              } else {
+                this.pushStackLiteral(string);
+              }
+            }
+          },
+
+          emptyHash: function emptyHash(omitEmpty) {
+            if (this.trackIds) {
+              this.push('{}'); // hashIds
+            }
+            if (this.stringParams) {
+              this.push('{}'); // hashContexts
+              this.push('{}'); // hashTypes
+            }
+            this.pushStackLiteral(omitEmpty ? 'undefined' : '{}');
+          },
+          pushHash: function pushHash() {
+            if (this.hash) {
+              this.hashes.push(this.hash);
+            }
+            this.hash = { values: {}, types: [], contexts: [], ids: [] };
+          },
+          popHash: function popHash() {
+            var hash = this.hash;
+            this.hash = this.hashes.pop();
+
+            if (this.trackIds) {
+              this.push(this.objectLiteral(hash.ids));
+            }
+            if (this.stringParams) {
+              this.push(this.objectLiteral(hash.contexts));
+              this.push(this.objectLiteral(hash.types));
+            }
+
+            this.push(this.objectLiteral(hash.values));
+          },
+
+          // [pushString]
+          //
+          // On stack, before: ...
+          // On stack, after: quotedString(string), ...
+          //
+          // Push a quoted version of `string` onto the stack
+          pushString: function pushString(string) {
+            this.pushStackLiteral(this.quotedString(string));
+          },
+
+          // [pushLiteral]
+          //
+          // On stack, before: ...
+          // On stack, after: value, ...
+          //
+          // Pushes a value onto the stack. This operation prevents
+          // the compiler from creating a temporary variable to hold
+          // it.
+          pushLiteral: function pushLiteral(value) {
+            this.pushStackLiteral(value);
+          },
+
+          // [pushProgram]
+          //
+          // On stack, before: ...
+          // On stack, after: program(guid), ...
+          //
+          // Push a program expression onto the stack. This takes
+          // a compile-time guid and converts it into a runtime-accessible
+          // expression.
+          pushProgram: function pushProgram(guid) {
+            if (guid != null) {
+              this.pushStackLiteral(this.programExpression(guid));
+            } else {
+              this.pushStackLiteral(null);
+            }
+          },
+
+          // [registerDecorator]
+          //
+          // On stack, before: hash, program, params..., ...
+          // On stack, after: ...
+          //
+          // Pops off the decorator's parameters, invokes the decorator,
+          // and inserts the decorator into the decorators list.
+          registerDecorator: function registerDecorator(paramSize, name) {
+            var foundDecorator = this.nameLookup('decorators', name, 'decorator'),
+                options = this.setupHelperArgs(name, paramSize);
+
+            this.decorators.push(['fn = ', this.decorators.functionCall(foundDecorator, '', ['fn', 'props', 'container', options]), ' || fn;']);
+          },
+
+          // [invokeHelper]
+          //
+          // On stack, before: hash, inverse, program, params..., ...
+          // On stack, after: result of helper invocation
+          //
+          // Pops off the helper's parameters, invokes the helper,
+          // and pushes the helper's return value onto the stack.
+          //
+          // If the helper is not found, `helperMissing` is called.
+          invokeHelper: function invokeHelper(paramSize, name, isSimple) {
+            var nonHelper = this.popStack(),
+                helper = this.setupHelper(paramSize, name);
+
+            var possibleFunctionCalls = [];
+
+            if (isSimple) {
+              // direct call to helper
+              possibleFunctionCalls.push(helper.name);
+            }
+            // call a function from the input object
+            possibleFunctionCalls.push(nonHelper);
+            if (!this.options.strict) {
+              possibleFunctionCalls.push(this.aliasable('container.hooks.helperMissing'));
+            }
+
+            var functionLookupCode = ['(', this.itemsSeparatedBy(possibleFunctionCalls, '||'), ')'];
+            var functionCall = this.source.functionCall(functionLookupCode, 'call', helper.callParams);
+            this.push(functionCall);
+          },
+
+          itemsSeparatedBy: function itemsSeparatedBy(items, separator) {
+            var result = [];
+            result.push(items[0]);
+            for (var i = 1; i < items.length; i++) {
+              result.push(separator, items[i]);
+            }
+            return result;
+          },
+          // [invokeKnownHelper]
+          //
+          // On stack, before: hash, inverse, program, params..., ...
+          // On stack, after: result of helper invocation
+          //
+          // This operation is used when the helper is known to exist,
+          // so a `helperMissing` fallback is not required.
+          invokeKnownHelper: function invokeKnownHelper(paramSize, name) {
+            var helper = this.setupHelper(paramSize, name);
+            this.push(this.source.functionCall(helper.name, 'call', helper.callParams));
+          },
+
+          // [invokeAmbiguous]
+          //
+          // On stack, before: hash, inverse, program, params..., ...
+          // On stack, after: result of disambiguation
+          //
+          // This operation is used when an expression like `{{foo}}`
+          // is provided, but we don't know at compile-time whether it
+          // is a helper or a path.
+          //
+          // This operation emits more code than the other options,
+          // and can be avoided by passing the `knownHelpers` and
+          // `knownHelpersOnly` flags at compile-time.
+          invokeAmbiguous: function invokeAmbiguous(name, helperCall) {
+            this.useRegister('helper');
+
+            var nonHelper = this.popStack();
+
+            this.emptyHash();
+            var helper = this.setupHelper(0, name, helperCall);
+
+            var helperName = this.lastHelper = this.nameLookup('helpers', name, 'helper');
+
+            var lookup = ['(', '(helper = ', helperName, ' || ', nonHelper, ')'];
+            if (!this.options.strict) {
+              lookup[0] = '(helper = ';
+              lookup.push(' != null ? helper : ', this.aliasable('container.hooks.helperMissing'));
+            }
+
+            this.push(['(', lookup, helper.paramsInit ? ['),(', helper.paramsInit] : [], '),', '(typeof helper === ', this.aliasable('"function"'), ' ? ', this.source.functionCall('helper', 'call', helper.callParams), ' : helper))']);
+          },
+
+          // [invokePartial]
+          //
+          // On stack, before: context, ...
+          // On stack after: result of partial invocation
+          //
+          // This operation pops off a context, invokes a partial with that context,
+          // and pushes the result of the invocation back.
+          invokePartial: function invokePartial(isDynamic, name, indent) {
+            var params = [],
+                options = this.setupParams(name, 1, params);
+
+            if (isDynamic) {
+              name = this.popStack();
+              delete options.name;
+            }
+
+            if (indent) {
+              options.indent = JSON.stringify(indent);
+            }
+            options.helpers = 'helpers';
+            options.partials = 'partials';
+            options.decorators = 'container.decorators';
+
+            if (!isDynamic) {
+              params.unshift(this.nameLookup('partials', name, 'partial'));
+            } else {
+              params.unshift(name);
+            }
+
+            if (this.options.compat) {
+              options.depths = 'depths';
+            }
+            options = this.objectLiteral(options);
+            params.push(options);
+
+            this.push(this.source.functionCall('container.invokePartial', '', params));
+          },
+
+          // [assignToHash]
+          //
+          // On stack, before: value, ..., hash, ...
+          // On stack, after: ..., hash, ...
+          //
+          // Pops a value off the stack and assigns it to the current hash
+          assignToHash: function assignToHash(key) {
+            var value = this.popStack(),
+                context = undefined,
+                type = undefined,
+                id = undefined;
+
+            if (this.trackIds) {
+              id = this.popStack();
+            }
+            if (this.stringParams) {
+              type = this.popStack();
+              context = this.popStack();
+            }
+
+            var hash = this.hash;
+            if (context) {
+              hash.contexts[key] = context;
+            }
+            if (type) {
+              hash.types[key] = type;
+            }
+            if (id) {
+              hash.ids[key] = id;
+            }
+            hash.values[key] = value;
+          },
+
+          pushId: function pushId(type, name, child) {
+            if (type === 'BlockParam') {
+              this.pushStackLiteral('blockParams[' + name[0] + '].path[' + name[1] + ']' + (child ? ' + ' + JSON.stringify('.' + child) : ''));
+            } else if (type === 'PathExpression') {
+              this.pushString(name);
+            } else if (type === 'SubExpression') {
+              this.pushStackLiteral('true');
+            } else {
+              this.pushStackLiteral('null');
+            }
+          },
+
+          // HELPERS
+
+          compiler: JavaScriptCompiler,
+
+          compileChildren: function compileChildren(environment, options) {
+            var children = environment.children,
+                child = undefined,
+                compiler = undefined;
+
+            for (var i = 0, l = children.length; i < l; i++) {
+              child = children[i];
+              compiler = new this.compiler(); // eslint-disable-line new-cap
+
+              var existing = this.matchExistingProgram(child);
+
+              if (existing == null) {
+                this.context.programs.push(''); // Placeholder to prevent name conflicts for nested children
+                var index = this.context.programs.length;
+                child.index = index;
+                child.name = 'program' + index;
+                this.context.programs[index] = compiler.compile(child, options, this.context, !this.precompile);
+                this.context.decorators[index] = compiler.decorators;
+                this.context.environments[index] = child;
+
+                this.useDepths = this.useDepths || compiler.useDepths;
+                this.useBlockParams = this.useBlockParams || compiler.useBlockParams;
+                child.useDepths = this.useDepths;
+                child.useBlockParams = this.useBlockParams;
+              } else {
+                child.index = existing.index;
+                child.name = 'program' + existing.index;
+
+                this.useDepths = this.useDepths || existing.useDepths;
+                this.useBlockParams = this.useBlockParams || existing.useBlockParams;
+              }
+            }
+          },
+          matchExistingProgram: function matchExistingProgram(child) {
+            for (var i = 0, len = this.context.environments.length; i < len; i++) {
+              var environment = this.context.environments[i];
+              if (environment && environment.equals(child)) {
+                return environment;
+              }
+            }
+          },
+
+          programExpression: function programExpression(guid) {
+            var child = this.environment.children[guid],
+                programParams = [child.index, 'data', child.blockParams];
+
+            if (this.useBlockParams || this.useDepths) {
+              programParams.push('blockParams');
+            }
+            if (this.useDepths) {
+              programParams.push('depths');
+            }
+
+            return 'container.program(' + programParams.join(', ') + ')';
+          },
+
+          useRegister: function useRegister(name) {
+            if (!this.registers[name]) {
+              this.registers[name] = true;
+              this.registers.list.push(name);
+            }
+          },
+
+          push: function push(expr) {
+            if (!(expr instanceof Literal)) {
+              expr = this.source.wrap(expr);
+            }
+
+            this.inlineStack.push(expr);
+            return expr;
+          },
+
+          pushStackLiteral: function pushStackLiteral(item) {
+            this.push(new Literal(item));
+          },
+
+          pushSource: function pushSource(source) {
+            if (this.pendingContent) {
+              this.source.push(this.appendToBuffer(this.source.quotedString(this.pendingContent), this.pendingLocation));
+              this.pendingContent = undefined;
+            }
+
+            if (source) {
+              this.source.push(source);
+            }
+          },
+
+          replaceStack: function replaceStack(callback) {
+            var prefix = ['('],
+                stack = undefined,
+                createdStack = undefined,
+                usedLiteral = undefined;
+
+            /* istanbul ignore next */
+            if (!this.isInline()) {
+              throw new _exception2['default']('replaceStack on non-inline');
+            }
+
+            // We want to merge the inline statement into the replacement statement via ','
+            var top = this.popStack(true);
+
+            if (top instanceof Literal) {
+              // Literals do not need to be inlined
+              stack = [top.value];
+              prefix = ['(', stack];
+              usedLiteral = true;
+            } else {
+              // Get or create the current stack name for use by the inline
+              createdStack = true;
+              var _name = this.incrStack();
+
+              prefix = ['((', this.push(_name), ' = ', top, ')'];
+              stack = this.topStack();
+            }
+
+            var item = callback.call(this, stack);
+
+            if (!usedLiteral) {
+              this.popStack();
+            }
+            if (createdStack) {
+              this.stackSlot--;
+            }
+            this.push(prefix.concat(item, ')'));
+          },
+
+          incrStack: function incrStack() {
+            this.stackSlot++;
+            if (this.stackSlot > this.stackVars.length) {
+              this.stackVars.push('stack' + this.stackSlot);
+            }
+            return this.topStackName();
+          },
+          topStackName: function topStackName() {
+            return 'stack' + this.stackSlot;
+          },
+          flushInline: function flushInline() {
+            var inlineStack = this.inlineStack;
+            this.inlineStack = [];
+            for (var i = 0, len = inlineStack.length; i < len; i++) {
+              var entry = inlineStack[i];
+              /* istanbul ignore if */
+              if (entry instanceof Literal) {
+                this.compileStack.push(entry);
+              } else {
+                var stack = this.incrStack();
+                this.pushSource([stack, ' = ', entry, ';']);
+                this.compileStack.push(stack);
+              }
+            }
+          },
+          isInline: function isInline() {
+            return this.inlineStack.length;
+          },
+
+          popStack: function popStack(wrapped) {
+            var inline = this.isInline(),
+                item = (inline ? this.inlineStack : this.compileStack).pop();
+
+            if (!wrapped && item instanceof Literal) {
+              return item.value;
+            } else {
+              if (!inline) {
+                /* istanbul ignore next */
+                if (!this.stackSlot) {
+                  throw new _exception2['default']('Invalid stack pop');
+                }
+                this.stackSlot--;
+              }
+              return item;
+            }
+          },
+
+          topStack: function topStack() {
+            var stack = this.isInline() ? this.inlineStack : this.compileStack,
+                item = stack[stack.length - 1];
+
+            /* istanbul ignore if */
+            if (item instanceof Literal) {
+              return item.value;
+            } else {
+              return item;
+            }
+          },
+
+          contextName: function contextName(context) {
+            if (this.useDepths && context) {
+              return 'depths[' + context + ']';
+            } else {
+              return 'depth' + context;
+            }
+          },
+
+          quotedString: function quotedString(str) {
+            return this.source.quotedString(str);
+          },
+
+          objectLiteral: function objectLiteral(obj) {
+            return this.source.objectLiteral(obj);
+          },
+
+          aliasable: function aliasable(name) {
+            var ret = this.aliases[name];
+            if (ret) {
+              ret.referenceCount++;
+              return ret;
+            }
+
+            ret = this.aliases[name] = this.source.wrap(name);
+            ret.aliasable = true;
+            ret.referenceCount = 1;
+
+            return ret;
+          },
+
+          setupHelper: function setupHelper(paramSize, name, blockHelper) {
+            var params = [],
+                paramsInit = this.setupHelperArgs(name, paramSize, params, blockHelper);
+            var foundHelper = this.nameLookup('helpers', name, 'helper'),
+                callContext = this.aliasable(this.contextName(0) + ' != null ? ' + this.contextName(0) + ' : (container.nullContext || {})');
+
+            return {
+              params: params,
+              paramsInit: paramsInit,
+              name: foundHelper,
+              callParams: [callContext].concat(params)
+            };
+          },
+
+          setupParams: function setupParams(helper, paramSize, params) {
+            var options = {},
+                contexts = [],
+                types = [],
+                ids = [],
+                objectArgs = !params,
+                param = undefined;
+
+            if (objectArgs) {
+              params = [];
+            }
+
+            options.name = this.quotedString(helper);
+            options.hash = this.popStack();
+
+            if (this.trackIds) {
+              options.hashIds = this.popStack();
+            }
+            if (this.stringParams) {
+              options.hashTypes = this.popStack();
+              options.hashContexts = this.popStack();
+            }
+
+            var inverse = this.popStack(),
+                program = this.popStack();
+
+            // Avoid setting fn and inverse if neither are set. This allows
+            // helpers to do a check for `if (options.fn)`
+            if (program || inverse) {
+              options.fn = program || 'container.noop';
+              options.inverse = inverse || 'container.noop';
+            }
+
+            // The parameters go on to the stack in order (making sure that they are evaluated in order)
+            // so we need to pop them off the stack in reverse order
+            var i = paramSize;
+            while (i--) {
+              param = this.popStack();
+              params[i] = param;
+
+              if (this.trackIds) {
+                ids[i] = this.popStack();
+              }
+              if (this.stringParams) {
+                types[i] = this.popStack();
+                contexts[i] = this.popStack();
+              }
+            }
+
+            if (objectArgs) {
+              options.args = this.source.generateArray(params);
+            }
+
+            if (this.trackIds) {
+              options.ids = this.source.generateArray(ids);
+            }
+            if (this.stringParams) {
+              options.types = this.source.generateArray(types);
+              options.contexts = this.source.generateArray(contexts);
+            }
+
+            if (this.options.data) {
+              options.data = 'data';
+            }
+            if (this.useBlockParams) {
+              options.blockParams = 'blockParams';
+            }
+            return options;
+          },
+
+          setupHelperArgs: function setupHelperArgs(helper, paramSize, params, useRegister) {
+            var options = this.setupParams(helper, paramSize, params);
+            options.loc = JSON.stringify(this.source.currentLocation);
+            options = this.objectLiteral(options);
+            if (useRegister) {
+              this.useRegister('options');
+              params.push('options');
+              return ['options=', options];
+            } else if (params) {
+              params.push(options);
+              return '';
+            } else {
+              return options;
+            }
+          }
+        };
+
+        (function () {
+          var reservedWords = ('break else new var' + ' case finally return void' + ' catch for switch while' + ' continue function this with' + ' default if throw' + ' delete in try' + ' do instanceof typeof' + ' abstract enum int short' + ' boolean export interface static' + ' byte extends long super' + ' char final native synchronized' + ' class float package throws' + ' const goto private transient' + ' debugger implements protected volatile' + ' double import public let yield await' + ' null true false').split(' ');
+
+          var compilerWords = JavaScriptCompiler.RESERVED_WORDS = {};
+
+          for (var i = 0, l = reservedWords.length; i < l; i++) {
+            compilerWords[reservedWords[i]] = true;
+          }
+        })();
+
+        /**
+         * @deprecated May be removed in the next major version
+         */
+        JavaScriptCompiler.isValidJavaScriptVariableName = function (name) {
+          return !JavaScriptCompiler.RESERVED_WORDS[name] && /^[a-zA-Z_$][0-9a-zA-Z_$]*$/.test(name);
+        };
+
+        function strictLookup(requireTerminal, compiler, parts, type) {
+          var stack = compiler.popStack(),
+              i = 0,
+              len = parts.length;
+          if (requireTerminal) {
+            len--;
+          }
+
+          for (; i < len; i++) {
+            stack = compiler.nameLookup(stack, parts[i], type);
+          }
+
+          if (requireTerminal) {
+            return [compiler.aliasable('container.strict'), '(', stack, ', ', compiler.quotedString(parts[i]), ', ', JSON.stringify(compiler.source.currentLocation), ' )'];
+          } else {
+            return stack;
+          }
+        }
+
+        exports['default'] = JavaScriptCompiler;
+        module.exports = exports['default'];
+
+/***/ }),
+/* 53 */
+/***/ (function(module, exports, __webpack_require__) {
+
+        /* global define */
+        'use strict';
+
+        var _Object$keys = __webpack_require__(13)['default'];
+
+        exports.__esModule = true;
+
+        var _utils = __webpack_require__(5);
+
+        var SourceNode = undefined;
+
+        try {
+          /* istanbul ignore next */
+          if (false) {
+            // We don't support this in AMD environments. For these environments, we asusme that
+            // they are running on the browser and thus have no need for the source-map library.
+            var SourceMap = require('source-map');
+            SourceNode = SourceMap.SourceNode;
+          }
+        } catch (err) {}
+        /* NOP */
+
+        /* istanbul ignore if: tested but not covered in istanbul due to dist build  */
+        if (!SourceNode) {
+          SourceNode = function (line, column, srcFile, chunks) {
+            this.src = '';
+            if (chunks) {
+              this.add(chunks);
+            }
+          };
+          /* istanbul ignore next */
+          SourceNode.prototype = {
+            add: function add(chunks) {
+              if (_utils.isArray(chunks)) {
+                chunks = chunks.join('');
+              }
+              this.src += chunks;
+            },
+            prepend: function prepend(chunks) {
+              if (_utils.isArray(chunks)) {
+                chunks = chunks.join('');
+              }
+              this.src = chunks + this.src;
+            },
+            toStringWithSourceMap: function toStringWithSourceMap() {
+              return { code: this.toString() };
+            },
+            toString: function toString() {
+              return this.src;
+            }
+          };
+        }
+
+        function castChunk(chunk, codeGen, loc) {
+          if (_utils.isArray(chunk)) {
+            var ret = [];
+
+            for (var i = 0, len = chunk.length; i < len; i++) {
+              ret.push(codeGen.wrap(chunk[i], loc));
+            }
+            return ret;
+          } else if (typeof chunk === 'boolean' || typeof chunk === 'number') {
+            // Handle primitives that the SourceNode will throw up on
+            return chunk + '';
+          }
+          return chunk;
+        }
+
+        function CodeGen(srcFile) {
+          this.srcFile = srcFile;
+          this.source = [];
+        }
+
+        CodeGen.prototype = {
+          isEmpty: function isEmpty() {
+            return !this.source.length;
+          },
+          prepend: function prepend(source, loc) {
+            this.source.unshift(this.wrap(source, loc));
+          },
+          push: function push(source, loc) {
+            this.source.push(this.wrap(source, loc));
+          },
+
+          merge: function merge() {
+            var source = this.empty();
+            this.each(function (line) {
+              source.add(['  ', line, '\n']);
+            });
+            return source;
+          },
+
+          each: function each(iter) {
+            for (var i = 0, len = this.source.length; i < len; i++) {
+              iter(this.source[i]);
+            }
+          },
+
+          empty: function empty() {
+            var loc = this.currentLocation || { start: {} };
+            return new SourceNode(loc.start.line, loc.start.column, this.srcFile);
+          },
+          wrap: function wrap(chunk) {
+            var loc = arguments.length <= 1 || arguments[1] === undefined ? this.currentLocation || { start: {} } : arguments[1];
+
+            if (chunk instanceof SourceNode) {
+              return chunk;
+            }
+
+            chunk = castChunk(chunk, this, loc);
+
+            return new SourceNode(loc.start.line, loc.start.column, this.srcFile, chunk);
+          },
+
+          functionCall: function functionCall(fn, type, params) {
+            params = this.generateList(params);
+            return this.wrap([fn, type ? '.' + type + '(' : '(', params, ')']);
+          },
+
+          quotedString: function quotedString(str) {
+            return '"' + (str + '').replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r').replace(/\u2028/g, '\\u2028') // Per Ecma-262 7.3 + 7.8.4
+            .replace(/\u2029/g, '\\u2029') + '"';
+          },
+
+          objectLiteral: function objectLiteral(obj) {
+            // istanbul ignore next
+
+            var _this = this;
+
+            var pairs = [];
+
+            _Object$keys(obj).forEach(function (key) {
+              var value = castChunk(obj[key], _this);
+              if (value !== 'undefined') {
+                pairs.push([_this.quotedString(key), ':', value]);
+              }
+            });
+
+            var ret = this.generateList(pairs);
+            ret.prepend('{');
+            ret.add('}');
+            return ret;
+          },
+
+          generateList: function generateList(entries) {
+            var ret = this.empty();
+
+            for (var i = 0, len = entries.length; i < len; i++) {
+              if (i) {
+                ret.add(',');
+              }
+
+              ret.add(castChunk(entries[i], this));
+            }
+
+            return ret;
+          },
+
+          generateArray: function generateArray(entries) {
+            var ret = this.generateList(entries);
+            ret.prepend('[');
+            ret.add(']');
+
+            return ret;
+          }
+        };
+
+        exports['default'] = CodeGen;
+        module.exports = exports['default'];
+
+/***/ })
+/******/ ])
+});
+;

--- a/frontend/js/models/annotation.js
+++ b/frontend/js/models/annotation.js
@@ -17,13 +17,18 @@
  * A module representing the annotation model
  * @module models-annotation
  */
-define(["underscore",
+define(
+    [
+        "underscore",
         "util",
         "collections/comments",
+        "collections/annotation-content",
+        "models/content-item",
         "models/resource",
-        "localstorage"],
+        "localstorage"
+    ],
 
-    function (_, util, Comments, Resource) {
+    function (_, util, Comments, AnnotationContent, ContentItem, Resource) {
 
         "use strict";
 
@@ -71,6 +76,12 @@ define(["underscore",
                     this.attributes.comments = attr.comments;
                     delete attr.comments;
                 }
+
+                if (_.isObject(attr.content)) {
+                    this.attributes.content = attr.content;
+                } else {
+                    this.attributes.content = new AnnotationContent(attr.content || []);
+                }
             },
 
             /**
@@ -81,54 +92,17 @@ define(["underscore",
              */
             parse: function (data) {
                 return Resource.prototype.parse.call(this, data, function (attr) {
-                    var tempSettings,
-                        categories,
-                        tempLabel,
-                        label;
-
-                    if (attr.scaleValue) {
-                        attr.scalevalue = attr.scaleValue;
-                        delete attr.scaleValue;
-                    }
-
                     if (annotationTool.user.get("id") === attr.created_by) {
                         attr.isMine = true;
                     } else {
                         attr.isMine = false;
                     }
 
-                    if (attr.label) {
-                        if (attr.label.category && (tempSettings = util.parseJSONString(attr.label.category.settings))) {
-                            attr.label.category.settings = tempSettings;
-                        }
-
-                        if ((tempSettings = util.parseJSONString(attr.label.settings))) {
-                            attr.label.settings = tempSettings;
-                        }
-                    }
-
                     if (annotationTool.localStorage && _.isArray(attr.comments)) {
                         attr.comments = new Comments(attr.comments, { annotation: this });
                     }
 
-                    if (!annotationTool.localStorage &&  attr.label_id && (_.isNumber(attr.label_id) || _.isString(attr.label_id))) {
-                        categories = annotationTool.video.get("categories");
-
-                        categories.each(function (cat) {
-
-                            if ((tempLabel = cat.attributes.labels.get(attr.label_id))) {
-                                label = tempLabel;
-                                return true;
-                            }
-
-                        }, this);
-
-                        attr.label = label;
-                    }
-
-                    if (!annotationTool.localStorage &&  attr.scalevalue) {
-                        attr.scaleValue = attr.scalevalue;
-                    }
+                    attr.content = new AnnotationContent(attr.content);
                 });
             },
 
@@ -145,14 +119,6 @@ define(["underscore",
                     }
                 });
                 if (invalidResource) return invalidResource;
-
-                if (!annotationTool.localStorage && attr.label) {
-                    if (attr.label.id) {
-                        this.attributes.label_id = attr.label.id;
-                    } else if (attr.label.attributes) {
-                        this.attributes.label_id = attr.label.get("id");
-                    }
-                }
 
                 if (attr.start &&  !_.isNumber(attr.start)) {
                     return "\"start\" attribute must be a number!";
@@ -179,7 +145,7 @@ define(["underscore",
 
             /**
              * Load the list of comments from the server
-             * @param  {Function} [callback] Optional callback to call when comments are loaded 
+             * @param  {Function} [callback] Optional callback to call when comments are loaded
              * @alias module:models-annotation.Annotation#fetchComments
              */
             fetchComments: function (callback) {
@@ -218,18 +184,23 @@ define(["underscore",
 
                 delete json.comments;
 
-                if (json.label && json.label.toJSON) {
-                    json.label = json.label.toJSON();
+                if (json.content && json.content.toJSON) {
+                    json.content = json.content.toJSON();
                 }
 
-                if (json.scalevalue) {
-                    if (json.scalevalue.attributes) {
-                        json.scale_value_id = json.scalevalue.attributes.id;
-                    } else if (json.scalevalue.id) {
-                        json.scale_value_id = json.scalevalue.id;
-                    }
-                }
                 return json;
+            },
+
+            /**
+             * Add a content item to this annotation.
+             * @alias module:models-annotation.Annotation#addContent
+             * @param {object} JSON representation of the content item
+             */
+            addContent: function (content) {
+                var contentItem = new ContentItem(content);
+                this.attributes.content.add(contentItem);
+                this.save();
+                this.trigger("change", this, {});
             },
 
             /**
@@ -244,21 +215,107 @@ define(["underscore",
                 var start = this.get("start");
                 var duration = this.get("duration");
                 var end = start + (duration || minDuration);
- 
+
                 return start <= time && time <= end;
             },
 
             /**
-             * Access an annotations category, if it has any.
-             * @alias module:models-annotation.Annotation#category
-             * @return {Category} The category this annotations label belongs to, if it has a label
+             * Access an annotation's categories, if it has any.
+             * @alias module:models-annotation.Annotation#getCategories
+             * @return {array} The array of categories this annotation' labels belongs to, if it has any labels
              */
-            category: function () {
-                var label = this.get("label");
-                return label && annotationTool.video.get("categories").get(label.category.id);
+            getCategories: function () {
+                return this.get("content").reduce(function(memo, item) {
+                    var category = item.getCategory();
+                    if (category) {
+                        memo.push(category);
+                    }
+                    return memo;
+                }, []);
+            },
+
+            /**
+             * Access an annotation's color, if it has any.
+             * @alias module:models-annotation.Annotation#getColor
+             * @return {string} The string containing a CSS color value.
+             */
+            getColor: function () {
+                var color;
+                var content = this.get("content");
+
+                if (getAnnotationType(this) === "multi") {
+                    color = "white";
+                } else {
+                    var label = content.first().getLabel();
+                    color = getColorFromLabel(label);
+                }
+
+                return color;
+            },
+
+            /**
+             * Access an annotation's content items' labels, if it has any.
+             * @alias module:models-annotation.Annotation#getLabels
+             * @return {Label[]} An array of labels.
+             */
+            getLabels: function () {
+                return this.get("content").reduce(function(memo, item) {
+                    var label = item.getLabel();
+                    if (label) {
+                        memo.push(label);
+                    }
+                    return memo;
+                }, []);
+            },
+
+            /**
+             * Generate a `title` attribute according to this annotation's content items.
+             * @alias module:models-annotation.Annotation#getTitleAttribute
+             * @return {string} A string containing the value for the `title` attribute.
+             */
+            getTitleAttribute: function () {
+                var title;
+                switch (getAnnotationType(this)) {
+                case "label":
+                case "scaling":
+                    var label = this.get("content").first().getLabel();
+                    title = getTitleFromLabel(label);
+                    break;
+
+                case "text":
+                    title = this.get("content").first().get("value");
+                    break;
+                }
+
+                return title;
             }
         });
 
         return Annotation;
+
+        // return the type of an annotation's single content item and `multi` otherwise
+        function getAnnotationType(annotation) {
+            var content = annotation.get("content") || [];
+            return content.models.length !== 1 ? "multi" : content.first().get("type");
+        }
+
+        function getColorFromLabel(label) {
+            var color;
+            if (label) {
+                var category = label.get("category");
+                if (category && category.settings && category.settings.color) {
+                    color = category.settings.color;
+                }
+            }
+            return color;
+        }
+
+        function getTitleFromLabel(label) {
+            var title;
+            if (label) {
+                title = label.get("abbreviation") + " - " + label.get("value");
+            }
+            return title;
+        }
     }
 );

--- a/frontend/js/models/content-item.js
+++ b/frontend/js/models/content-item.js
@@ -1,0 +1,94 @@
+/**
+ *  Copyright 2020, ELAN e.V., Germany
+ *  Licensed under the Educational Community License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.osedu.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an "AS IS"
+ *  BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ *  or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ *
+ */
+
+/**
+ * A module representing the annotation-content model
+ * @module models-content-item
+ */
+define(["underscore", "backbone"], function(_, Backbone) {
+    "use strict";
+
+    /**
+     * @constructor
+     * @see {@link http://www.backbonejs.org/#Model}
+     * @augments module:Backbone.Model
+     * @memberOf module:models-content-item
+     * @alias module:models-content-item.ContentItem
+     */
+    var ContentItem = Backbone.Model.extend({
+        /**
+         * Get a category associated with this content item. May be undefined.
+         * @alias module:models-content-item.ContentItem#getCategory
+         * @return {Category|undefined} Either a category or undefined if there is none
+         */
+        getCategory: function() {
+            var label = this.getLabel();
+
+            return label && annotationTool.video.get("categories").get(label.category.id);
+        },
+
+        /**
+         * Get a label associated with this content item. May be undefined.
+         * @alias module:models-content-item.ContentItem#getLabel
+         * @return {Label|undefined} Either a label or undefined if there is none
+         */
+        getLabel: function() {
+            var labelId;
+            switch (this.get("type")) {
+                case "label":
+                    labelId = this.get("value");
+                    break;
+                case "scaling":
+                    labelId = this.get("value").label;
+                    break;
+            }
+
+            return labelId && _.findWhere(annotationTool.video.getLabels(), { id: labelId });
+        },
+
+        /**
+         * Get a short text describing this content item.
+         * @alias module:models-content-item.ContentItem#getText
+         * @return {string} The short string describing this item.
+         */
+        getText: function() {
+            switch (this.get("type")) {
+                case "text":
+                    return this.get("value");
+
+                case "label":
+                    return this.getLabel().get("value");
+
+                case "scaling":
+                    var scaleValue = _.findWhere(annotationTool.video.getScaleValues(), {
+                        id: this.get("value").scaling
+                    });
+                    return this.getLabel().get("abbreviation") + " (" + scaleValue.get("name") + ")";
+            }
+        },
+
+        /**
+         * Shortcut to get the `type` attribute of this content item.
+         * @alias module:models-content-item.ContentItem#getType
+         * @return {string} The type of this content item
+         */
+        getType: function() {
+            return this.get("type");
+        }
+    });
+
+    return ContentItem;
+});

--- a/frontend/js/views/annotate-label.js
+++ b/frontend/js/views/annotate-label.js
@@ -110,8 +110,6 @@ define(["jquery",
              * @param {PlainObject} attr Object literal containing the view initialization attributes.
              */
             initialize: function (attr) {
-                var scaleId;
-
                 if (!attr.label || !_.isObject(attr.label)) {
                     throw "Label object must be given as constuctor attribute!";
                 }
@@ -170,16 +168,9 @@ define(["jquery",
             annnotateWithScaling: function (event) {
                 event.stopImmediatePropagation();
 
-                var id = event.target.getAttribute("value"),
-                    scalevalue = this.scaleValues.get(id),
-                    annotation,
-                    params = {
-                        text: this.model.get("value"),
-                        label: this.model,
-                        scalevalue: scalevalue.toJSON()
-                    };
-
-                annotation = annotationTool.createAnnotation(params);
+                var id = event.target.getAttribute("value");
+                var annotation = annotationTool.createAnnotation({});
+                annotation.addContent({ type: "scaling", title: null, value: { label: this.model.id, scaling: id } });
             },
 
             /**
@@ -194,10 +185,8 @@ define(["jquery",
                     return;
                 }
 
-                var annotation = annotationTool.createAnnotation({
-                    text : this.model.get("value"),
-                    label: this.model
-                });
+                var annotation = annotationTool.createAnnotation({ });
+                annotation.addContent({ type: "label", title: null, value: this.model.id });
             },
 
             /**

--- a/frontend/js/views/annotate.js
+++ b/frontend/js/views/annotate.js
@@ -83,6 +83,7 @@ define(["jquery",
              */
             events: {
                 "keyup #new-annotation": "keydownOnAnnotate",
+                "click #insert-mca": "insertMCA",
                 "click #insert": "insert",
                 "keydown #new-annotation": "onFocusIn",
                 "focusout #new-annotation": "onFocusOut",
@@ -139,6 +140,7 @@ define(["jquery",
                 // Set the current context for all these functions
                 _.bindAll(this,
                             "insert",
+                            "insertMCA",
                             "onFocusIn",
                             "onFocusOut",
                             "changeTrack",
@@ -204,6 +206,11 @@ define(["jquery",
                 }
             },
 
+            insertMCA: function (event) {
+                event.stopImmediatePropagation();
+                annotationTool.createAnnotation({});
+            },
+
             /**
              * Insert a new annotation
              * @alias module:views-annotate.Annotate#insert
@@ -220,7 +227,8 @@ define(["jquery",
                     return;
                 }
 
-                annotationTool.createAnnotation({ text: value });
+                var annotation = annotationTool.createAnnotation({});
+                annotation.addContent({ type: "text", title: null, value: value });
 
                 if (this.continueVideo) {
                     this.playerAdapter.play();

--- a/frontend/js/views/list-annotation.js
+++ b/frontend/js/views/list-annotation.js
@@ -18,19 +18,31 @@
  * A module representing the view for an item of the annotations list
  * @module views-list-annotation
  */
-define(["jquery",
+define(
+    [
+        "jquery",
         "underscore",
         "util",
         "i18next",
         "views/comments-container",
+        "views/modal-add-free-text",
+        "views/modal-add-labelled",
+        "views/modal-edit-free-text",
+        "views/modal-edit-labelled",
         "templates/comments-container-header",
         "templates/list-annotation",
         "templates/list-annotation-expanded",
         "templates/list-annotation-edit",
+        "templates/list-annotation-category",
+        "templates/content-type-text",
+        "templates/content-type-label",
+        "templates/content-type-scaling",
+        "templates/content-item-header",
         "backbone",
-        "handlebarsHelpers"],
+        "handlebarsHelpers"
+    ],
 
-    function ($, _, util, i18next, CommentsContainer, commentsContainerHeader, TmplCollapsed, TmplExpanded, TmplEdit, Backbone) {
+    function ($, _, util, i18next, CommentsContainer, AddFreeTextModal, AddLabelledModal, EditFreeTextModal, EditLabelledModal, commentsContainerHeader, TmplCollapsed, TmplExpanded, TmplEdit, TmplCategory, TmplTypeText, TmplTypeLabel, TmplTypeScaling, TmplContentItemHeader, Backbone) {
 
         "use strict";
 
@@ -94,21 +106,6 @@ define(["jquery",
 
                 this.model.fetchComments();
                 this.listenTo(this.model.get("comments"), "add remove reset reply", this.render);
-
-                if (this.model.get("label")) {
-                    category = this.model.get("label").category;
-
-                    if (!category) {
-                        category = this.model.get("label").get("category");
-                    }
-
-                    this.scale = annotationTool.video.get("scales").get(category.scale_id);
-                }
-
-                if (this.scale) {
-                    this.scaleValues = this.scale.get("scaleValues");
-                }
-
                 this.listenTo(this.model, "change", this.render);
                 this.listenTo(this.model.get("comments"), "change", this.render);
                 this.listenTo(this.model.get("comments"), "remove", this.render);
@@ -161,50 +158,6 @@ define(["jquery",
                     event.stopImmediatePropagation();
                 }
                 annotationTool.deleteOperation.start(this.model, this.typeForDelete);
-            },
-
-            /**
-             * Save the modification done in the free text field
-             * @alias module:views-list-annotation.ListAnnotation#saveFreeText
-             * @param  {event} event Event object
-             */
-            saveFreeText: function (event) {
-
-                // If keydown event but not enter, value must not be saved
-                if (event.type === "keydown" && !(event.keyCode === 13 && !event.shiftKey)) {
-                    return;
-                }
-
-                var newValue = this.$el.find(".freetext textarea").val();
-                this.model.save({ text: newValue });
-
-                if (event.type === "keydown") {
-                    $(event.currentTarget).blur();
-                }
-                this.toggleEditState(event);
-            },
-
-            /**
-             * Save the scaling value
-             * @alias module:views-list-annotation.ListAnnotation#saveScaling
-             * @param  {event} event Event object
-             */
-            saveScaling: function (event) {
-                var newValue = _.escape(this.$el.find(".scaling select").val());
-
-                // If keydown event but not enter, value must not be saved
-                if (event.type === "keydown" && event.keyCode !== 13) {
-                    return;
-                }
-
-                if (newValue === "OFF") {
-                    this.model.unset("scalevalue");
-                } else {
-                    this.model.set({ scalevalue: this.scaleValues.get(newValue).toJSON() });
-                    this.$el.find(".scaling span").html(this.scaleValues.get(newValue).get("name"));
-                }
-
-                this.model.save();
             },
 
             /**
@@ -341,9 +294,6 @@ define(["jquery",
              */
             render: function () {
                 var modelJSON,
-                    scaleValues,
-                    category,
-                    selectedScaleValue,
                     title;
 
                 modelJSON              = this.model.toJSON();
@@ -352,42 +302,39 @@ define(["jquery",
                 modelJSON.duration     = (modelJSON.duration || 0.0);
                 modelJSON.textHeight   = this.$el.find("span.freetext").height();
 
-                if (modelJSON.isMine && this.scale && modelJSON.label.category.scale_id) {
-                    category = annotationTool.video.get("categories").get(this.model.get("label").category.id);
-
-                    // Check if the category is still linked to the video to get the current version
-                    if (category) {
-                        modelJSON.hasScale = category.get("settings").hasScale;
-                    } else {
-                        // Othervise use the json copy
-                        modelJSON.hasScale = this.model.get("label").category.settings.hasScale;
-                    }
-
-                    if (modelJSON.hasScale && this.scale) {
-                        scaleValues = this.scaleValues.toJSON();
-                        selectedScaleValue = _.where(scaleValues, { id: modelJSON.scale_value_id });
-
-                        if (selectedScaleValue.length > 0) {
-                            selectedScaleValue[0].isSelected = true;
-                        }
-                    }
-                    modelJSON.scalevalues = scaleValues;
-                }
-
                 modelJSON.numberOfComments = this.model.get("comments").countCommentsAndReplies();
                 modelJSON.state = this.getState().id;
                 modelJSON.end = modelJSON.start + modelJSON.duration;
 
-                this.$el.html(this.currentState.render(modelJSON));
+                modelJSON.labels = annotationTool.video.getLabels();
 
-                if (!_.isUndefined(modelJSON.label) && !_.isNull(modelJSON.label)) {
-                    title = modelJSON.label.abbreviation + " - " + modelJSON.label.value;
-                    if (!_.isUndefined(modelJSON.label.category)) {
-                        this.$el.css("background-color", modelJSON.label.category.settings.color);
+                modelJSON.categories = annotationTool.video.get("categories").map(
+                    function (category) {
+                        var labels = category.get("labels").toJSON();
+                        var scale = null;
+                        if (category.get("scale_id")) {
+                            scale = annotationTool.video.get("scales").get(category.get("scale_id"));
+                            scale = _.extend(scale.toJSON(), { scaleValues: scale.get("scaleValues").toJSON() });
+                        }
+                        return _.extend(category.toJSON(), { labels: labels, scale: scale });
                     }
-                } else {
-                    title = modelJSON.text;
+                );
+
+                var partials = _.extend(
+                    {
+                        category: TmplCategory,
+                        "content-item-header": TmplContentItemHeader
+                    },
+                    this.currentState.partials || {}
+                );
+                this.$el.html(this.currentState.render(modelJSON, { partials: partials }));
+
+                var color = this.model.getColor();
+                if (color) {
+                    this.$el.css("background-color", color);
                 }
+
+                title = this.model.getTitleAttribute();
 
                 if (this.getState() == ListAnnotation.STATES.EDIT) {
                     title += " edit-on";
@@ -570,6 +517,99 @@ define(["jquery",
             remove: function () {
                 this.commentContainer.remove();
                 Backbone.View.prototype.remove.apply(this, arguments);
+            },
+
+            /**
+             * Add a new annotation with a content item containing free text.
+             * @alias module:views-list-annotation.ListAnnotation#addFreetextContent
+             * @param {Event} event Event object
+             */
+            addFreeTextContent(event) {
+                event.stopPropagation();
+
+                annotationTool.addModal(
+                    i18next.t("annotation.add content.add free text"),
+                    new AddFreeTextModal({ model: this.model }),
+                    i18next.t("common actions.insert")
+                );
+            },
+
+            /**
+             * Add a new annotation with a content item containing a label w/ or w/o a scale value.
+             * @alias module:views-list-annotation.ListAnnotation#addLabelledContent
+             * @param {Event} event Event object
+             */
+            addLabelledContent(event) {
+                event.stopPropagation();
+
+                var categoryID = $(event.target).data("category");
+                var category = annotationTool.video.get("categories").get(categoryID);
+
+                annotationTool.addModal(
+                    i18next.t("annotation.add content.category") + " " + category.get("name"),
+                    new AddLabelledModal({ model: this.model, category: category })
+                );
+            },
+
+            /**
+             * Edit an annotation's content item in a modal dialog.
+             * @alias module:views-list-annotation.ListAnnotation#editContentitem
+             * @param {Event} event Event object
+             */
+            editContentItem: function (event) {
+                var $contentItem = $(event.target).closest(".content-item");
+                var position = $contentItem.prevAll().length;
+                var contentItems = this.model.get("content");
+                var contentItem = contentItems.at(position);
+
+                switch (contentItem.getType()) {
+                case "text":
+                    annotationTool.addModal(
+                        i18next.t("annotation.edit.edit"),
+                        new EditFreeTextModal({
+                            model: this.model,
+                            contentItem: contentItem
+                        }),
+                        i18next.t("common actions.save")
+                    );
+                    break;
+
+                case "label":
+                case "scaling":
+                    annotationTool.addModal(
+                        i18next.t("annotation.edit.edit"),
+                        new EditLabelledModal({
+                            model: this.model,
+                            category: contentItem.getCategory(),
+                            contentItem: contentItem
+                        })
+                    );
+                    break;
+                }
+            },
+
+            /**
+             * Remove an annotation's content item.
+             * @alias module:views-list-annotation.ListAnnotation#removeContentitem
+             * @param {Event} event Event object
+             */
+            removeContentItem: function (event) {
+                var $contentItem = $(event.target).closest(".content-item");
+                var position = $contentItem.prevAll().length;
+                var contentItems = this.model.get("content");
+                contentItems.remove(contentItems.at(position));
+                this.model.save();
+                this.model.trigger("change", this.model, {});
+            },
+
+            /**
+             * Toggle between expanding and collapsing an annotation's content item.
+             * @alias module:views-list-annotation.ListAnnotation#toggleContentItem
+             * @param {Event} event Event object
+             */
+            toggleContentItem: function (event) {
+                var $contentItem = $(event.target).closest(".content-item");
+                $contentItem.toggleClass("open");
             }
         }, {
 
@@ -591,6 +631,11 @@ define(["jquery",
                 },
                 EXPANDED: {
                     render: TmplExpanded,
+                    partials: {
+                        "text": TmplTypeText,
+                        "label": TmplTypeLabel,
+                        "scaling": TmplTypeScaling
+                    },
                     withComments: true,
                     id: "expanded",
                     events: {
@@ -600,7 +645,13 @@ define(["jquery",
                         "click i.icon-comment-amount": "toggleCommentsState",
                         "click i.icon-comment": "toggleCommentsState",
                         "click .toggle-edit": "toggleEditState",
-                        "click i.delete": "deleteFull"
+                        "click i.delete": "deleteFull",
+                        "click button.add-free-text-content": "addFreeTextContent",
+                        "click button.add-labelled-content": "addLabelledContent",
+                        "click .content-item-expand": "toggleContentItem",
+                        "click .content-item-collapse": "toggleContentItem",
+                        "click .content-item-edit": "editContentItem",
+                        "click .content-item-trash": "removeContentItem",
                     }
                 },
                 EDIT: {
@@ -623,13 +674,9 @@ define(["jquery",
                         "click button.out": "setCurrentTimeAsEnd",
                         "keydown .start-value": "saveStart",
                         "keydown .end-value": "saveEnd",
-                        "keydown .freetext textarea": "saveFreeText",
                         "focusout .start-value": "saveStart",
                         "focusout .end-value": "saveEnd",
-                        "click button[type=submit]": "saveFreeText",
                         "click button[type=button]": "toggleEditState",
-                        "focusout .freetext textarea": "saveFreeText",
-                        "change .scaling select": "saveScaling",
                         "keyup": "handleEsc"
                     }
                 },
@@ -650,5 +697,6 @@ define(["jquery",
                 }
             }
         });
+
     return ListAnnotation;
 });

--- a/frontend/js/views/list.js
+++ b/frontend/js/views/list.js
@@ -357,9 +357,20 @@ define(["underscore",
                 this.$list.empty();
 
                 _.each(this.annotationViews, function (annView) {
-                    var category = annView.model.category();
-                    if (category && !category.get("visible")) return;
-                    if (!category && !annotationTool.freeTextVisible) return;
+                    var categories = annView.model.getCategories();
+
+                    if (categories.length) {
+                        if (_.some(
+                            categories,
+                            function (category) {
+                                return !category.get("visible");
+                            }
+                        )) {
+                            return;
+                        }
+                    } else {
+                        if (!annotationTool.freeTextVisible) return;
+                    }
                     this.$list.append(annView.$el);
                 }, this);
 

--- a/frontend/js/views/modal-add-free-text.js
+++ b/frontend/js/views/modal-add-free-text.js
@@ -1,0 +1,52 @@
+/**
+ *  Copyright 2020, ELAN e.V., Germany
+ *  Licensed under the Educational Community License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.osedu.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an "AS IS"
+ *  BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ *  or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ *
+ */
+define(["templates/modal-add-free-text", "backbone", "bootstrap"], function(template, Backbone) {
+    "use strict";
+
+    return Backbone.View.extend({
+        /**
+         * Constructor
+         * @alias module:views-modal-add-free-text.ModalAddFreeText#initialize
+         */
+        initialize: function() {
+            this.error = false;
+            this.listenTo(this, "modal:click", this.addContent);
+        },
+        /**
+         * Render this view
+         * @alias module:views-modal-add-free-text.ModalAddFreeText#render
+         */
+        render: function() {
+            this.$el.html(template({ cid: this.cid, error: this.error }));
+            return this;
+        },
+        /**
+         * Listener for click on this modal's submit button
+         * @alias module:views-modal-add-free-text.ModalAddFreeText#addContent
+         */
+        addContent: function(event) {
+            this.error = false;
+            var value = this.$("textarea").val();
+            if (value.length) {
+                this.model.addContent({ type: "text", title: null, value: value });
+                this.trigger("modal:request-close");
+            } else {
+                this.error = true;
+                this.render();
+            }
+        }
+    });
+});

--- a/frontend/js/views/modal-add-labelled.js
+++ b/frontend/js/views/modal-add-labelled.js
@@ -1,0 +1,117 @@
+/**
+ *  Copyright 2020, ELAN e.V., Germany
+ *  Licensed under the Educational Community License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.osedu.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an "AS IS"
+ *  BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ *  or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ *
+ */
+define([
+    "templates/modal-add-labelled",
+    "templates/partial-label-chooser",
+    "templates/partial-scale-chooser",
+    "backbone",
+    "bootstrap"
+], function(template, tmplLabelChooser, tmplScaleChooser, Backbone) {
+    "use strict";
+
+    return Backbone.View.extend({
+        /**
+         * Events to handle
+         * @alias module:views-modal-add-labelled.ModalAddLabelled#events
+         * @type {object}
+         */
+        events: {
+            "click .btn.label": "onLabelledContent",
+            "click .btn.label-and-scale": "onScalingContent"
+        },
+
+        /**
+         * Constructor
+         * @alias module:views-modal-add-labelled.ModalAddLabelled#initialize
+         */
+        initialize: function(options) {
+            this.category = options.category;
+        },
+
+        /**
+         * Render this view
+         * @alias module:views-modal-add-labelled.ModalAddLabelled#render
+         */
+        render: function() {
+            this.$el.html(
+                template(
+                    {
+                        color: getColor(this.category),
+                        labels: this.category.get("labels").toJSON(),
+                        scale: getScale(this.category)
+                    },
+                    {
+                        partials: {
+                            labelChooser: tmplLabelChooser,
+                            scaleChooser: tmplScaleChooser
+                        }
+                    }
+                )
+            );
+
+            return this;
+        },
+
+        /**
+         * Listener for click on a button to add a `label` content item
+         * @alias module:views-modal-add-labelled.ModalAddLabelled#onLabelledContent
+         */
+        onLabelledContent: function(event) {
+            var $button = $(event.currentTarget);
+            var labelId = $button.data("label");
+
+            this.model.addContent({
+                type: "label",
+                title: null,
+                value: labelId
+            });
+            this.trigger("modal:request-close");
+        },
+
+        /**
+         * Listener for click on a button to add a `scaling` content item
+         * @alias module:views-modal-add-labelled.ModalAddLabelled#onScalingContent
+         */
+        onScalingContent: function(event) {
+            var $button = $(event.currentTarget);
+            var labelId = $button.data("label");
+            var scaleValueId = $button.data("scalevalue");
+
+            this.model.addContent({
+                type: "scaling",
+                title: null,
+                value: { label: labelId, scaling: scaleValueId }
+            });
+            this.trigger("modal:request-close");
+        }
+    });
+});
+
+function getColor(category) {
+    var json = category.toJSON();
+
+    return json && json.settings && json.settings.color;
+}
+
+function getScale(category) {
+    var scale = null;
+    if (category.get("scale_id")) {
+        scale = annotationTool.video.get("scales").get(category.get("scale_id"));
+        scale = _.extend(scale.toJSON(), { scaleValues: scale.get("scaleValues").toJSON() });
+    }
+
+    return scale;
+}

--- a/frontend/js/views/modal-container.js
+++ b/frontend/js/views/modal-container.js
@@ -1,0 +1,78 @@
+/**
+ *  Copyright 2020, ELAN e.V., Germany
+ *  Licensed under the Educational Community License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.osedu.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an "AS IS"
+ *  BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ *  or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ *
+ */
+define(["templates/modal-container", "backbone", "bootstrap"], function(template, Backbone) {
+    "use strict";
+
+    return Backbone.View.extend({
+        /**
+         * Events to handle
+         * @alias module:views-modal-container.ModalContainer#events
+         * @type {object}
+         */
+        events: { "click .btn-primary": "onClick" },
+        /**
+         * Constructor
+         * @alias module:views-modal-container.ModalContainer#initialize
+         */
+        initialize: function(options) {
+            this.buttonText = options.buttonText;
+            this.contentView = options.contentView;
+            this.header = options.header;
+
+            this.listenTo(this.contentView, "modal:request-close", this.close);
+
+            // auto-render into #dialogs
+            Backbone.$("#dialogs").append(this.render().$el);
+            this.$(".modal").modal({ show: true, backdrop: true, keyboard: true });
+        },
+        /**
+         * Destructor
+         * @alias module:views-modal-container.ModalContainer#remove
+         */
+        remove: function() {
+            this.contentView.remove();
+            Backbone.View.prototype.remove.apply(this, arguments);
+        },
+
+        /**
+         * Render this view
+         * @alias module:views-modal-container.ModalContainer#render
+         */
+        render: function() {
+            this.$el.html(template({ cid: this.cid, buttonText: this.buttonText, header: this.header }));
+            this.$(".modal-body").append(this.contentView.render().$el);
+
+            return this;
+        },
+
+        /**
+         * Listener for a close event out of this container
+         * @alias module:views-modal-container.ModalContainer#close
+         */
+        close: function() {
+            this.$(".modal").modal("hide");
+            this.remove();
+        },
+
+        /**
+         * Listener for a click on the submit button of this modal.
+         * @alias module:views-modal-container.ModalContainer#onClick
+         */
+        onClick: function(event) {
+            this.contentView.trigger("modal:click", event);
+        }
+    });
+});

--- a/frontend/js/views/modal-edit-free-text.js
+++ b/frontend/js/views/modal-edit-free-text.js
@@ -1,0 +1,60 @@
+/**
+ *  Copyright 2020, ELAN e.V., Germany
+ *  Licensed under the Educational Community License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.osedu.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an "AS IS"
+ *  BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ *  or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ *
+ */
+define(["templates/modal-edit-free-text", "backbone", "bootstrap"], function(template, Backbone) {
+    "use strict";
+
+    return Backbone.View.extend({
+        /**
+         * Constructor
+         * @alias module:views-modal-edit-free-text.ModalEditFreeText#initialize
+         */
+        initialize: function(options) {
+            this.contentItem = options.contentItem;
+            this.error = false;
+            this.listenTo(this, "modal:click", this.updateContent);
+        },
+        /**
+         * Render this view
+         * @alias module:views-modal-edit-free-text.ModalEditFreeText#render
+         */
+        render: function() {
+            this.$el.html(
+                template({
+                    cid: this.cid,
+                    error: this.error,
+                    contentItem: this.contentItem.toJSON()
+                })
+            );
+            return this;
+        },
+        /**
+         * Listener for click on this modal's submit button
+         * @alias module:views-modal-edit-free-text.ModalEditFreeText#updateContent
+         */
+        updateContent: function(event) {
+            this.error = false;
+            var value = this.$("textarea").val();
+            if (value.length) {
+                this.contentItem.set("value", value);
+                this.model.save();
+                this.trigger("modal:request-close");
+            } else {
+                this.error = true;
+                this.render();
+            }
+        }
+    });
+});

--- a/frontend/js/views/modal-edit-labelled.js
+++ b/frontend/js/views/modal-edit-labelled.js
@@ -1,0 +1,131 @@
+/**
+ *  Copyright 2020, ELAN e.V., Germany
+ *  Licensed under the Educational Community License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.osedu.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an "AS IS"
+ *  BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ *  or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ *
+ */
+define([
+    "templates/modal-add-labelled",
+    "templates/partial-label-chooser",
+    "templates/partial-scale-chooser",
+    "backbone",
+    "bootstrap"
+], function(template, tmplLabelChooser, tmplScaleChooser, Backbone) {
+    "use strict";
+
+    return Backbone.View.extend({
+        /**
+         * Events to handle
+         * @alias module:views-modal-edit-labelled.ModalEditLabelled#events
+         * @type {object}
+         */
+        events: {
+            "click .btn.label": "onLabelledContent",
+            "click .btn.label-and-scale": "onScalingContent"
+        },
+
+        /**
+         * Constructor
+         * @alias module:views-modal-edit-labelled.ModalEditLabelled#initialize
+         */
+        initialize: function(options) {
+            this.category = options.category;
+            this.contentItem = options.contentItem;
+        },
+
+        /**
+         * Render this view
+         * @alias module:views-modal-edit-labelled.ModalEditLabelled#render
+         */
+        render: function() {
+            this.$el.html(
+                template(
+                    {
+                        color: getColor(this.category),
+                        labels: getLabels(this.category, this.contentItem),
+                        scale: getScale(this.category, this.contentItem)
+                    },
+                    {
+                        partials: {
+                            labelChooser: tmplLabelChooser,
+                            scaleChooser: tmplScaleChooser
+                        }
+                    }
+                )
+            );
+
+            return this;
+        },
+
+        /**
+         * Listener for click on a button to add a `label` content item
+         * @alias module:views-modal-edit-labelled.ModalEditLabelled#onLabelledContent
+         */
+        onLabelledContent: function(event) {
+            var $button = $(event.currentTarget);
+            var labelId = $button.data("label");
+
+            this.contentItem.set("value", labelId);
+            this.model.save();
+            this.trigger("modal:request-close");
+        },
+
+        /**
+         * Listener for click on a button to add a `scaling` content item
+         * @alias module:views-modal-edit-labelled.ModalEditLabelled#onScalingContent
+         */
+        onScalingContent: function(event) {
+            var $button = $(event.currentTarget);
+            var labelId = $button.data("label");
+            var scaleValueId = $button.data("scalevalue");
+
+            this.contentItem.set("value", { label: labelId, scaling: scaleValueId });
+            this.model.save();
+            this.trigger("modal:request-close");
+        }
+    });
+});
+
+function getColor(category) {
+    var json = category.toJSON();
+
+    return json && json.settings && json.settings.color;
+}
+
+function getLabels(category, contentItem) {
+    var selectedLabel = contentItem.getLabel();
+    var labels = category
+        .get("labels")
+        .toJSON()
+        .map(function(label) {
+            return _.extend(label, { selected: label.id === selectedLabel.id });
+        });
+
+    return labels;
+}
+
+function getScale(category, contentItem) {
+    var scale;
+    if (category.get("scale_id")) {
+        var selectedScaleValueId = contentItem && contentItem.get("value").scaling;
+        scale = annotationTool.video.get("scales").get(category.get("scale_id"));
+        var scaleValues = scale
+            .get("scaleValues")
+            .toJSON()
+            .map(function(scaleValue) {
+                return _.extend(scaleValue, { selected: scaleValue.id === selectedScaleValueId });
+            });
+        scale = _.extend(scale.toJSON(), { scaleValues: scaleValues });
+    }
+
+    return scale;
+}

--- a/frontend/js/views/print.js
+++ b/frontend/js/views/print.js
@@ -68,13 +68,15 @@ define(["underscore", "backbone", "templates/print", "handlebarsHelpers"], funct
                 return tracks.get(trackId);
             });
             var annotations = _.chain(tracks)
-                .invoke('get', 'annotations')
+                .map("annotations")
                 .pluck("models")
                 .flatten()
                 .filter(function (annotation) {
-                    var category = annotation.category();
-                    if (!category) return annotationTool.freeTextVisible;
-                    return category.get("visible");
+                    var categories = annotation.getCategories();
+                    if (!categories.length) {
+                        return annotationTool.freeTextVisible;
+                    }
+                    return _.every(_.invoke(categories, "get", "visible"));
                 });
 
             var users = annotations
@@ -85,10 +87,8 @@ define(["underscore", "backbone", "templates/print", "handlebarsHelpers"], funct
                 }).value();
 
             // Get all used categories and and their scales
-            var labels = annotations
-                .filter(function (annotation) { return annotation.has("label"); })
-                .invoke("get", "label")
-                .uniq("id");
+            var labels = annotations.invoke("getLabels").flatten();
+
             var categories = labels.pluck("category")
                 .sortBy("name")
                 .uniq("id")
@@ -114,7 +114,7 @@ define(["underscore", "backbone", "templates/print", "handlebarsHelpers"], funct
                 .unzip()
                 .map(function (labels) {
                     return {
-                        labels: labels
+                        labels: _.invoke(labels, "toJSON")
                     };
                 }).value();
 
@@ -127,14 +127,20 @@ define(["underscore", "backbone", "templates/print", "handlebarsHelpers"], funct
                     result.author = annotation.get("created_by_nickname");
 
                     // Assign text for free text annotations
-                    var label = annotation.get("label");
-                    if (!label) result.free = annotation.get("text");
+                    var labels = annotation.getLabels();
+                    if (!labels.length) {
+                        result.free = annotation.get("content").reduce(function (memo, item) {
+                            if (item.get("type") === "text") {
+                                memo.push(item.get("value"));
+                            }
+                            return memo;
+                        }, []).join(", ");
+                    }
 
                     // Build the display code
-                    if (label) {
-                        result.codes = label.abbreviation;
-                        var scaleValue = annotation.get("scalevalue");
-                        if (scaleValue) result.codes += " " + scaleValue.name;
+                    var scaleValues = annotationTool.video.getScaleValues();
+                    if (labels.length) {
+                        result.codes = labels.invoke("get","abbreviation").join(", ");
                     } else {
                         result.codes = "Free";
                     }
@@ -201,6 +207,7 @@ define(["underscore", "backbone", "templates/print", "handlebarsHelpers"], funct
                     }
                 }
             }));
+
             return this;
         }
     });

--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -74,14 +74,25 @@ define([
         item.group = annotation.collection.track.id;
         item.start = util.dateFromSeconds(item.start);
         item.end = util.dateFromSeconds(item.end);
-        var label = item.label;
-        if (label) {
-            item.className = "category-" + label.category.id;
+        delete item.content;
+
+        item.text = annotation.get("content")
+            .chain()
+            .sortBy(function (c) { return c.get("type"); })
+            .invoke("getText")
+            .value()
+            .join(", ");
+
+        var labels = annotation.getLabels();
+        if (labels.length === 1) {
+            item.className = "category-" + labels[0].get("category").id;
+            item.label = labels[0].toJSON();
         }
         item.type = item.duration
             ? "range"
             : "box";
         item.model = annotation;
+
         return item;
     }
 

--- a/frontend/locales/de/translation.json
+++ b/frontend/locales/de/translation.json
@@ -30,6 +30,7 @@
     "edit category scaling": "Skala für diese Kategorie bearbeiten",
     "edit mode": "Bearbeiten",
     "insert": "$t(common actions.insert)",
+    "insert mca": "Erstelle Multi-Content-Annotation",
     "items visibility": {
       "collapse all": "Alle zuklappen",
       "expand all": "Alle aufklappen",
@@ -54,6 +55,12 @@
     "author": "Erstellt von",
     "created": "am",
     "track": "auf",
+    "empty text": "ohne Inhalt",
+    "types": {
+      "free text": "Freitextannotation",
+      "label": "Kennzeichen",
+      "scaling": "Kennzeichen mit Skalenwert"
+    },
     "comments": {
       "author": "Kommentar von",
       "cancel": "$t(common actions.cancel)",
@@ -70,6 +77,13 @@
       "modified": "zuletzt verändert am {{date}}",
       "placeholder": "Einen Kommentar für diese Annotation schreiben",
       "title": "Kommentare"
+    },
+    "add content": {
+      "add free text": "Freitext hinzufügen",
+      "category": "Kategorie:",
+      "free text": "Freitext",
+      "list prompt": "Inhalt hinzufügen:",
+      "please choose": "Wählen Sie bitte ein Kennzeichen"
     },
     "edit": {
       "delete": "Annotation löschen.",
@@ -340,6 +354,9 @@
     "loop": "Schleifensteuerung",
     "timeline": "Zeitleiste",
     "player": "Player"
+  },
+  "validation errors": {
+    "empty": "Dieses Feld darf nicht leer sein"
   },
   "common actions": {
     "cancel": "Abbrechen",

--- a/frontend/locales/en/translation.json
+++ b/frontend/locales/en/translation.json
@@ -30,6 +30,7 @@
     "edit category scaling": "Edit scaling for this category",
     "edit mode": "Edit mode",
     "insert": "$t(common actions.insert)",
+    "insert mca": "Create multi content annotation",
     "items visibility": {
       "collapse all": "Collapse all",
       "expand all": "Expand all",
@@ -54,6 +55,12 @@
     "author": "Created by",
     "created": "on",
     "track": "on",
+    "empty text": "no content",
+    "types": {
+      "free text": "free text",
+      "label": "label",
+      "scaling": "label with scale value"
+    },
     "comments": {
       "author": "Comment by",
       "cancel": "$t(common actions.cancel)",
@@ -70,6 +77,13 @@
       "modified": "modified on {{date}}",
       "placeholder": "Write a comment for this annotation.",
       "title": "Comments"
+    },
+    "add content": {
+      "add free text": "Add free text",
+      "category": "Category:",
+      "free text": "Free Text",
+      "list prompt": "Add content:",
+      "please choose": "Please choose a label"
     },
     "edit": {
       "delete": "Delete annotation.",
@@ -328,6 +342,9 @@
     "player": "Player"
   },
   "version": "Version: {{version}}",
+  "validation errors": {
+    "empty": "This field must not be empty"
+  },
   "common actions": {
     "cancel": "Cancel",
     "close": "Close",

--- a/frontend/style/annotations/annotate.less
+++ b/frontend/style/annotations/annotate.less
@@ -90,6 +90,12 @@ i.check {
 		color: @white;
 		white-space: nowrap;
 	}
+
+	#mca-creator {
+		width: 100%;
+		text-align: center;
+		padding: 1.5em;
+	}
 }
 
 #annotate-container {
@@ -589,4 +595,8 @@ i.check {
 		font-weight: bold;
 		border: 1px solid red;
 	}
+}
+
+.modal-add-free-text textarea {
+    width: calc(100% - 15px);
 }

--- a/frontend/style/annotations/list.less
+++ b/frontend/style/annotations/list.less
@@ -122,11 +122,17 @@
             height: @headerSumHeight;
             border: 1px solid @btnBorder;
             vertical-align: top;
-            line-height: headerHeight;
+            line-height: @headerHeight;
             &.collapse {
                 .link-button();
             }
             padding: @headerPadding;
+        }
+
+        a.btn {
+            height: @headerSumHeight;
+            box-sizing: border-box;
+            border-radius: 0;
         }
 
         /* Content Elements in headerbar*/
@@ -300,6 +306,44 @@
                 font-style: italic;
             }
         }
+
+        .content-items {
+            border-top: 1px solid #ccc;
+            margin-left: 5px;
+            margin-top: 10px;
+            padding-top: 10px;
+            & > div {
+                margin-bottom: 16px;
+            }
+        }
+
+        .content-item:not(.open) {
+            span.icons i:nth-child(1) {
+                display: none;
+            }
+            div.well {
+                display: none;
+            }
+        }
+
+        .content-item.open {
+            span.icons i:nth-child(2) {
+                display: none;
+            }
+        }
+
+        .content-item header {
+            line-height: 25px;
+        }
+
+        .content-item .actions {
+            float: right;
+            margin-right: 0.5em;
+
+            i {
+                margin-left: 8px;
+            }
+        }
     }
 
     .button-bar {
@@ -378,6 +422,46 @@
                 margin-left: 5px;
                 float: right;
             }
+        }
+    }
+}
+
+.label-chooser {
+    a.btn {
+        line-height: 24px;
+        margin: 12px 8px;
+        padding: 0;
+
+        &:not(.btn-primary) {
+            background-image: none;
+        }
+
+        span {
+            background-color: rgba(255,255,255,0.6);
+            display: inline-block;
+            padding: 4px 12px;
+        }
+
+        &:hover span {
+            background-color: rgba(255,255,255,0.4);
+        }
+    }
+}
+
+.scale-chooser {
+    border-collapse: separate;
+    border-spacing: 8px 24px;
+
+    th {
+        font-size: 1.2em;
+        padding-left: 1em;
+        padding-right: 1em;
+    }
+
+    a.btn {
+        line-height: 24px;
+        span {
+            padding: 4px 12px;
         }
     }
 }

--- a/frontend/templates/annotate.tmpl
+++ b/frontend/templates/annotate.tmpl
@@ -41,5 +41,9 @@
             </ul>
             <div class="tab-content" id="label-tabs-contents"></div>
         </div>
+
+        <div id="mca-creator" class="insert-fields">
+            <button id="insert-mca" type="button" class="btn">{{t "annotate.insert mca"}}</button>
+        </div>
     </div>
 </div>

--- a/frontend/templates/content-item-header.tmpl
+++ b/frontend/templates/content-item-header.tmpl
@@ -1,0 +1,19 @@
+<header>
+    <span class="icons">
+        <i class="icon-chevron-down content-item-collapse"></i>
+        <i class="icon-chevron-right content-item-expand"></i>
+    </span>
+    <span class="title">
+        {{> @partial-block }}
+    </span>
+    <span class="actions">
+        {{#if annotation.isMine}}
+        <i class="icon-pencil content-item-edit"
+           title="{{t "annotation.edit.edit"}}"
+        ></i>
+        <i class="icon-trash content-item-trash"
+           title="{{t "annotation.edit.delete"}}"
+        ></i>
+        {{/if}}
+    </span>
+</header>

--- a/frontend/templates/content-type-label.tmpl
+++ b/frontend/templates/content-type-label.tmpl
@@ -1,0 +1,15 @@
+{{#with (withLabel value) as |label|}}
+<div class="content-item" data-position="{{@index}}"{{#if category.settings.color}} style="background-color: {{category.settings.color}}"{{/if}}>
+    {{#> content-item-header annotation=../annotation}}
+        {{#if title}}
+            <b>{{title}}</b>
+        {{^}}
+            <b> {{label.category.name}} </b>
+            <i>({{t "annotation.types.label"}})</i>
+        {{/if}}
+    {{/content-item-header}}
+    <div class="well">
+        <span class="text">{{label.category.name}} - {{label.value}} ({{label.abbreviation}})</span>
+    </div>
+</div>
+{{/with}}

--- a/frontend/templates/content-type-scaling.tmpl
+++ b/frontend/templates/content-type-scaling.tmpl
@@ -1,0 +1,34 @@
+{{#with (withLabel value.label) as |label|}}
+<div class="content-item" data-position="{{@index}}"{{#if category.settings.color}} style="background-color: {{category.settings.color}}"{{/if}}>
+    {{#> content-item-header annotation=../annotation}}
+        {{#if title}}
+            <b>{{title}}</b>
+        {{^}}
+            <b> {{label.category.name}} </b>
+            <i>({{t "annotation.types.scaling"}})</i>
+        {{/if}}
+    {{/content-item-header}}
+    {{/with}}
+
+    <div class="well">
+        {{#with (withScaleValue value.scaling) as |scaleValue|}}
+        <span class="scaling">
+            <span class="read-only" title="{{scaleValue.name}}">{{scaleValue.name}}</span>
+        </span>
+        {{/with}}
+
+
+        {{#with (withLabel value.label) as |label|}}
+        <span class="category" title="{{label.category.name}} - {{label.value}} ({{label.abbreviation}})">
+            <span class="abbreviation">{{label.abbreviation}}</span>
+            <span class="label-value print">{{label.value}}</span>
+            {{/with}}
+
+            {{#with (withScaleValue value.scaling) as |scaleValue|}}
+            <span class="scalevalue print">
+                {{scaleValue.name}} ({{scaleValue.value}})
+            </span>
+            {{/with}}
+        </span>
+    </div>
+</div>

--- a/frontend/templates/content-type-text.tmpl
+++ b/frontend/templates/content-type-text.tmpl
@@ -1,0 +1,6 @@
+<div class="content-item" data-position="{{@index}}">
+    {{#> content-item-header annotation=annotation}}
+        <b>{{#if title}}{{title}}{{^}}{{t "annotation.types.free text"}}{{/if}}</b>
+    {{/content-item-header}}
+    <div class="well">{{displayRaw value}}</div>
+</div>

--- a/frontend/templates/list-annotation-category.tmpl
+++ b/frontend/templates/list-annotation-category.tmpl
@@ -1,0 +1,71 @@
+{{!-- Skalenwerte zuerst --}}
+{{#each content}}
+    {{#ifeq type "scaling"}}
+        <span class="scaling">
+            {{#with (withScaleValue value.scaling) as |scaleValue|}}
+                <span class="read-only" title="{{scaleValue.name}}" >{{scaleValue.name}}</span>
+            {{/with}}
+        </span>
+    {{/ifeq}}
+{{/each}}
+
+{{#each content}}
+
+    {{!-- Annotationen mit Kennzeichen und Skalenwert --}}
+    {{#ifeq type "scaling"}}
+
+      {{#with (withLabel value) as |label|}}
+    <span class="category" title="{{label.category.name}} - {{label.value}} ({{label.abbreviation}})">
+
+      <span class="abbreviation">
+        {{label.abbreviation}}
+      </span>
+
+      <span class="label-value print">
+        {{label.value}}
+      </span>
+      {{/with}}
+
+      {{#with (withScaleValue value.scaling) as |scaleValue|}}
+      <span class="scalevalue print">
+        {{scaleValue.name}} ({{scaleValue.value}})
+      </span>
+      {{/with}}
+
+    </span>
+    {{/ifeq}}
+
+    {{!-- Annotationen mit Kennzeichen --}}
+    {{#ifeq type "label"}}
+
+        {{#with (withLabel value) as |label|}}
+            <span class="category" title="{{label.category.name}} - {{label.value}} ({{label.abbreviation}})">
+                <span class="abbreviation">
+                    {{label.abbreviation}}
+                </span>
+
+                <span class="label-value print">
+                    {{label.value}}
+                </span>
+            </span>
+        {{/with}}
+    {{/ifeq}}
+
+    {{!-- Freitextannotationen --}}
+    {{#ifeq type "text"}}
+        <span class="category">
+            <span class="no-label">
+                {{value}}
+            </span>
+        </span>
+    {{/ifeq}}
+
+{{/each}}
+
+{{#unless content}}
+    <span class="category">
+        <span class="no-label">
+            <i>{{t "annotation.empty text"}}</i>
+        </span>
+    </span>
+{{/unless}}

--- a/frontend/templates/list-annotation-edit.tmpl
+++ b/frontend/templates/list-annotation-edit.tmpl
@@ -45,48 +45,6 @@
                 title="{{t "annotation.you own"}}"
             ></i>
         {{/if}}
-
-        {{#if scalevalues}}
-            <span class="scaling">
-                {{#if isMine}}
-                    <select>
-                        {{#each scalevalues}}
-                            <option
-                                value="{{this.id}}"
-                                {{#if this.isSelected}}
-                                    selected="selected"
-                                {{/if}}
-                            >{{this.name}}</option>
-                        {{/each}}
-                    </select>
-                {{/if}}
-                {{#if scalevalue}}
-                    <span
-                        class="read-only"
-                        title="{{scalevalue.name}}"
-                    >{{scalevalue.name}}</span>
-                {{/if}}
-            </span>
-        {{/if}}
-
-        <span
-            class="category"
-            {{#if label}}
-                title="{{label.category.name}} - {{label.value}} ({{label.abbreviation}})"
-            {{/if}}
-        >
-            {{#if label}}
-                <span class="abbreviation">{{label.abbreviation}}</span>
-                <span class="label-value print">{{label.value}}</span>
-                {{#if scalevalue}}
-                    <span class="scalevalue print">
-                        {{scalevalue.name}} ({{scalevalue.value}})
-                    </span>
-                {{/if}}
-            {{else}}
-                <span class="no-label">{{text}}</span>
-            {{/if}}
-        </span>
     </div>
 
     <div class="right">
@@ -117,26 +75,5 @@
         </i>
     </div>
 </div>
-
-{{#unless label}}
-    <div id="text-container{{id}}" class="in text-container">
-        <span class="text">
-            <span class="freetext">
-                <textarea
-                    placeholder="{{t "annotation.edit.free text placeholder"}}"
-                    style="height: {{textHeight}}px"
-                >{{text}}</textarea>
-            </span>
-            <div class="button-bar">
-                <button type="button" class="btn">
-                    Cancel
-                </button>
-                <button type="submit" class="btn btn-primary">
-                    OK
-                </button>
-            </div>
-        </span>
-    </div>
-{{/unless}}
 
 <div class="comments"></div>

--- a/frontend/templates/list-annotation-expanded.tmpl
+++ b/frontend/templates/list-annotation-expanded.tmpl
@@ -26,36 +26,6 @@
                 title="{{t "annotation.you own"}}"
             ></i>
         {{/if}}
-
-        {{#if scalevalue}}
-            <span class="scaling">
-                {{#if scalevalue}}
-                    <span
-                        class="read-only"
-                        title="{{scalevalue.name}}"
-                    >{{scalevalue.name}}</span>
-                {{/if}}
-            </span>
-        {{/if}}
-
-        <span
-            class="category"
-            {{#if label}}
-                title="{{label.category.name}} - {{label.value}} ({{label.abbreviation}})"
-            {{/if}}
-        >
-            {{#if label}}
-                <span class="abbreviation">{{label.abbreviation}}</span>
-                <span class="label-value print">{{label.value}}</span>
-                {{#if scalevalue}}
-                    <span class="scalevalue print">
-                        {{scalevalue.name}} ({{scalevalue.value}})
-                    </span>
-                {{/if}}
-            {{else}}
-                <span class="no-label">{{text}}</span>
-            {{/if}}
-        </span>
     </div>
 
     <div class="right">
@@ -96,13 +66,28 @@
         {{t "annotation.track"}}
         <span class="track">{{track}}</span>
     </div>
-    <span class="text freetext read-only">
-        {{#if label}}
-            {{label.value}}
-        {{else}}
-            {{{textReadOnly}}}
-        {{/if}}
-    </span>
+
+    <div id="accordion-container-{{id}}" class="accordion content-items">
+        {{#each content}}
+            {{> (lookup . 'type') annotation=..}}
+        {{/each}}
+    </div>
+
+    {{#if isMine}}
+        <div>
+            <span>{{t "annotation.add content.list prompt"}}</span>
+            <button class="btn add-free-text-content" type="button">
+                {{t "annotation.add content.free text"}}
+            </button>
+
+            {{#each categories}}
+            <button class="btn add-labelled-content" type="button" data-category="{{id}}" {{#if settings.color}}style="background-color:{{settings.color}};background-image: none;"{{/if}}>
+                {{t "annotation.add content.category"}} {{name}}
+            </button>
+            {{/each}}
+
+        </div>
+    {{/if}}
 </div>
 
 <div class="comments"></div>

--- a/frontend/templates/list-annotation.tmpl
+++ b/frontend/templates/list-annotation.tmpl
@@ -27,39 +27,7 @@
             ></i>
         {{/if}}
 
-        {{#if scalevalue}}
-            <span class="scaling">
-                {{#if scalevalue}}
-                    <span
-                        class="read-only"
-                        title="{{scalevalue.name}}"
-                    >{{scalevalue.name}}</span>
-                {{/if}}
-            </span>
-        {{/if}}
-
-        <span
-            class="category"
-            {{#if label}}
-                title="{{label.category.name}} - {{label.value}} ({{label.abbreviation}})"
-            {{/if}}
-        >
-            {{#if label}}
-                <span class="abbreviation">
-                    {{label.abbreviation}}
-                </span>
-                <span class="label-value print">
-                    {{label.value}}
-                </span>
-                {{#if scalevalue}}
-                    <span class="scalevalue print">
-                        {{scalevalue.name}} ({{scalevalue.value}})
-                    </span>
-                {{/if}}
-            {{else}}
-                <span class="no-label">{{text}}</span>
-            {{/if}}
-        </span>
+        {{> category}}
     </div>
 
     <div class="right">

--- a/frontend/templates/modal-add-free-text.tmpl
+++ b/frontend/templates/modal-add-free-text.tmpl
@@ -1,0 +1,11 @@
+<textarea
+    required
+    placeholder="{{t "annotate.new.placeholder"}}"
+    title="{{t "annotate.new.title"}}"
+    rows="3"></textarea>
+
+{{#error}}
+<div class="alert alert-error">
+    {{t "validation errors.empty"}}
+</div>
+{{/error}}

--- a/frontend/templates/modal-add-labelled.tmpl
+++ b/frontend/templates/modal-add-labelled.tmpl
@@ -1,0 +1,12 @@
+<header>
+    {{#if contentItem.title}}
+    <h2>{{contentItem.title}}</h2>
+    {{/if}}
+    <h3>{{t "annotation.add content.please choose"}}</h3>
+</header>
+
+{{#if scale}}
+{{> scaleChooser }}
+{{else}}
+{{> labelChooser }}
+{{/if}}

--- a/frontend/templates/modal-container.tmpl
+++ b/frontend/templates/modal-container.tmpl
@@ -1,0 +1,13 @@
+<div class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="modal-label-{{cid}}" aria-hidden="true">
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+        <h3 id="modal-label-{{cid}}">{{header}}</h3>
+    </div>
+    <div class="modal-body"></div>
+    <div class="modal-footer">
+        <button class="btn" data-dismiss="modal" aria-hidden="true">{{t "common actions.cancel"}}</button>
+        {{#if buttonText}}
+            <button class="btn btn-primary">{{buttonText}}</button>
+        {{/if}}
+    </div>
+</div>

--- a/frontend/templates/modal-edit-free-text.tmpl
+++ b/frontend/templates/modal-edit-free-text.tmpl
@@ -1,0 +1,14 @@
+{{#if contentItem.title}}
+<header><h2>{{contentItem.title}}</h2></header>
+{{/if}}
+<textarea
+    required
+    placeholder="{{t "annotate.new.placeholder"}}"
+    title="{{t "annotate.new.title"}}"
+    rows="3">{{contentItem.value}}</textarea>
+
+{{#error}}
+<div class="alert alert-error">
+    {{t "validation errors.empty"}}
+</div>
+{{/error}}

--- a/frontend/templates/partial-label-chooser.tmpl
+++ b/frontend/templates/partial-label-chooser.tmpl
@@ -1,0 +1,8 @@
+<div class="label-chooser">
+    {{#each labels as |label|}}
+    <a class="btn label{{#if label.selected}} btn-primary{{/if}}" data-label="{{label.id}}"
+        href="#"{{#if ../color}} style="background-color:{{../color}};"{{/if}}>
+        <span> {{label.abbreviation}} </span>
+    </a>
+    {{/each}}
+</div>

--- a/frontend/templates/partial-scale-chooser.tmpl
+++ b/frontend/templates/partial-scale-chooser.tmpl
@@ -1,0 +1,15 @@
+<table class="scale-chooser">
+    {{#each labels as |label|}}
+    <tr>
+        <th{{#if ../color}} style="background-color:{{../color}};"{{/if}}>{{label.value}}</th>
+        {{#each ../scale.scaleValues}}
+        <td>
+            <a class="btn label-and-scale{{#if label.selected}}{{#if selected}} btn-primary{{/if}}{{/if}}"
+                href="#" data-label="{{../id}}" data-scalevalue="{{id}}">
+                <span> {{name}} ({{value}})</span>
+            </a>
+        </td>
+        {{/each}}
+    </tr>
+    {{/each}}
+</table>


### PR DESCRIPTION
This pull request will contain all changes required to enable multi content annotations.

What does this necessitate:

* [X] Change the data model
* [X] Add a way to add an empty multi content annotation
* [x] Change the way annotations are shown in the list of annotations
* [x] Enable adding new content to a multi content annotation
* [x] Enable dropping content from a multi content annotation
* [x] Enable editing content of a multi content annotation
* [x] Change the way annotations are shown in the timeline
* [x] Refactor existing code to use the new data structuring

Refs #370 