### PR TITLE
Show all categories in an item of a questionnaire, if none is specified.

### DIFF
--- a/frontend/js/views/questionnaire-block-categories.js
+++ b/frontend/js/views/questionnaire-block-categories.js
@@ -40,7 +40,7 @@ define([
             this.validationErrors = [];
         },
         render: function () {
-            var categories = _.invoke(_.filter(_.map(this.item.categories, getCategoryByName)), "toJSON");
+            var categories = getCategories(this.item);
             this.$el.html(
                 template(
                     {
@@ -87,6 +87,15 @@ define([
             this.contentItems.remove(this.contentItems.at(position));
         }
     });
+
+    function getCategories(item) {
+        return _.invoke(
+            "categories" in item
+                ? _.filter(_.map(item.categories, getCategoryByName))
+                : annotationTool.video.get("categories").models,
+            "toJSON"
+        );
+    }
 
     function getCategoryByName(name) {
         return annotationTool.video.get("categories").models.find(function (category) {

--- a/frontend/js/views/questionnaire.js
+++ b/frontend/js/views/questionnaire.js
@@ -319,11 +319,11 @@ function getMockupQuestionnaire() {
                 "type": "categories",
                 "title": "2a. Interpretation",
                 "description": "Interpretieren und erklären Sie möglichst theoriegeleitet die (Re-)Aktion der Lehrperson (und ggf. der SuS) in dieser Unterrichtssequenz. Nutzen Sie die Kategorien des Analysefokus. (Wählen Sie mindestens eine Kategorie aus)",
-                "categories": [
-                    "KF-MO: Monitoring",
-                    "KF-ST: Strukturierung",
-                    "KF-RR: Regeln und Routinen"
-                ],
+                // "categories": [
+                //     "KF-MO: Monitoring",
+                //     "KF-ST: Strukturierung",
+                //     "KF-RR: Regeln und Routinen"
+                // ],
                 "minItems": 1
             },
             "item-2": {


### PR DESCRIPTION
If an item of an questionnaire has the type "categories" but does not specify the field "categories", show all existing categories in the questionnaire.

Fixes #505 