### PR TITLE
Update the color of structured annotations in the list view ...

### DIFF
--- a/frontend/js/models/annotation.js
+++ b/frontend/js/models/annotation.js
@@ -250,12 +250,31 @@ define(["underscore",
 
             /**
              * Access an annotations category, if it has any.
+             * Note that this returns <code>undefined</code>
+             * if the category has been deleted!
              * @alias module:models-annotation.Annotation#category
              * @return {Category} The category this annotations label belongs to, if it has a label
              */
             category: function () {
                 var label = this.get("label");
                 return label && annotationTool.video.get("categories").get(label.category.id);
+            },
+
+            /**
+             * Get the display color of an annotation.
+             * This is determined by the color of the category of its label,
+             * if it has any.
+             * Free text annotations return <code>undefined</code>
+             * @alias module:models-annotation.Annotation#category
+             * @return {string} a CSS color value
+             */
+            color: function () {
+                var category = this.category();
+                var label = this.get("label");
+                return category && category.get("settings").color ||
+                    // If the category is a deleted one, we don't get it from `category`.
+                    // However, the label should still have it.
+                    label && label.category.settings.color;
             }
         });
 

--- a/frontend/js/views/list-annotation.js
+++ b/frontend/js/views/list-annotation.js
@@ -366,7 +366,10 @@ define(["jquery",
                     category = annotationTool.video.get("categories").get(this.model.get("label").category.id);
 
                     title = modelJSON.label.abbreviation + " - " + modelJSON.label.value;
-                    this.$el.css("background-color", category.get("settings").color);
+                    var color = category
+                        ? category.get("settings").color
+                        : modelJSON.label.category.settings.color;
+                    this.$el.css("background-color", color);
                 } else {
                     title = modelJSON.text;
                 }

--- a/frontend/js/views/list-annotation.js
+++ b/frontend/js/views/list-annotation.js
@@ -120,6 +120,16 @@ define(["jquery",
 
                 this.currentState = ListAnnotation.STATES.COLLAPSED;
 
+                // TODO This should actually be done in the list view,
+                //   instead of the individual list item views.
+                //   However, the list view is not designed to be rerendered, currently.
+                //   Alternatively we could listen to the `model`-s category,
+                //   but that's more complicated, because the entire category
+                //   as opposed to just a property of it could change,
+                //   even to something like "no category".
+                //   However, that would probably be better for performance.
+                this.listenTo(annotationTool.video.get("categories"), "change", this.render);
+
                 return this.render();
             },
 
@@ -352,9 +362,16 @@ define(["jquery",
                 modelJSON.duration     = (modelJSON.duration || 0.0);
                 modelJSON.textHeight   = this.$el.find("span.freetext").height();
 
-                if (modelJSON.isMine && this.scale && modelJSON.label.category.scale_id) {
+                if (modelJSON.label) {
                     category = annotationTool.video.get("categories").get(this.model.get("label").category.id);
 
+                    title = modelJSON.label.abbreviation + " - " + modelJSON.label.value;
+                    this.$el.css("background-color", category.get("settings").color);
+                } else {
+                    title = modelJSON.text;
+                }
+
+                if (modelJSON.isMine && this.scale && modelJSON.label.category.scale_id) {
                     // Check if the category is still linked to the video to get the current version
                     if (category) {
                         modelJSON.hasScale = category.get("settings").hasScale;
@@ -379,15 +396,6 @@ define(["jquery",
                 modelJSON.end = modelJSON.start + modelJSON.duration;
 
                 this.$el.html(this.currentState.render(modelJSON));
-
-                if (!_.isUndefined(modelJSON.label) && !_.isNull(modelJSON.label)) {
-                    title = modelJSON.label.abbreviation + " - " + modelJSON.label.value;
-                    if (!_.isUndefined(modelJSON.label.category)) {
-                        this.$el.css("background-color", modelJSON.label.category.settings.color);
-                    }
-                } else {
-                    title = modelJSON.text;
-                }
 
                 if (this.getState() == ListAnnotation.STATES.EDIT) {
                     title += " edit-on";

--- a/frontend/js/views/list-annotation.js
+++ b/frontend/js/views/list-annotation.js
@@ -363,13 +363,10 @@ define(["jquery",
                 modelJSON.textHeight   = this.$el.find("span.freetext").height();
 
                 if (modelJSON.label) {
-                    category = annotationTool.video.get("categories").get(this.model.get("label").category.id);
+                    category = this.model.category();
 
                     title = modelJSON.label.abbreviation + " - " + modelJSON.label.value;
-                    var color = category
-                        ? category.get("settings").color
-                        : modelJSON.label.category.settings.color;
-                    this.$el.css("background-color", color);
+                    this.$el.css("background-color", this.model.color());
                 } else {
                     title = modelJSON.text;
                 }


### PR DESCRIPTION
... as soon as the color of a category changes.

Note: This is a quick fix that we need for some upcoming changes,
and the quality of the code surrounding these changes does not warrant
a clean solution right now.

Let's just hope we will get to it one day.

This should solve at least part of #425.