### PR TITLE
Make the distinction between active and selected annotations more consistent and less confusing

### DIFF
--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -104,8 +104,8 @@ define(["jquery",
 
             /**
              * Initialize the tool
-             * @alias   annotationTool.start
-             * @param  {module:annotation-tool-configuration.Configuration} config The tool configuration
+             * @alias annotationTool.start
+             * @param {module:annotation-tool-configuration.Configuration} config The tool configuration
              */
             start: function (config) {
                 _.bindAll(this,
@@ -176,7 +176,7 @@ define(["jquery",
 
             /**
              * Listen and retrigger timeupdate event from player adapter events with added intervals
-             * @alias   annotationTool.onTimeUpdate
+             * @alias annotationTool.onTimeUpdate
              */
             onTimeUpdate: function () {
                 var currentPlayerTime = this.playerAdapter.getCurrentTime();
@@ -206,7 +206,7 @@ define(["jquery",
 
             /**
              * Add a timeupdate listener with the given interval
-             * @alias   annotationTool.addTimeupdateListener
+             * @alias annotationTool.addTimeupdateListener
              * @param {Object} callback the listener callback
              * @param {Number} interval the interval between each timeupdate event
              */
@@ -234,9 +234,9 @@ define(["jquery",
 
             /**
              * Remove the given timepudate listener
-             * @alias   annotationTool.removeTimeupdateListener
+             * @alias annotationTool.removeTimeupdateListener
              * @param {Object} callback the listener callback
-             * @param {Number} (interval) the interval between each timeupdate event
+             * @param {Number} interval the interval between each timeupdate event
              */
             removeTimeupdateListener: function (callback, interval) {
                 var timeupdateEvent = this.EVENTS.TIMEUPDATE;
@@ -287,7 +287,7 @@ define(["jquery",
 
             /**
              * Returns the current selection of the tool
-             * @alias   annotationTool.getSelection
+             * @alias annotationTool.getSelection
              * @return {Annotation} The current selection or undefined if no selection.
              */
             getSelection: function () {
@@ -296,7 +296,7 @@ define(["jquery",
 
             /**
              * Informs if there is or not some items selected
-             * @alias   annotationTool.hasSelection
+             * @alias annotationTool.hasSelection
              * @return {Boolean} true if an annotation is selected or false.
              */
             hasSelection: function () {
@@ -305,7 +305,7 @@ define(["jquery",
 
             /**
              * Update the ordering of the tracks and alert everyone who is interested.
-             * @alias  annotationTool.orderTracks
+             * @alias annotationTool.orderTracks
              * @param {Array} order The new track order
              */
             orderTracks: function (order) {
@@ -334,7 +334,7 @@ define(["jquery",
 
             /**
              * Get all annotations that cover a given point in time.
-             * @alias   annotationTool.getCurrentAnnotations
+             * @alias annotationTool.getCurrentAnnotations
              */
             getCurrentAnnotations: function () {
                 return this.video.get("tracks")
@@ -350,7 +350,7 @@ define(["jquery",
 
             /**
              * Listener for player "timeupdate" event to highlight the current annotations
-             * @alias   annotationTool.updateSelectionOnTimeUpdate
+             * @alias annotationTool.updateSelectionOnTimeUpdate
              */
             updateSelectionOnTimeUpdate: function () {
                 var previousAnnotations = this.currentAnnotations || [];
@@ -407,9 +407,9 @@ define(["jquery",
 
             /**
              * Get the track with the given Id
-             * @alias   annotationTool.getTrack
+             * @alias annotationTool.getTrack
              * @param  {String} id The track Id
-             * @return {Object}    The track object or undefined if not found
+             * @return {Object} The track object or undefined if not found
              */
             getTrack: function (id) {
                 if (_.isUndefined(this.video)) {
@@ -422,8 +422,8 @@ define(["jquery",
 
             /**
              * Get all the tracks
-             * @alias   annotationTool.getTracks
-             * @return {Object}    The list of the tracks
+             * @alias annotationTool.getTracks
+             * @return {Object} The list of the tracks
              */
             getTracks: function () {
                 if (_.isUndefined(this.video)) {
@@ -436,9 +436,9 @@ define(["jquery",
 
             /**
              * Get the track with the given Id
-             * @alias   annotationTool.getTrack
-             * @param  {String} id The track Id
-             * @return {Object}    The track object or undefined if not found
+             * @alias annotationTool.getTrack
+             * @param {String} id The track Id
+             * @return {Object} The track object or undefined if not found
              */
             getSelectedTrack: function () {
                 return this.selectedTrack;
@@ -446,8 +446,8 @@ define(["jquery",
 
             /**
              * Select the given track
-             * @alias   annotationTool.selectTrack
-             * @param  {Object} track the track to select
+             * @alias annotationTool.selectTrack
+             * @param {Object} track the track to select
              */
             selectTrack: function (track) {
                 if (track === this.selectedTrack) return;
@@ -459,10 +459,10 @@ define(["jquery",
 
             /**
              * Get the annotation with the given Id
-             * @alias   annotationTool.getAnnotation
-             * @param  {String} annotationId The annotation
-             * @param  {String} (trackId)      The track Id (Optional)
-             * @return {Object}   The annotation object or undefined if not found
+             * @alias annotationTool.getAnnotation
+             * @param {String} annotationId The annotation
+             * @param {String} trackId The track Id (Optional)
+             * @return {Object} The annotation object or undefined if not found
              */
             getAnnotation: function (annotationId, trackId) {
                 var track,
@@ -499,9 +499,9 @@ define(["jquery",
 
             /**
              * Get an array containning all the annotations or only the ones from the given track
-             * @alias   annotationTool.getAnnotations
-             * @param  {String} (trackId)      The track Id (Optional)
-             * @return {Array}   The annotations
+             * @alias annotationTool.getAnnotations
+             * @param {String} trackId The track Id (Optional)
+             * @return {Array} The annotations
              */
             getAnnotations: function (trackId) {
                 var track,

--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -261,12 +261,14 @@ define(["jquery",
              * Set the given annotation(s) as current selection
              * @alias annotationTool.setSelection
              * @param {Array} selection The new selection
+             * @param {Boolean} noToggle don't toggle already selected annotations
              */
-            setSelection: function (selection) {
+            setSelection: function (selection, noToggle) {
                 if (this.selection) {
                     this.stopListening(this.selection, "destroy", this.onDestroyRemoveSelection);
 
                     if (selection && this.selection.id === selection.id) {
+                        if (noToggle) return;
                         selection = null;
                     }
                 } else if (!selection) return;  // Both selections are `null`, nothing to do

--- a/frontend/js/views/list-annotation.js
+++ b/frontend/js/views/list-annotation.js
@@ -432,10 +432,14 @@ define(["jquery",
              * @alias module:views-list-annotation.ListAnnotation#onSelect
              * @param {Event} event the click event
              */
-            onSelect: _.debounce(function (event) {
-                if (event.originalEvent.detail > 1) return;
-                annotationTool.setSelection(this.model);
-            }, 100),
+            onSelect: function (event) {
+                annotationTool.setSelection(
+                    this.model,
+                    // Toggle selection on single click,
+                    // unconditionally select on double click
+                    event.originalEvent.detail > 1
+                );
+            },
 
             /**
              * Navigate to this view's annotation

--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -504,14 +504,11 @@ define([
             // the item would just be deselected in that scenario.
             this.timeline.itemSet.hammer.off("press");
             this.timeline.on("select", _.bind(function (properties) {
-                if (properties.event.tapCount > 1) {
-                    // Restore the selection
-                    var selection = annotationTool.getSelection();
-                    this.timeline.setSelection(selection && selection.id);
-                    return;
-                }
                 annotationTool.setSelection(
-                    this.items.get(properties.items[0]).model
+                    this.items.get(properties.items[0]).model,
+                    // Toggle selection on single click,
+                    // unconditionally select on double click
+                    properties.event.tapCount > 1
                 );
             }, this));
 

--- a/frontend/style/annotations/base_style.less
+++ b/frontend/style/annotations/base_style.less
@@ -193,10 +193,14 @@ input, textarea, select, .uneditable-input {
 }
 
 .active-annotation {
-    --annotation-highlight-color: orange;
-    box-shadow: inset 0px 0px 2px 1px var(--annotation-highlight-color);
+    box-shadow: inset 0px 0px 2px 1px red;
 }
 .selected-annotation {
-    .active-annotation();
-    --annotation-highlight-color: red;
+    background-image: repeating-linear-gradient(
+        315deg,
+        transparent,
+        transparent 10px,
+        rgba(0, 0, 0, 0.15) 10px,
+        rgba(0, 0, 0, 0.15) 20px
+    );
 }

--- a/frontend/style/annotations/list.less
+++ b/frontend/style/annotations/list.less
@@ -69,7 +69,6 @@
             line-height: @headerSumHeight;
         }
 
-        background-color: @white;
         border-left: 1px solid @gray;
         border-right: 1px solid @gray;
         border-top: 1px solid @gray;

--- a/frontend/style/annotations/list.less
+++ b/frontend/style/annotations/list.less
@@ -97,7 +97,6 @@
         }
 
         &.selected {
-            .active();
             .selected-annotation();
         }
 

--- a/frontend/style/annotations/timeline.less
+++ b/frontend/style/annotations/timeline.less
@@ -65,7 +65,7 @@
 
     &.active {
         border-color: @gray;
-        background-color: @grayLight;
+        background-color: @grayLighter;
         .active-annotation();
     }
 


### PR DESCRIPTION
This should address all the remaining issues of, and thus close #359.

Specifically:

* Double clicking annotations in either the timeline or the list view now unconditionally selects the annotation, no matter it's previous state
* This is not a change, but to clarify: Double clicking also brings the play head to the corresponding annotation, ...
* while single clicking still doesn't; it only selects/deselects an annotation (depending on the previous state)
* Active annotations got their red "border" back \o/
* The selected annotation is now cross-hatched in the background

I hope I remembered our compromise correctly, @dagraf; feel free to correct me.