### PR TITLE
Fix deleting scales

### DIFF
--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -1096,7 +1096,7 @@ define(["jquery",
                 },
                 destroy: function (scale, callback) {
                     _.invoke(
-                        _.clone(scale.get("scalevalues").models),
+                        _.clone(scale.get("scaleValues").models),
                         "destroy",
                         { error: function () { throw "cannot delete scale value"; } }
                     );

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -768,7 +768,7 @@
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },


### PR DESCRIPTION
Deleting a scale currently does not work in the sense that when you hit the delete button in the scale editor, nothing seems to happen. The console spews a few errors at you, though.

This **should** fix that.