### PR TITLE
Fix the backend tests

### DIFF
--- a/.github/workflows/m2.yml
+++ b/.github/workflows/m2.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Build the artifacts
         run: mvn clean deploy
           --batch-mode
-          -DskipTests
           -Deslint.maxWarnings=0
           -DaltDeploymentRepository=m2::default::file:m2
           -Drevision=${{ steps.date.outputs.date }}-${{ github.sha }}

--- a/opencast-backend/annotation-impl/pom.xml
+++ b/opencast-backend/annotation-impl/pom.xml
@@ -100,12 +100,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-bundle</artifactId>
-      <version>1.19</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-osgi</artifactId>
       <version>${httpcomponents-httpclient.version}</version>

--- a/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestServiceTest.java
+++ b/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestServiceTest.java
@@ -34,6 +34,8 @@ import org.opencast.annotation.impl.ResourceImpl;
 
 import org.opencastproject.test.rest.RestServiceTestEnv;
 
+import com.jayway.restassured.http.ContentType;
+
 import org.hamcrest.Description;
 import org.json.simple.JSONObject;
 import org.junit.After;
@@ -128,7 +130,7 @@ public class ExtendedAnnotationsRestServiceTest {
     given().formParam("video_extid", "lecture").formParam("tags", json.toJSONString()).expect().statusCode(OK)
             .body("tags", equalTo(json)).body("video_extid", equalTo("lecture")).when().put(host("/videos"));
     // put/create/malformed
-    given().expect().statusCode(BAD_REQUEST).when().put(host("/videos"));
+    given().contentType(ContentType.URLENC).expect().statusCode(BAD_REQUEST).when().put(host("/videos"));
     given().formParam("video_extid", "").expect().statusCode(BAD_REQUEST).when().put(host("/videos"));
     // get
     given().pathParam("id", id).expect().statusCode(OK).body("video_extid", equalTo("lecture")).when()
@@ -320,8 +322,8 @@ public class ExtendedAnnotationsRestServiceTest {
             .body("name", equalTo("categoryTemplateName")).when().post(host("/videos/{videoId}/categories"));
     // put template
     json.put("channel", "22");
-    given().pathParam("videoId", 212).pathParam("categoryId", id).expect().statusCode(BAD_REQUEST).when()
-            .put(host("/videos/{videoId}/categories/{categoryId}"));
+    given().pathParam("videoId", 212).pathParam("categoryId", id).contentType(ContentType.URLENC).expect()
+            .statusCode(BAD_REQUEST).when().put(host("/videos/{videoId}/categories/{categoryId}"));
 
     given().pathParam("videoId", videoId).pathParam("categoryId", id).formParam("name", "newName")
             .formParam("tags", json.toJSONString()).expect().statusCode(OK).body("name", equalTo("newName"))
@@ -377,8 +379,8 @@ public class ExtendedAnnotationsRestServiceTest {
             .body("name", equalTo("scaleTemplateName")).when().post(host("/videos/{videoId}/scales"));
     // put template
     json.put("channel", "22");
-    given().pathParam("videoId", 212).pathParam("scaleId", id).expect().statusCode(BAD_REQUEST).when()
-            .put(host("/videos/{videoId}/scales/{scaleId}"));
+    given().pathParam("videoId", 212).pathParam("scaleId", id).contentType(ContentType.URLENC).expect()
+            .statusCode(BAD_REQUEST).when().put(host("/videos/{videoId}/scales/{scaleId}"));
 
     given().pathParam("videoId", videoId).pathParam("scaleId", id).formParam("name", "newName")
             .formParam("tags", json.toJSONString()).expect().statusCode(OK).body("name", equalTo("newName"))
@@ -445,8 +447,9 @@ public class ExtendedAnnotationsRestServiceTest {
             .post(host("/videos/{videoId}/scales/{scaleId}/scalevalues")));
     // put template
     json.put("channel", "22");
-    given().pathParam("videoId", 212).pathParam("scaleId", scaleId).pathParam("scaleValueId", id).expect()
-            .statusCode(BAD_REQUEST).when().put(host("/videos/{videoId}/scales/{scaleId}/scalevalues/{scaleValueId}"));
+    given().pathParam("videoId", 212).pathParam("scaleId", scaleId).pathParam("scaleValueId", id)
+            .contentType(ContentType.URLENC).expect() .statusCode(BAD_REQUEST).when()
+            .put(host("/videos/{videoId}/scales/{scaleId}/scalevalues/{scaleValueId}"));
 
     given().pathParam("videoId", videoId).pathParam("scaleId", scaleId).pathParam("scaleValueId", id)
             .formParam("name", "newName").formParam("tags", json.toJSONString()).expect().statusCode(OK)
@@ -533,8 +536,9 @@ public class ExtendedAnnotationsRestServiceTest {
             .post(host("/videos/{videoId}/categories/{categoryId}/labels")));
     // put template
     json.put("channel", "22");
-    given().pathParam("videoId", 212).pathParam("categoryId", categoryId).pathParam("labelId", id).expect()
-            .statusCode(BAD_REQUEST).when().put(host("/videos/{videoId}/categories/{categoryId}/labels/{labelId}"));
+    given().pathParam("videoId", 212).pathParam("categoryId", categoryId).pathParam("labelId", id)
+            .contentType(ContentType.URLENC).expect().statusCode(BAD_REQUEST).when()
+            .put(host("/videos/{videoId}/categories/{categoryId}/labels/{labelId}"));
 
     given().pathParam("videoId", videoId).pathParam("categoryId", categoryId).pathParam("labelId", id)
             .formParam("value", "newValue").formParam("abbreviation", "newAbbreviation")
@@ -627,13 +631,13 @@ public class ExtendedAnnotationsRestServiceTest {
     // put template
     json.put("channel", "22");
     given().pathParam("videoId", 323233).pathParam("trackId", trackId).pathParam("annotationId", annotationId)
-            .pathParam("commentId", id).expect().statusCode(BAD_REQUEST).when()
+            .pathParam("commentId", id).contentType(ContentType.URLENC).expect().statusCode(BAD_REQUEST).when()
             .put(host("/videos/{videoId}/tracks/{trackId}/annotations/{annotationId}/comments/{commentId}"));
     given().pathParam("videoId", videoId).pathParam("trackId", 32423234).pathParam("annotationId", annotationId)
-            .pathParam("commentId", id).expect().statusCode(BAD_REQUEST).when()
+            .pathParam("commentId", id).contentType(ContentType.URLENC).expect().statusCode(BAD_REQUEST).when()
             .put(host("/videos/{videoId}/tracks/{trackId}/annotations/{annotationId}/comments/{commentId}"));
     given().pathParam("videoId", videoId).pathParam("trackId", trackId).pathParam("annotationId", 32323)
-            .pathParam("commentId", id).expect().statusCode(BAD_REQUEST).when()
+            .pathParam("commentId", id).contentType(ContentType.URLENC).expect().statusCode(BAD_REQUEST).when()
             .put(host("/videos/{videoId}/tracks/{trackId}/annotations/{annotationId}/comments/{commentId}"));
 
     given().pathParam("videoId", videoId).pathParam("trackId", trackId).pathParam("annotationId", annotationId)
@@ -774,13 +778,13 @@ public class ExtendedAnnotationsRestServiceTest {
     // put
     json.put("channel", "33");
     given().pathParam("videoId", 323233).pathParam("trackId", trackId).pathParam("annotationId", annotationId)
-            .pathParam("commentId", id).expect().statusCode(BAD_REQUEST).when()
+            .pathParam("commentId", id).contentType(ContentType.URLENC).expect().statusCode(BAD_REQUEST).when()
             .put(host("/videos/{videoId}/tracks/{trackId}/annotations/{annotationId}/comments/{commentId}"));
     given().pathParam("videoId", videoId).pathParam("trackId", 32423234).pathParam("annotationId", annotationId)
-            .pathParam("commentId", id).expect().statusCode(BAD_REQUEST).when()
+            .pathParam("commentId", id).contentType(ContentType.URLENC).expect().statusCode(BAD_REQUEST).when()
             .put(host("/videos/{videoId}/tracks/{trackId}/annotations/{annotationId}/comments/{commentId}"));
     given().pathParam("videoId", videoId).pathParam("trackId", trackId).pathParam("annotationId", 32323)
-            .pathParam("commentId", id).expect().statusCode(BAD_REQUEST).when()
+            .pathParam("commentId", id).contentType(ContentType.URLENC).expect().statusCode(BAD_REQUEST).when()
             .put(host("/videos/{videoId}/tracks/{trackId}/annotations/{annotationId}/comments/{commentId}"));
 
     given().pathParam("videoId", videoId).pathParam("trackId", trackId).pathParam("annotationId", annotationId)

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <testResources>
       <!-- Add a log4j configuration file to the test resources -->
       <testResource>
-        <directory>${annotation.basedir}/docs/log4j</directory>
+        <directory>${maven.multiModuleProjectDirectory}/docs/log4j</directory>
         <includes>
           <include>log4j.properties</include>
         </includes>


### PR DESCRIPTION
The `contentType` calls are apparently necessary because
when you don't specify a `formParam` in a call to REST Assured,
it defaults to a `ContentType` of something other than
`application/x-www-form-urlencoded`, which the JAX-RS stuff
refuses to answer in the presence of `@FormParameter` annotations.

This was different when we still mostly dependet/ran against
Opencast 8, so I'm thinking something in the REST test environment
we use changed. ¯\\\_(ツ)_/¯

---

Closes #325 