### PR TITLE
Preserve annotation anchor coloring even for non-selected, active annotations

### DIFF
--- a/frontend/style/annotations/base_style.less
+++ b/frontend/style/annotations/base_style.less
@@ -192,10 +192,11 @@ input, textarea, select, .uneditable-input {
     }
 }
 
-@annotationSelectionColor: rgba(0, 0, 0, 0.125);
+@annotationSelectionColor: rgba(0, 0, 0, 0.15);
 
 .selectable-annotation {
     cursor: pointer;
+    color: black;
     &:hover {
         background-image: linear-gradient(@annotationSelectionColor, @annotationSelectionColor);
     }

--- a/frontend/style/annotations/list.less
+++ b/frontend/style/annotations/list.less
@@ -174,7 +174,6 @@
         .start,.end {
             display: inline-block;
             position: relative;
-            color: @black;
 
             &.no-duration {
                 display: none;
@@ -187,7 +186,6 @@
                 margin: 0;
                 padding: 0;
                 box-shadow: none;
-                color: @black;
                 text-align: center;
                 font-family: monospace;
                 background: transparent;
@@ -203,7 +201,6 @@
                 margin: 0;
                 padding: 0;
                 box-shadow: none;
-                color: @black;
                 text-align: center;
                 font-family: monospace;
                 background: @white;
@@ -257,10 +254,8 @@
         }
 
         span.category {
-            color: @gray;
-
             span.abbreviation {
-                color: @black;
+                font-weight: bold;
             }
 
             span.category-name {

--- a/frontend/style/annotations/timeline.less
+++ b/frontend/style/annotations/timeline.less
@@ -9,6 +9,18 @@
             border-bottom: 1px solid #bfbfbf;
         }
     }
+
+    // Make the "border" of the annotation anchors
+    // (which consist of nothing but (rounded) borders)
+    // transparent, for the background to shine through.
+    // The background is potentially the color of the category
+    // of the annotation.
+    // Do this here, globally, but also with higher specificity
+    // than the default styles provided by vis.js,
+    // so that it works for all combinations of the selected and active states.
+    .vis-item.vis-dot {
+        border-color: rgba(0, 0, 0, 0.25);
+    }
 }
 
 .vis-timeline {
@@ -73,9 +85,6 @@
 
     &.vis-selected {
         border-color: @gray;
-        &.vis-dot {
-            border-color: rgba(0, 0, 0, 0.25);
-        }
         background-color: @grayLighter;
         .selected-annotation();
     }


### PR DESCRIPTION
This is an amendmend to #398, and should address @dagraf's [comment](https://github.com/opencast/annotation-tool/issues/358#issuecomment-658118100) on #358. It should thus close #358.