### PR TITLE
Encode options in i18next nestings as proper JSON

### DIFF
--- a/frontend/locales/de/translation.json
+++ b/frontend/locales/de/translation.json
@@ -96,8 +96,8 @@
   "delete modal": {
     "cancel": "$t(common actions.cancel)",
     "delete": "$t(common actions.delete)",
-    "title": "$t(models.nominative, {'context': {{context}} }) löschen",
-    "warning": "Wollen Sie $t(models.accusative, {'context': {{context}} }) „{{content}}“ wirklich löschen?"
+    "title": "$t(models.nominative, {\"context\": \"{{context}}\" }) löschen",
+    "warning": "Wollen Sie $t(models.accusative, {\"context\": \"{{context}}\" }) „{{content}}“ wirklich löschen?"
   },
   "description": "Werkzeug zur Videoannotation",
   "list annotation": {


### PR DESCRIPTION
Firefox in particular seems to take this very seriously. :wink: 

This came up during the review of #440. Thx, @Arnei. :smile: 