### PR TITLE
Questionnaire annotation new "createdFromQuestionnaire" field

### DIFF
--- a/frontend/js/views/questionnaire.js
+++ b/frontend/js/views/questionnaire.js
@@ -254,6 +254,7 @@ define([
                 _.every(_.invoke(this.items, "validate"))) {
                 var contentItems = _.filter(_.flatten(_.invoke(this.items, "getContentItems")));
                 this.annotation.get("content").reset(contentItems);
+                this.annotation.set({createdFromQuestionnaire: true});
                 this.annotation.save();
                 this.annotation = null;
             }

--- a/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/Annotation.java
+++ b/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/Annotation.java
@@ -33,6 +33,9 @@ public interface Annotation extends Resource {
   /** The content of the annotation */
   String getContent();
 
+  /** If the annotation was created from a questionnaire */
+  boolean getCreatedFromQuestionnaire();
+
   /** The annotation settings */
   Option<String> getSettings();
 }

--- a/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/ExtendedAnnotationService.java
+++ b/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/ExtendedAnnotationService.java
@@ -278,7 +278,8 @@ public interface ExtendedAnnotationService {
    *           if an error occurs while storing/retrieving from persistence storage
    */
   Annotation createAnnotation(long trackId, double start, Option<Double> duration, String content,
-          Option<String> settings, Resource resource) throws ExtendedAnnotationException;
+          boolean createdFromQuestionnaire, Option<String> settings, Resource resource)
+          throws ExtendedAnnotationException;
 
   /**
    * Create an annotation with a certain annotation.

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/VideoEndpoint.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/VideoEndpoint.java
@@ -342,6 +342,7 @@ public class VideoEndpoint {
   @Path("tracks/{trackId}/annotations")
   public Response postAnnotation(@PathParam("trackId") final long trackId, @FormParam("start") final Double start,
           @FormParam("duration") final Double duration, @FormParam("content") @DefaultValue("[]") final String content,
+          @FormParam("createdFromQuestionnaire") @DefaultValue("false") final boolean createdFromQuestionnaire,
           @FormParam("settings") final String settings, @FormParam("tags") final String tags) {
     return run(array(start), new Function0<Response>() {
       @Override
@@ -353,8 +354,8 @@ public class VideoEndpoint {
 
           Resource resource = eas.createResource(
                   tagsMap.bind(Functions.identity()));
-          final Annotation a = eas.createAnnotation(trackId, start, option(duration), content, trimToNone(settings),
-                  resource);
+          final Annotation a = eas.createAnnotation(trackId, start, option(duration), content, createdFromQuestionnaire,
+                  trimToNone(settings), resource);
           return Response.created(annotationLocationUri(videoId, a))
                   .entity(Strings.asStringNull().apply(AnnotationDto.toJson.apply(eas, a))).build();
         } else {
@@ -369,7 +370,9 @@ public class VideoEndpoint {
   @Path("tracks/{trackId}/annotations/{id}")
   public Response putAnnotation(@PathParam("trackId") final long trackId, @PathParam("id") final long id,
           @FormParam("start") final double start, @FormParam("duration") final Double duration,
-          @FormParam("content") @DefaultValue("[]") final String content, @FormParam("settings") final String settings,
+          @FormParam("content") @DefaultValue("[]") final String content,
+          @FormParam("createdFromQuestionnaire") @DefaultValue("false") final boolean createdFromQuestionnaire,
+          @FormParam("settings") final String settings,
           @FormParam("tags") final String tags) {
     return run(array(start), new Function0<Response>() {
       @Override
@@ -391,7 +394,7 @@ public class VideoEndpoint {
 
               Resource resource = eas.updateResource(annotation, tags);
               final Annotation updated = new AnnotationImpl(id, trackId, start, option(duration), content,
-                      trimToNone(settings), resource);
+                      createdFromQuestionnaire, trimToNone(settings), resource);
               if (!annotation.equals(updated)) {
                 eas.updateAnnotation(updated);
                 annotation = updated;
@@ -405,8 +408,8 @@ public class VideoEndpoint {
             public Response none() {
               Resource resource = eas.createResource(tags);
               final Annotation a = eas.createAnnotation(
-                      new AnnotationImpl(id, trackId, start, option(duration), content, trimToNone(settings),
-                              resource));
+                      new AnnotationImpl(id, trackId, start, option(duration), content, createdFromQuestionnaire,
+                              trimToNone(settings), resource));
               return Response.created(annotationLocationUri(videoId, a))
                       .entity(Strings.asStringNull().apply(AnnotationDto.toJson.apply(eas, a))).build();
             }

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/AnnotationImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/AnnotationImpl.java
@@ -34,10 +34,11 @@ public class AnnotationImpl extends ResourceImpl implements Annotation {
   private final double start;
   private final Option<Double> duration;
   private final String content;
+  private final boolean createdFromQuestionnaire;
   private final Option<String> settings;
 
   public AnnotationImpl(long id, long trackId, double start, Option<Double> duration,
-          String content, Option<String> settings, Resource resource) {
+          String content, boolean createdFromQuestionnaire, Option<String> settings, Resource resource) {
     super(Option.option(resource.getAccess()), resource.getCreatedBy(), resource.getUpdatedBy(), resource
             .getDeletedBy(), resource.getCreatedAt(), resource.getUpdatedAt(), resource.getDeletedAt(), resource
             .getTags());
@@ -46,6 +47,7 @@ public class AnnotationImpl extends ResourceImpl implements Annotation {
     this.start = start;
     this.duration = duration;
     this.content = content;
+    this.createdFromQuestionnaire = createdFromQuestionnaire;
     this.settings = settings;
   }
 
@@ -82,6 +84,11 @@ public class AnnotationImpl extends ResourceImpl implements Annotation {
   @Override
   public String getContent() {
     return content;
+  }
+
+  @Override
+  public boolean getCreatedFromQuestionnaire() {
+    return createdFromQuestionnaire;
   }
 
   @Override

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/AnnotationDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/AnnotationDto.java
@@ -86,6 +86,9 @@ public class AnnotationDto extends AbstractResourceDto {
   @Column(name = "track_id", nullable = false)
   private long trackId;
 
+  @Column(name = "createdFromQuestionnaire", nullable = false)
+  private boolean createdFromQuestionnaire;
+
   @ElementCollection
   @MapKeyColumn(name = "name")
   @Column(name = "value")
@@ -93,14 +96,15 @@ public class AnnotationDto extends AbstractResourceDto {
   protected Map<String, String> tags = new HashMap<String, String>();
 
   public static AnnotationDto create(long trackId, double start, Option<Double> duration, String content,
-          Option<String> settings, Resource resource) {
-    final AnnotationDto dto = new AnnotationDto().update(start, duration, content, settings, resource);
+          boolean createdFromQuestionnaire, Option<String> settings, Resource resource) {
+    final AnnotationDto dto = new AnnotationDto().update(start, duration, content, createdFromQuestionnaire,
+            settings, resource);
     dto.trackId = trackId;
     return dto;
   }
 
-  public AnnotationDto update(double start, Option<Double> duration, String content, Option<String> settings,
-          Resource resource) {
+  public AnnotationDto update(double start, Option<Double> duration, String content, boolean createdFromQuestionnaire,
+          Option<String> settings, Resource resource) {
     super.update(resource);
     this.content = content;
     this.start = start;
@@ -112,13 +116,14 @@ public class AnnotationDto extends AbstractResourceDto {
   }
 
   public static AnnotationDto fromAnnotation(Annotation a) {
-    final AnnotationDto dto = create(a.getTrackId(), a.getStart(), a.getDuration(), a.getContent(), a.getSettings(), a);
+    final AnnotationDto dto = create(a.getTrackId(), a.getStart(), a.getDuration(), a.getContent(),
+            a.getCreatedFromQuestionnaire(), a.getSettings(), a);
     dto.id = a.getId();
     return dto;
   }
 
   public Annotation toAnnotation() {
-    return new AnnotationImpl(id, trackId, start, option(duration), content, option(settings),
+    return new AnnotationImpl(id, trackId, start, option(duration), content, createdFromQuestionnaire, option(settings),
             new ResourceImpl(option(access), option(createdBy), option(updatedBy),
                     option(deletedBy), option(createdAt), option(updatedAt), option(deletedAt), tags));
   }

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/AnnotationDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/AnnotationDto.java
@@ -78,6 +78,9 @@ public class AnnotationDto extends AbstractResourceDto {
   @Column(name = "content", nullable = false)
   private String content;
 
+  @Column(name = "createdFromQuestionnaire", nullable = false)
+  private boolean createdFromQuestionnaire;
+
   // Settings as JSON string
   @Column(name = "settings")
   private String settings;
@@ -85,9 +88,6 @@ public class AnnotationDto extends AbstractResourceDto {
   // Foreign keys
   @Column(name = "track_id", nullable = false)
   private long trackId;
-
-  @Column(name = "createdFromQuestionnaire", nullable = false)
-  private boolean createdFromQuestionnaire;
 
   @ElementCollection
   @MapKeyColumn(name = "name")
@@ -109,6 +109,7 @@ public class AnnotationDto extends AbstractResourceDto {
     this.content = content;
     this.start = start;
     this.duration = duration.getOrElseNull();
+    this.createdFromQuestionnaire = createdFromQuestionnaire;
     this.settings = settings.getOrElseNull();
     if (resource.getTags() != null)
       this.tags = resource.getTags();
@@ -141,7 +142,7 @@ public class AnnotationDto extends AbstractResourceDto {
       return conc(
               AbstractResourceDto.toJson.apply(s, a),
               jO(p("id", a.getId()), p("start", a.getStart()), p("duration", a.getDuration()), p("content", a.getContent()),
-                      p("settings", a.getSettings())));
+                      p("createdFromQuestionnaire", a.getCreatedFromQuestionnaire()), p("settings", a.getSettings())));
     }
   };
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
@@ -320,10 +320,11 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
 
   @Override
   public Annotation createAnnotation(final long trackId, final double start, final Option<Double> duration,
-          final String content, final Option<String> settings, final Resource resource)
+          final String content, final boolean createdFromQuestionnaire, final Option<String> settings, final Resource resource)
           throws ExtendedAnnotationException {
     if (getTrack(trackId).isSome()) {
-      final AnnotationDto dto = AnnotationDto.create(trackId, start, duration, content, settings, resource);
+      final AnnotationDto dto = AnnotationDto.create(trackId, start, duration, content, createdFromQuestionnaire,
+              settings, resource);
       return tx(Queries.persist(dto)).toAnnotation();
     } else {
       throw notFound;
@@ -344,7 +345,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
     update("Annotation.findById", a.getId(), new Effect<AnnotationDto>() {
       @Override
       protected void run(AnnotationDto dto) {
-        dto.update(a.getStart(), a.getDuration(), a.getContent(), a.getSettings(), a);
+        dto.update(a.getStart(), a.getDuration(), a.getContent(), a.getCreatedFromQuestionnaire(), a.getSettings(), a);
       }
     });
   }
@@ -358,7 +359,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
   public boolean deleteAnnotation(Annotation a) throws ExtendedAnnotationException {
     Resource deleteResource = deleteResource(a);
     final Annotation updated = new AnnotationImpl(a.getId(), a.getTrackId(), a.getStart(), a.getDuration(),
-            a.getContent(), a.getSettings(), deleteResource);
+            a.getContent(), a.getCreatedFromQuestionnaire(), a.getSettings(), deleteResource);
     updateAnnotation(updated);
     return true;
   }

--- a/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestServiceTest.java
+++ b/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestServiceTest.java
@@ -210,16 +210,17 @@ public class ExtendedAnnotationsRestServiceTest {
   public void testEqualsIgnoreTimestamp() throws Exception {
     Resource resource = new ResourceImpl(some(Resource.PRIVATE), none(), none(), none(), some(new Date()), none(),
             none(), new HashMap<String, String>());
-    final Annotation a = new AnnotationImpl(1, 1, 10D, some(20D), textAnnotation("a text"), some("the settings"),
-            resource);
+    final Annotation a = new AnnotationImpl(1, 1, 10D, some(20D), textAnnotation("a text"),
+            false, some("the settings"), resource);
     Thread.sleep(10);
-    final Annotation b = new AnnotationImpl(1, 1, 10D, some(20D), textAnnotation("a text"), some("the settings"),
+    final Annotation b = new AnnotationImpl(1, 1, 10D, some(20D), textAnnotation("a text"),
+            false, some("the settings"),
             new ResourceImpl(some(Resource.PRIVATE), none(), none(), none(), some(new Date()), none(), none(),
                     new HashMap<String, String>()));
-    final Annotation c = new AnnotationImpl(1, 2, 10D, some(10D), textAnnotation("a text"), some("the settings"),
-            resource);
+    final Annotation c = new AnnotationImpl(1, 2, 10D, some(10D), textAnnotation("a text"),
+            false, some("the settings"), resource);
     final Annotation d = new AnnotationImpl(1, 1, 10D, some(20D), textAnnotation("another text"),
-            some("other settings"), resource);
+            false, some("other settings"), resource);
     assertTrue(a.equals(b));
     assertFalse(a.equals(c));
     assertFalse(a.equals(d));

--- a/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/impl/ExtendedAnnotationServiceJpaImplTest.java
+++ b/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/impl/ExtendedAnnotationServiceJpaImplTest.java
@@ -269,10 +269,10 @@ public class ExtendedAnnotationServiceJpaImplTest {
     final Video v = eas.createVideo("lecture", resource);
     final Track t = eas.createTrack(v.getId(), "track1", none(), none(), resource);
     // create
-    final Annotation a = eas.createAnnotation(t.getId(), 20.0D, some(10.0D), textAnnotation("cool video"), none(),
-            resource);
-    eas.createAnnotation(t.getId(), 30.0D, some(3.0D), textAnnotation("nice!"), none(), resource);
-    eas.createAnnotation(t.getId(), 40.0D, some(5.0D), textAnnotation("look at this"), none(), resource);
+    final Annotation a = eas.createAnnotation(t.getId(), 20.0D, some(10.0D), textAnnotation("cool video"),
+            false, none(), resource);
+    eas.createAnnotation(t.getId(), 30.0D, some(3.0D), textAnnotation("nice!"), false, none(), resource);
+    eas.createAnnotation(t.getId(), 40.0D, some(5.0D), textAnnotation("look at this"), false, none(), resource);
     // get
     assertTrue(eas.getAnnotation(a.getId()).isSome());
     assertEquals(textAnnotation("cool video"), eas.getAnnotation(a.getId()).get().getContent());
@@ -309,18 +309,18 @@ public class ExtendedAnnotationServiceJpaImplTest {
     expectCause(Cause.NOT_FOUND, new Effect0() {
       @Override
       protected void run() {
-        eas.updateAnnotation(new AnnotationImpl(12345, 12345, 21.0D, some(10.0D), textAnnotation("not cool"), none(),
-                resource));
+        eas.updateAnnotation(new AnnotationImpl(12345, 12345, 21.0D, some(10.0D), textAnnotation("not cool"),
+                false, none(), resource));
       }
     });
     // create
-    final Annotation a = eas.createAnnotation(t.getId(), 20.0D, some(10.0D), textAnnotation("cool video"), none(),
-            resource);
+    final Annotation a = eas.createAnnotation(t.getId(), 20.0D, some(10.0D), textAnnotation("cool video"),
+            false, none(), resource);
     assertEquals(textAnnotation("cool video"), eas.getAnnotation(a.getId()).get().getContent());
 
     Resource updatedResource = eas.updateResource(a, tags);
     eas.updateAnnotation(new AnnotationImpl(a.getId(), t.getId(), 22.0D, some(5.0D), textAnnotation("not cool"),
-            none(), updatedResource));
+            false, none(), updatedResource));
     assertEquals(textAnnotation("not cool"), eas.getAnnotation(a.getId()).get().getContent());
     assertEquals(tags.get(), eas.getAnnotation(a.getId()).get().getTags());
   }
@@ -332,8 +332,8 @@ public class ExtendedAnnotationServiceJpaImplTest {
     final Video v = eas.createVideo("lecture", resource);
     final Track t = eas.createTrack(v.getId(), "track", none(), none(), resource);
     // create
-    final Annotation a = eas.createAnnotation(t.getId(), 20.0D, some(10.0D), textAnnotation("cool video"), none(),
-            resource);
+    final Annotation a = eas.createAnnotation(t.getId(), 20.0D, some(10.0D), textAnnotation("cool video"),
+            false, none(), resource);
     assertTrue(eas.getAnnotation(a.getId()).isSome());
     // delete
     eas.deleteAnnotation(a);
@@ -633,8 +633,8 @@ public class ExtendedAnnotationServiceJpaImplTest {
     final User u = eas.createUser("jsbach", "J.S. Bach", some("js@bach.de"), resource);
     final Video v = eas.createVideo("lecture", resource);
     final Track t = eas.createTrack(v.getId(), "track", none(), none(), resource);
-    final Annotation a = eas.createAnnotation(t.getId(), 20.0D, some(10.0D), textAnnotation("cool video"), none(),
-            resource);
+    final Annotation a = eas.createAnnotation(t.getId(), 20.0D, some(10.0D), textAnnotation("cool video"),
+            false, none(), resource);
     assertTrue(eas.getUser(u.getId()).isSome());
     assertTrue(eas.getVideo(v.getId()).isSome());
     assertTrue(eas.getTrack(t.getId()).isSome());


### PR DESCRIPTION
Added a new boolean field called "createdFromQuestionnaire" to the annotation model in the backend. Should signify whether the annotation was created through a questionnaire or not. This PR is in preparation for further tasks.

As this PR adds a new column to the database, you will have to upgrade yours: [504_upgrade_script.zip](https://github.com/opencast/annotation-tool/files/6917261/504_upgrade_script.zip)

Useful file if you want to create an annotation from a questionnaire: [OAT-Kategorien Klassenführung.zip](https://github.com/opencast/annotation-tool/files/6917285/OAT-Kategorien.Klassenfuhrung.zip) (Import as category)

