### PR TITLE
Fixes the overflow behavior of the annotate container

### DIFF
--- a/frontend/style/bootstrap/carousel.less
+++ b/frontend/style/bootstrap/carousel.less
@@ -4,6 +4,8 @@
 
 
 .carousel {
+  height: 0;
+  flex-grow: 1;
   position: relative;
   margin-bottom: @baseLineHeight;
   line-height: 1;


### PR DESCRIPTION
Fixes #463

While rescaling the annotation container in edit mode, the MCA button on the bottom should stay visible. Also the vertical and horizontal scrollbars should appear and stay visible while rescaling.