### PR TITLE
Always start the scale editor in "not-edit mode"

### DIFF
--- a/frontend/js/views/scale-editor.js
+++ b/frontend/js/views/scale-editor.js
@@ -300,18 +300,9 @@ define(["jquery",
                     this.currentScaleId = this.$el.find("select#scale-id").val();
                     this.currentScale = annotationTool.video.get("scales").get(this.currentScaleId);
 
-                    if (this.currentScale && this.currentScale.isEditable()) {
-                        if (this.isInEditMode) {
-                            this.$el.find(".edit-scale").hide();
-                        } else {
-                            this.$el.find(".edit-scale").show();
-                        }
-                        this.renderEditContent(this.currentScale);
-                    } else {
-                        this.isInEditMode = false;
-                        this.$el.find(".edit-scale").hide();
-                        this.$el.find(".modal-body").hide();
-                    }
+                    this.isInEditMode = false;
+                    this.$el.find(".edit-scale").show();
+                    this.$el.find(".modal-body").hide();
                 },
 
                 /**
@@ -368,6 +359,7 @@ define(["jquery",
                     this.isInEditMode = true;
                     this.$el.find("#save-scale").text(this.TITLES.SAVE_BUTTON);
                     this.$el.find(".edit-scale").hide();
+                    this.renderEditContent(this.currentScale);
                     this.$el.find(".modal-body").show();
                 },
 

--- a/frontend/js/views/scale-editor.js
+++ b/frontend/js/views/scale-editor.js
@@ -46,9 +46,9 @@ define(["jquery",
                  * @type {map}
                  */
                 TITLES: {
-                    CATEGORY_EDIT  : i18next.t("scale editor.edit category scale"),
+                    CATEGORY_EDIT: i18next.t("scale editor.edit category scale"),
                     STANDALONE_EDIT: i18next.t("scale editor.edit scales"),
-                    SAVE_BUTTON    : i18next.t("scale editor.save")
+                    SAVE_BUTTON: i18next.t("scale editor.save")
                 },
 
                 /**
@@ -58,7 +58,7 @@ define(["jquery",
                  */
                 EMPTY_SCALE: {
                     name: i18next.t("scale editor.no scale"),
-                    id  : "NO"
+                    id: "NO"
                 },
 
                 /**
@@ -130,7 +130,7 @@ define(["jquery",
                     // Type use for delete operation
                     this.scaleDeleteType = annotationTool.deleteOperation.targetTypes.SCALE;
 
-                    this.$el.modal({show: true, backdrop: false, keyboard: false });
+                    this.$el.modal({ show: true, backdrop: false, keyboard: false });
                     this.$el.modal("hide");
                 },
 
@@ -141,8 +141,8 @@ define(["jquery",
                  */
                 show: function (category) {
                     var templateParams = {
-                            title: this.TITLES.STANDALONE_EDIT
-                        };
+                        title: this.TITLES.STANDALONE_EDIT
+                    };
 
                     this.EMPTY_SCALE.isSelected = false;
 
@@ -178,8 +178,8 @@ define(["jquery",
 
                     if (this.currentScaleId) {
                         selectedScale = _.find(scales, function (scale) {
-                                                return scale.id === this.currentScaleId;
-                                            }, this);
+                            return scale.id === this.currentScaleId;
+                        }, this);
 
                         if (selectedScale) {
                             selectedScale.isSelected = true;
@@ -322,7 +322,7 @@ define(["jquery",
                     this.isInEditMode = true;
 
                     this.currentScale = annotationTool.video.get("scales").create({
-                        name  : i18next.t("scale editor.new scale.name"),
+                        name: i18next.t("scale editor.new scale.name"),
                         access: this.currentCategory.get("access")
                     });
 
@@ -342,7 +342,7 @@ define(["jquery",
                 createScaleValue: function () {
                     this.currentScale.get("scaleValues").create({
                         order: this.$el.find(".scale-value").length,
-                        name : i18next.t("scale editor.new scale.value"),
+                        name: i18next.t("scale editor.new scale.value"),
                         value: 0,
                         access: this.currentCategory.get("access")
                     });
@@ -422,6 +422,7 @@ define(["jquery",
                     this.delegateEvents(this.events);
                 }
             });
-            return ScaleEditor;
-        }
+
+        return ScaleEditor;
+    }
 );

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -768,7 +768,7 @@
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },


### PR DESCRIPTION
Previously it already showed the editing interface for the scale
of the category you got to the dialog with. It wasn't fully in edit
mode yet, though, so edits could get lost.