### PR TITLE
Remove unnecessary `commons-io` dependency

### DIFF
--- a/opencast-backend/annotation-impl/pom.xml
+++ b/opencast-backend/annotation-impl/pom.xml
@@ -64,10 +64,6 @@
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <version>1.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -550,14 +550,6 @@
         <scope>test</scope>
       </dependency>
 
-      <!-- apache commons syncing -->
-
-      <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>2.1</version>
-      </dependency>
-
       <!-- testing -->
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
@dependabot tried to update this in #479, but apparently we don't even need this anymore.