### PR TITLE
Remove `localStorage` specific code

### DIFF
--- a/frontend/js/models/annotation.js
+++ b/frontend/js/models/annotation.js
@@ -80,17 +80,8 @@ define(["underscore",
              */
             parse: function (data) {
                 return Resource.prototype.parse.call(this, data, function (attr) {
-                    var tempSettings,
-                        categories,
-                        tempLabel,
-                        label;
-
-                    if (attr.scaleValue) {
-                        attr.scalevalue = attr.scaleValue;
-                        delete attr.scaleValue;
-                    }
-
                     if (attr.label) {
+                        var tempSettings;
                         if (attr.label.category && (tempSettings = util.parseJSONString(attr.label.category.settings))) {
                             attr.label.category.settings = tempSettings;
                         }
@@ -98,29 +89,6 @@ define(["underscore",
                         if ((tempSettings = util.parseJSONString(attr.label.settings))) {
                             attr.label.settings = tempSettings;
                         }
-                    }
-
-                    if (annotationTool.localStorage && _.isArray(attr.comments)) {
-                        attr.comments = new Comments(attr.comments, { annotation: this });
-                    }
-
-                    if (!annotationTool.localStorage &&  attr.label_id && (_.isNumber(attr.label_id) || _.isString(attr.label_id))) {
-                        categories = annotationTool.video.get("categories");
-
-                        categories.each(function (cat) {
-
-                            if ((tempLabel = cat.attributes.labels.get(attr.label_id))) {
-                                label = tempLabel;
-                                return true;
-                            }
-
-                        }, this);
-
-                        attr.label = label;
-                    }
-
-                    if (!annotationTool.localStorage &&  attr.scalevalue) {
-                        attr.scaleValue = attr.scalevalue;
                     }
                 });
             },
@@ -138,14 +106,6 @@ define(["underscore",
                     }
                 });
                 if (invalidResource) return invalidResource;
-
-                if (!annotationTool.localStorage && attr.label) {
-                    if (attr.label.id) {
-                        this.attributes.label_id = attr.label.id;
-                    } else if (attr.label.attributes) {
-                        this.attributes.label_id = attr.label.get("id");
-                    }
-                }
 
                 if (attr.start && !_.isNumber(attr.start)) {
                     return "\"start\" attribute must be a number!";
@@ -209,19 +169,21 @@ define(["underscore",
 
                 json.end = json.start + json.duration;
 
-                delete json.comments;
-
-                if (json.label && json.label.toJSON) {
-                    json.label = json.label.toJSON();
-                }
-
-                if (json.scalevalue) {
-                    if (json.scalevalue.attributes) {
-                        json.scale_value_id = json.scalevalue.attributes.id;
-                    } else if (json.scalevalue.id) {
-                        json.scale_value_id = json.scalevalue.id;
+                if (json.label) {
+                    if (json.label.id) {
+                        json.label_id = json.label.id;
+                    }
+                    if (json.label.toJSON) {
+                        json.label = json.label.toJSON();
                     }
                 }
+
+                if (json.scalevalue && json.scalevalue.id) {
+                    json.scale_value_id = json.scalevalue.id;
+                }
+
+                delete json.comments;
+
                 return json;
             },
 

--- a/frontend/js/models/annotation.js
+++ b/frontend/js/models/annotation.js
@@ -147,15 +147,15 @@ define(["underscore",
                     }
                 }
 
-                if (attr.start &&  !_.isNumber(attr.start)) {
+                if (attr.start && !_.isNumber(attr.start)) {
                     return "\"start\" attribute must be a number!";
                 }
 
-                if (attr.text &&  !_.isString(attr.text)) {
+                if (attr.text && !_.isString(attr.text)) {
                     return "\"text\" attribute must be a string!";
                 }
 
-                if (attr.duration &&  (!_.isNumber(attr.duration) || (_.isNumber(attr.duration) && attr.duration < 0))) {
+                if (attr.duration && (!_.isNumber(attr.duration) || (_.isNumber(attr.duration) && attr.duration < 0))) {
                     return "\"duration\" attribute must be a positive number";
                 }
 
@@ -191,8 +191,8 @@ define(["underscore",
                             this.once("ready", this.fetchComments);
                         } else {
                             this.attributes.comments.fetch({
-                                async   : true,
-                                success : fetchCallback
+                                async: true,
+                                success: fetchCallback
                             });
                         }
                     }

--- a/frontend/js/models/category.js
+++ b/frontend/js/models/category.js
@@ -92,24 +92,6 @@ define(["underscore",
             },
 
             /**
-             * Parse the attribute list passed to the model
-             * @alias module:models-category.Category#parse
-             * @param  {object} data Object literal containing the model attribute to parse.
-             * @return {object}  The object literal with the list of parsed model attribute.
-             */
-            parse: function (data) {
-                return Resource.prototype.parse.call(this, data, function (attr) {
-                    if (annotationTool.localStorage && _.isArray(attr.labels)) {
-                        attr.labels = new Labels(attr.labels, { category: this });
-                    }
-
-                    if (!annotationTool.localStorage && attr.scale_id && (_.isNumber(attr.scale_id) || _.isString(attr.scale_id))) {
-                        attr.scale = annotationTool.video.get("scales").get(attr.scale_id);
-                    }
-                });
-            },
-
-            /**
              * Validate the attribute list passed to the model
              * @alias module:models-category.Category#validate
              * @param {object} attr Object literal containing the model attribute to validate.
@@ -189,9 +171,7 @@ define(["underscore",
                         json.scale_id = this.attributes.scale.id;
                     }
 
-                    if (!annotationTool.localStorage) {
-                        delete json.scale;
-                    }
+                    delete json.scale;
                 }
 
                 return json;

--- a/frontend/js/models/label.js
+++ b/frontend/js/models/label.js
@@ -101,19 +101,19 @@ define(["underscore",
                 var invalidResource = Resource.prototype.validate.call(this, attr);
                 if (invalidResource) return invalidResource;
 
-                if (attr.value &&  !_.isString(attr.value)) {
+                if (attr.value && !_.isString(attr.value)) {
                     return "'value' attribute must be a string!";
                 }
 
-                if (attr.abbreviation &&  !_.isString(attr.abbreviation)) {
+                if (attr.abbreviation && !_.isString(attr.abbreviation)) {
                     return "'abbreviation' attribute must be a string!";
                 }
 
-                if (attr.description &&  !_.isString(attr.description)) {
+                if (attr.description && !_.isString(attr.description)) {
                     return "'description' attribute must be a string!";
                 }
 
-                if (attr.category &&  !_.isObject(attr.category)) {
+                if (attr.category && !_.isObject(attr.category)) {
                     return "'category' attribute must be a JSON Object!";
                 }
 

--- a/frontend/js/models/resource.js
+++ b/frontend/js/models/resource.js
@@ -36,28 +36,7 @@ var Resource = Backbone.Model.extend({
      * @param {object} attr Object literal containing the model initialion attributes.
      */
     initialize: function (attr) {
-        var annotationTool = window.annotationTool || {};
-
         if (!attr) attr = {};
-        if (annotationTool.localStorage) {
-            if (annotationTool.user) {
-                if (!attr.created_by) {
-                    this.set("created_by", annotationTool.user.id);
-                }
-                if (!attr.created_by_nickname) {
-                    this.set("created_by_nickname", annotationTool.user.get("nickname"));
-                }
-                if (!attr.created_by_email) {
-                    this.set("created_by_email", annotationTool.user.get("email"));
-                }
-            }
-            if (!attr.created_at) {
-                this.set("created_at", new Date());
-            }
-            if (!attr.updated_at) {
-                this.set("updated_at", new Date());
-            }
-        }
 
         if (attr.tags) {
             this.set("tags", util.parseJSONString(attr.tags));

--- a/frontend/js/models/video.js
+++ b/frontend/js/models/video.js
@@ -115,7 +115,7 @@ define(["underscore",
                 var invalidResource = Resource.prototype.validate.call(this, attr, {
                     onIdChange: function () {
                         categories = this.attributes.categories;
-                        scales     = this.attributes.scales;
+                        scales = this.attributes.scales;
 
                         this.loadTracks();
 

--- a/frontend/js/views/annotate-label.js
+++ b/frontend/js/views/annotate-label.js
@@ -194,7 +194,7 @@ define(["jquery",
                 }
 
                 var annotation = annotationTool.createAnnotation({
-                    text : this.model.get("value"),
+                    text: this.model.get("value"),
                     label: this.model
                 });
             },


### PR DESCRIPTION
Some follow up to #481. Since the "`dev`-mode" is no longer supported, we can get rid of code that was purely there to support it.