### PR TITLE
Fixed default createdAsMine value for old categories

### DIFF
--- a/frontend/js/models/category.js
+++ b/frontend/js/models/category.js
@@ -64,7 +64,7 @@ define(
 
                 this.set("settings", _.extend({
                     hasScale: true,
-                    createdAsMine: this.isMine()
+                    createdAsMine: !this.isPublic()
                 }, this.get("settings")));
             },
 


### PR DESCRIPTION
Changes the default initializer for the createdAsMine field to more closely resemble the actual meaning of the field.

This is an issue for old categories which do not have createdAsMine saved in the backend. Since `isMine()` only returns true for Mine categories of the current user, all other categories that were created as Mine by other users ended up in the Public tab instead of the Mine tab, causing weird errors and lots of confusion. 

`!isPublic()" should instead be accurate for those types of categories, since for old categories the visibility level could not be changed, so every old category that has a access level of "not public" must then be a private/mine category.