### PR TITLE
Fix double modals for scale(-value) deletion

### DIFF
--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -67,7 +67,7 @@ define(["jquery",
                  * @param {Object} target Element to be delete
                  * @param {TargetsType} type Type of the target to be deleted
                  */
-                start: function (target, type, callback) {
+                start: function (target, type, confirmCallback, closeCallback) {
 
                     if (!target.isEditable()) {
                         alerts.warning("You are not authorized to deleted this " + type.name + "!");
@@ -80,8 +80,8 @@ define(["jquery",
                     }));
 
                     function confirm() {
-                        type.destroy(target, callback);
                         deleteModal.modal("toggle");
+                        type.destroy(target, confirmCallback);
                     }
                     function confirmWithEnter(event) {
                         if (event.keyCode === 13) {
@@ -99,6 +99,7 @@ define(["jquery",
                     deleteModal.one("hide", function () {
                         $(window).off("keypress", confirmWithEnter);
                         deleteModal.remove();
+                        if (closeCallback) closeCallback();
                     });
 
                     // Show the modal

--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -1096,7 +1096,7 @@ define(["jquery",
                 },
                 destroy: function (scale, callback) {
                     _.invoke(
-                        _.clone(scale.get("scalevalues").models),
+                        _.clone(scale.get("scaleValues").models),
                         "destroy",
                         { error: function () { throw "cannot delete scale value"; } }
                     );

--- a/frontend/js/views/scale-editor.js
+++ b/frontend/js/views/scale-editor.js
@@ -130,7 +130,7 @@ define(["jquery",
                     // Type use for delete operation
                     this.scaleDeleteType = annotationTool.deleteOperation.targetTypes.SCALE;
 
-                    this.$el.modal({show: true, backdrop: false, keyboard: false });
+                    this.$el.modal({ show: true, backdrop: false, keyboard: false });
                     this.$el.modal("hide");
                 },
 
@@ -354,10 +354,19 @@ define(["jquery",
                  * @alias module:views-scale-editor.ScaleEditor#deleteScale
                  */
                 deleteScale: function (event) {
-                    var self = this;
-
                     event.stopImmediatePropagation();
-                    annotationTool.deleteOperation.start(this.currentScale, this.scaleDeleteType, self.cancel);
+                    this.$el.modal("hide");
+                    annotationTool.deleteOperation.start(
+                        this.currentScale,
+                        this.scaleDeleteType,
+                        _.bind(function () {
+                            this.$el.modal("show");
+                            this.cancel();
+                        }, this),
+                        _.bind(function () {
+                            this.$el.modal("show");
+                        }, this)
+                    );
                 },
 
                 /**
@@ -400,6 +409,7 @@ define(["jquery",
                         addScaleValue = function (scaleValue, index) {
                             var self = this,
                                 params = {
+                                    scaleEditor: this,
                                     model: scaleValue,
                                     onChange: function () {
                                         renderScaleValues.call(self);

--- a/frontend/js/views/scalevalue-editor.js
+++ b/frontend/js/views/scalevalue-editor.js
@@ -79,11 +79,12 @@ define(["underscore",
                               "getSortedCollection",
                               "deleteScaleValue");
 
-                    this.model    = attr.model;
-                    this.isNew    = attr.isNew;
-                    this.next     = attr.next;
+                    this.model = attr.model;
+                    this.isNew = attr.isNew;
+                    this.next = attr.next;
                     this.previous = attr.previous;
                     this.onChange = attr.onChange;
+                    this.scaleEditor = attr.scaleEditor;
 
                     this.scaleValueDeleteType = annotationTool.deleteOperation.targetTypes.SCALEVALUE;
                     this.setElement(this.scaleValueEditorTemplate(this.model.toJSON()));
@@ -182,26 +183,35 @@ define(["underscore",
                  * @param  {Event} event Event object
                  */
                 deleteScaleValue: function (event) {
-                    var self = this,
-                        sortedCollection = self.getSortedCollection();
+                    var sortedCollection = this.getSortedCollection();
 
                     event.stopImmediatePropagation();
-                    annotationTool.deleteOperation.start(this.model, this.scaleValueDeleteType, function () {
-                        var currentOrder = self.model.get("order"),
-                            i;
+                    this.scaleEditor.$el.modal("hide");
+                    annotationTool.deleteOperation.start(
+                        this.model,
+                        this.scaleValueDeleteType,
+                        _.bind(function () {
+                            this.scaleEditor.$el.modal("show");
 
-                        // Update order for following item
-                        if (currentOrder < (sortedCollection.length - 1)) {
-                            for (i = currentOrder + 1; i < sortedCollection.length; i++) {
-                                sortedCollection[i].set("order", i - 1);
-                                sortedCollection[i].save();
+                            var currentOrder = this.model.get("order"),
+                                i;
+
+                            // Update order for following item
+                            if (currentOrder < (sortedCollection.length - 1)) {
+                                for (i = currentOrder + 1; i < sortedCollection.length; i++) {
+                                    sortedCollection[i].set("order", i - 1);
+                                    sortedCollection[i].save();
+                                }
                             }
-                        }
 
-                        self.isDeleted = true;
-                        self.onChange();
-                        self.remove();
-                    });
+                            this.isDeleted = true;
+                            this.onChange();
+                            this.remove();
+                        }, this),
+                        _.bind(function () {
+                            this.scaleEditor.$el.modal("show");
+                        }, this)
+                    );
                 },
 
                 /**

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -768,7 +768,7 @@
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },


### PR DESCRIPTION
Actually one solution to #442, just hiding one modal as long as another is open, was relatively easy to implement in the particular case of the delete modal and the scale editor being open at the same time.

Note that this includes #440, since that's the only way to even observe the faulty behavior right now.