### PR TITLE
Simplify `isMine` and `isPublic`

### DIFF
--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -614,7 +614,7 @@ define(["jquery",
                     concludeInitialization = _.bind(function () {
 
                         // At least one private track should exist, we select the first one
-                        var selectedTrack = tracks.where({ isMine: true })[0];
+                        var selectedTrack = tracks.filter(util.caller("isMine"))[0];
 
                         if (!selectedTrack.get("id")) {
                             selectedTrack.on("ready", concludeInitialization, this);
@@ -633,7 +633,7 @@ define(["jquery",
 
                         tracks = this.video.get("tracks");
 
-                        if (!tracks.where({ isMine: true }).length) {
+                        if (!tracks.filter(util.caller("isMine")).length) {
                             tracks.create({
                                 name: i18next.t("default track.name", {
                                     nickname: this.user.get("nickname")
@@ -647,7 +647,7 @@ define(["jquery",
                             });
                         } else {
                             tracks.showTracks(
-                                tracks.where({ isMine: true })
+                                tracks.filter(util.caller("isMine"))
                             );
                             concludeInitialization();
                         }

--- a/frontend/js/collections/tracks.js
+++ b/frontend/js/collections/tracks.js
@@ -121,7 +121,7 @@ define(["underscore",
 
                 if (!selectedTrack || !selectedTrack.get("visible")) {
                     selectedTrack = _.find(visibleTracks, function (track) {
-                        return track.get("isMine");
+                        return track.isMine();
                     }, this);
                     annotationTool.selectTrack(selectedTrack);
                 }

--- a/frontend/js/models/annotation.js
+++ b/frontend/js/models/annotation.js
@@ -91,12 +91,6 @@ define(["underscore",
                         delete attr.scaleValue;
                     }
 
-                    if (annotationTool.user.get("id") === attr.created_by) {
-                        attr.isMine = true;
-                    } else {
-                        attr.isMine = false;
-                    }
-
                     if (attr.label) {
                         if (attr.label.category && (tempSettings = util.parseJSONString(attr.label.category.settings))) {
                             attr.label.category.settings = tempSettings;

--- a/frontend/js/models/resource.js
+++ b/frontend/js/models/resource.js
@@ -59,14 +59,6 @@ var Resource = Backbone.Model.extend({
             }
         }
 
-        function updateIsPublic(access) {
-            this.set("isPublic", access === ACCESS.PUBLIC);
-        }
-        if (attr.access) updateIsPublic.call(this, attr.access);
-        this.on("change:access", function (self, access) {
-            updateIsPublic.call(self, access);
-        });
-
         this.set("isMine", !attr.created_by || (annotationTool.user && attr.created_by === annotationTool.user.id));
 
         if (attr.tags) {

--- a/frontend/js/models/resource.js
+++ b/frontend/js/models/resource.js
@@ -201,7 +201,7 @@ var Resource = Backbone.Model.extend({
      * @alias module:models-resource.Resource#isEditable
      */
     isEditable: function () {
-        return this.get("isMine") || (
+        return this.isMine() || (
             this.administratorCanEditPublicInstances
                 // TODO We should check this as well, but it does not work with labels so well ...
                 //   so for now we assume that this is only ever checked when the resource is public

--- a/frontend/js/models/resource.js
+++ b/frontend/js/models/resource.js
@@ -18,7 +18,7 @@
  * A module representing a generic annotation tool resource.
  * @module models-resource
  */
-define(["underscore", "backbone", "util", "access", "roles"], function (_, Backbone, util, ACCESS, ROLES) {
+define(["underscore", "backbone", "util", "access"], function (_, Backbone, util, ACCESS) {
 "use strict";
 
 /**
@@ -196,7 +196,7 @@ var Resource = Backbone.Model.extend({
                 //   so for now we assume that this is only ever checked when the resource is public
                 //   in the right sense, i.e. it can be seen at all.
                 //&& this.isPublic()
-                && annotationTool.user.get("role") === ROLES.ADMINISTRATOR
+                && annotationTool.user.isAdmin()
         );
     },
 

--- a/frontend/js/models/resource.js
+++ b/frontend/js/models/resource.js
@@ -203,7 +203,7 @@ var Resource = Backbone.Model.extend({
                 // TODO We should check this as well, but it does not work with labels so well ...
                 //   so for now we assume that this is only ever checked when the resource is public
                 //   in the right sense, i.e. it can be seen at all.
-                //&& this.get("isPublic")
+                //&& this.isPublic()
                 && annotationTool.user.get("role") === ROLES.ADMINISTRATOR
         );
     },

--- a/frontend/js/models/resource.js
+++ b/frontend/js/models/resource.js
@@ -185,6 +185,15 @@ var Resource = Backbone.Model.extend({
     },
 
     /**
+     * Check whether this resource belongs to the current user
+     * @alias module:models-resource.Resource#isMine
+     */
+    isMine: function () {
+        var creator = this.get("created_by");
+        return !creator || (annotationTool.user && creator === annotationTool.user.id);
+    },
+
+    /**
      * Decide whether this resource can be deleted by the current user.
      * @see administratorCanEditPublicInstances
      * @alias module:models-resource.Resource#isEditable

--- a/frontend/js/models/resource.js
+++ b/frontend/js/models/resource.js
@@ -185,6 +185,14 @@ var Resource = Backbone.Model.extend({
     },
 
     /**
+     * Check whether this resource is public
+     * @alias module:models-resource.Resource#isPublic
+     */
+    isPublic: function () {
+        return this.get("access") === ACCESS.PUBLIC;
+    },
+
+    /**
      * Decide whether this resource can be deleted by the current user.
      * @see administratorCanEditPublicInstances
      * @alias module:models-resource.Resource#isEditable

--- a/frontend/js/models/resource.js
+++ b/frontend/js/models/resource.js
@@ -173,6 +173,8 @@ var Resource = Backbone.Model.extend({
             if (json.settings && _.isObject(json.settings)) json.settings = JSON.stringify(json.settings);
         }
 
+        json.isMine = this.isMine();
+
         return json;
     },
 

--- a/frontend/js/models/resource.js
+++ b/frontend/js/models/resource.js
@@ -59,8 +59,6 @@ var Resource = Backbone.Model.extend({
             }
         }
 
-        this.set("isMine", !attr.created_by || (annotationTool.user && attr.created_by === annotationTool.user.id));
-
         if (attr.tags) {
             this.set("tags", util.parseJSONString(attr.tags));
         }
@@ -148,10 +146,6 @@ var Resource = Backbone.Model.extend({
 
         if (attr.settings) {
             attr.settings = util.parseJSONString(attr.settings);
-        }
-
-        if (annotationTool.user) {
-            attr.isMine = annotationTool.user.id === attr.created_by;
         }
 
         if (callback) callback.call(this, attr);

--- a/frontend/js/views/annotate.js
+++ b/frontend/js/views/annotate.js
@@ -44,7 +44,7 @@ define(["jquery",
                 id: "all",
                 name: i18next.t("annotate.categories.all"),
                 filter: function (category) {
-                    return category.get("isPublic") || category.get("isMine");
+                    return category.isPublic() || category.get("isMine");
                 },
                 roles: []
             },
@@ -52,7 +52,7 @@ define(["jquery",
                 id: "public",
                 name: i18next.t("annotate.categories.public"),
                 filter: function (category) {
-                    return category.get("isPublic");
+                    return category.isPublic();
                 },
                 roles: [ROLES.ADMINISTRATOR],
                 attributes: { access: ACCESS.PUBLIC }
@@ -61,7 +61,7 @@ define(["jquery",
                 id: "mine",
                 name: i18next.t("annotate.categories.mine"),
                 filter: function (category) {
-                    return category.get("isMine") && !category.get("isPublic");
+                    return category.get("isMine") && !category.isPublic();
                 },
                 roles: [ROLES.USER, ROLES.ADMINISTRATOR],
                 attributes: { access: ACCESS.PRIVATE }

--- a/frontend/js/views/annotate.js
+++ b/frontend/js/views/annotate.js
@@ -41,29 +41,29 @@ define(["jquery",
          */
         var DEFAULT_TABS = {
             ALL: {
-                id    : "all",
-                name  : i18next.t("annotate.categories.all"),
+                id: "all",
+                name: i18next.t("annotate.categories.all"),
                 filter: function (category) {
                     return category.get("isPublic") || category.get("isMine");
                 },
-                roles : []
+                roles: []
             },
             PUBLIC: {
-                id        : "public",
-                name      : i18next.t("annotate.categories.public"),
-                filter    : function (category) {
+                id: "public",
+                name: i18next.t("annotate.categories.public"),
+                filter: function (category) {
                     return category.get("isPublic");
                 },
-                roles     : [ROLES.ADMINISTRATOR],
+                roles: [ROLES.ADMINISTRATOR],
                 attributes: { access: ACCESS.PUBLIC }
             },
             MINE: {
-                id        : "mine",
-                name      : i18next.t("annotate.categories.mine"),
-                filter    : function (category) {
+                id: "mine",
+                name: i18next.t("annotate.categories.mine"),
+                filter: function (category) {
                     return category.get("isMine") && !category.get("isPublic");
                 },
-                roles     : [ROLES.USER, ROLES.ADMINISTRATOR],
+                roles: [ROLES.USER, ROLES.ADMINISTRATOR],
                 attributes: { access: ACCESS.PRIVATE }
             }
         },

--- a/frontend/js/views/annotate.js
+++ b/frontend/js/views/annotate.js
@@ -44,7 +44,7 @@ define(["jquery",
                 id: "all",
                 name: i18next.t("annotate.categories.all"),
                 filter: function (category) {
-                    return category.isPublic() || category.get("isMine");
+                    return category.isPublic() || category.isMine();
                 },
                 roles: []
             },
@@ -61,7 +61,7 @@ define(["jquery",
                 id: "mine",
                 name: i18next.t("annotate.categories.mine"),
                 filter: function (category) {
-                    return category.get("isMine") && !category.isPublic();
+                    return category.isMine() && !category.isPublic();
                 },
                 roles: [ROLES.USER, ROLES.ADMINISTRATOR],
                 attributes: { access: ACCESS.PRIVATE }

--- a/frontend/js/views/comment.js
+++ b/frontend/js/views/comment.js
@@ -201,7 +201,7 @@ define(["underscore",
                     creator: this.model.get("created_by_nickname"),
                     creationdate: this.model.get("created_at"),
                     text: this.model.get("text"),
-                    canEdit: this.model.get("isMine"),
+                    canEdit: this.model.isMine(),
                     numberOfReplies: this.model.replies.countCommentsAndReplies(),
                     isEditEnable: this.isEditEnable
                 },

--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -402,7 +402,7 @@ define([
             function clickedOnOneOfMyTracks(properties) {
                 var track = this.tracks.get(properties.group);
                 if (!track) return false;
-                if (!track.get("isMine")) return false;
+                if (!track.isMine()) return false;
                 if (
                     this.groupHeaders[properties.group].$el
                         .find("button")

--- a/frontend/js/views/timeline.js
+++ b/frontend/js/views/timeline.js
@@ -94,7 +94,6 @@ define([
 
     var PLACEHOLDER_TRACK = {
         isMine: true,
-        isPublic: true,
         id: "placeholder",
         name: i18next.t("timeline.no track available.short"),
         description: i18next.t("timeline.no track available.long"),


### PR DESCRIPTION
This refactors how the frontend code dtermines whether a resource is public and/or belongs to the current user.