### PR TITLE
Reset questionnaire after creating an annotation

### DIFF
--- a/frontend/js/views/questionnaire.js
+++ b/frontend/js/views/questionnaire.js
@@ -139,7 +139,6 @@ define([
         /**
          * Helper function for resetting the local state and re-rendering.
          * @alias module:views-questionnaire.QuestionnaireView#onDestroy
-         * @param {Event} event the click event
          */
         onDestroy: function() {
             this.stopListening(this.annotation);
@@ -259,7 +258,7 @@ define([
                 this.annotation = null;
             }
 
-            this.render();
+            this.onDestroy();
         }
     });
 


### PR DESCRIPTION
As soon as an annotation is created using the questionnaire, the form of the questionnaire is now reset and the view stops listening to the original annotation.

Fixes #506 