### PR TITLE
Fixes overflow behavior and disappearing labels

### DIFF
--- a/frontend/js/views/annotate-category.js
+++ b/frontend/js/views/annotate-category.js
@@ -287,6 +287,11 @@ define(["jquery",
             removeOne: function (delLabel) {
                 _.find(this.labelViews, function (labelView, index) {
                     if (delLabel === labelView.model) {
+                        // this event fires when the "deleted_at" attribute of the label model changes
+                        // ignore this event when the attribute is just being initialized
+                        if(labelView.model.changed.deleted_at == null) {
+                            return false;
+                        }
                         labelView.remove();
                         this.labelViews.splice(index, 1);
                         return true;

--- a/frontend/style/bootstrap/carousel.less
+++ b/frontend/style/bootstrap/carousel.less
@@ -4,6 +4,8 @@
 
 
 .carousel {
+  height: 0;
+  flex-grow: 1;
   position: relative;
   margin-bottom: @baseLineHeight;
   line-height: 1;


### PR DESCRIPTION
Fixes #463 
While rescaling the annotation container in edit mode, the MCA button on the bottom should stay visible. Also the vertical and horizontal scrollbars should appear and stay visible while rescaling.

Fixes #464
After importing annotations, the labels should stay visible as expected.