### PR TITLE
Don't override timeline item's class name when (de-)activating

### DIFF
--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -484,17 +484,26 @@ define([
                     this.items.update(_.map(previousAnnotations, function (annotation) {
                         return {
                             id: annotation.id,
-                            className: ""
+                            className: _.without(
+                                getClassName.call(this, annotation).split(" "),
+                                "active"
+                            ).join(' ')
                         };
                     }, this));
                     this.items.update(_.map(currentAnnotations, function (annotation) {
                         return {
                             id: annotation.id,
-                            className: "active"
+                            className: _.uniq(
+                                getClassName.call(this, annotation).split(" ")
+                                    .concat(["active"])
+                            ).join(' ')
                         };
                     }, this));
                 }
             );
+            function getClassName(annotation) {
+                return this.items.get(annotation.id).className || "";
+            }
             // Long-pressing is normally only used for multiple selections,
             // which we don't support.
             // Additionally this is a problem when you select an item


### PR DESCRIPTION
Fixes #357 