### PR TITLE
More scale editor improvements

### DIFF
--- a/frontend/js/views/scale-editor.js
+++ b/frontend/js/views/scale-editor.js
@@ -172,14 +172,14 @@ define(["jquery",
                         selectedScale;
 
                     // Filter by access values
-                    scales = _.where(scales, {access: this.currentCategory.get("access")});
+                    scales = _.where(scales, { access: this.currentCategory.get("access") });
 
                     scales.push(this.EMPTY_SCALE);
 
                     if (this.currentScaleId) {
                         selectedScale = _.find(scales, function (scale) {
-                                                return scale.id === this.currentScaleId;
-                                            }, this);
+                            return scale.id === this.currentScaleId;
+                        }, this);
 
                         if (selectedScale) {
                             selectedScale.isSelected = true;
@@ -195,8 +195,10 @@ define(["jquery",
                  * @alias module:views-scale-editor.ScaleEditor#renderScaleSelect
                  */
                 renderScaleSelect: function () {
-                    this.$el.find("select#scale-id").empty()
-                                                    .append(this.scaleEditorSelectTemplate({scales: this.generateScalesForTemplate()}));
+                    this.$el.find("select#scale-id").html(
+                        this.scaleEditorSelectTemplate({
+                            scales: this.generateScalesForTemplate()
+                        }));
 
                     this.delegateEvents(this.events);
                 },
@@ -322,7 +324,7 @@ define(["jquery",
                     this.isInEditMode = true;
 
                     this.currentScale = annotationTool.video.get("scales").create({
-                        name  : i18next.t("scale editor.new scale.name"),
+                        name: i18next.t("scale editor.new scale.name"),
                         access: this.currentCategory.get("access")
                     });
 

--- a/frontend/js/views/scale-editor.js
+++ b/frontend/js/views/scale-editor.js
@@ -184,6 +184,7 @@ define(["jquery",
                         if (selectedScale) {
                             selectedScale.isSelected = true;
                         }
+                        this.EMPTY_SCALE.isSelected = false;
                     } else {
                         this.EMPTY_SCALE.isSelected = true;
                     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -768,7 +768,7 @@
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },


### PR DESCRIPTION
When you create a new scale in the scale editor and hit the "save" button, you would expect the newly created scale to be selected in the dropdown. Fortunately, this is what happens in most cases, except when you previously had the "NO SCALE" placeholder item selected. Then that one stays selected.

This should fix that.

Note that in both cases, with or without this change, the new scale is not selected (in fact it doesn't even appear in the dropdown) until you actually hit save. This is outside the scope of this PR. See #446.