### PR TITLE
Protect annotations created via questionnaire by enforcing editing in the questionnaire only

### DIFF
--- a/frontend/js/views/list-annotation.js
+++ b/frontend/js/views/list-annotation.js
@@ -353,9 +353,6 @@ define(
                         }
                     );
 
-                // TODO
-                modelJSON.hasQuestionnaire = false; // !!annotationTool.video.getQuestionnaire();
-
                 var partials = _.extend(
                     {
                         category: TmplCategory,
@@ -452,11 +449,16 @@ define(
                     event.stopImmediatePropagation();
                 }
 
-                this.commentContainer.setState(CommentsContainer.STATES.READ);
-                this.setState(ListAnnotation.STATES.EDIT, ListAnnotation.STATES.EXPANDED);
+                if (this.model.get("createdFromQuestionnaire")) {
+                    Backbone.trigger("questionnaire:edit-annotation", this.model);
+                } else {
 
-                if (this.isEditEnable) {
-                    this.trigger("edit", this);
+                    this.commentContainer.setState(CommentsContainer.STATES.READ);
+                    this.setState(ListAnnotation.STATES.EDIT, ListAnnotation.STATES.EXPANDED);
+
+                    if (this.isEditEnable) {
+                        this.trigger("edit", this);
+                    }
                 }
 
                 this.render();

--- a/frontend/js/views/questionnaire-block-categories.js
+++ b/frontend/js/views/questionnaire-block-categories.js
@@ -35,7 +35,9 @@ define([
         },
         initialize: function (options) {
             this.item = options.item;
-            this.contentItems = new ContentItems([]);
+            this.schema = options.schema;
+            var value = options.value || [];
+            this.contentItems = new ContentItems(value);
             this.listenTo(this.contentItems, "all", this.render);
             this.validationErrors = [];
         },
@@ -73,10 +75,17 @@ define([
             var categoryID = $(event.target).data("category");
             var category = annotationTool.video.get("categories").get(categoryID);
 
+            var self = this;
             annotationTool.addModal(
                 i18next.t("annotation.add content.category") + " " + category.get("name"),
                 new AddLabelledModal({
-                    model: { addContent: this.contentItems.add.bind(this.contentItems) },
+                    model: {
+                        addContent: function (content) {
+                            content.schema = self.schema;
+
+                            return self.contentItems.add(content);
+                        }
+                    },
                     category: category
                 })
             );

--- a/frontend/js/views/questionnaire-block-label.js
+++ b/frontend/js/views/questionnaire-block-label.js
@@ -32,7 +32,13 @@ define([
         },
         initialize: function (options) {
             this.item = options.item;
-            this.model = new ContentItem({ type: "label", title: this.item.title, value: null });
+            var value = options.value || null;
+            this.model = new ContentItem({
+                type: "label",
+                schema: options.schema,
+                title: this.item.title,
+                value: value
+            });
             this.validationErrors = [];
         },
         render: function () {

--- a/frontend/js/views/questionnaire-block-scale.js
+++ b/frontend/js/views/questionnaire-block-scale.js
@@ -31,7 +31,8 @@ define([
         },
         initialize: function(options) {
             this.item = options.item;
-            this.model = new ContentItem({ type: "scaling", title: this.item.title, value: {} });
+            var value = options.value || {};
+            this.model = new ContentItem({ type: "scaling", title: this.item.title, value: value });
             this.validationErrors = [];
         },
         render: function() {

--- a/frontend/js/views/questionnaire-block-text.js
+++ b/frontend/js/views/questionnaire-block-text.js
@@ -30,10 +30,12 @@ define([
         },
         initialize: function(options) {
             this.item = options.item;
+            var value = options.value || null;
             this.model = new ContentItem({
                 type: "text",
+                schema: options.schema,
                 title: this.item.title,
-                value: null
+                value: value
             });
             this.validationErrors = [];
         },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -768,7 +768,7 @@
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+      "resolved": "http://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
       "dev": true
     },
@@ -1290,7 +1290,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1352,7 +1352,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1400,7 +1400,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1454,7 +1454,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -2349,7 +2349,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,5 +32,17 @@
   },
   "prettier": {
     "tabWidth": 4
+  },
+  "eslintConfig": {
+    "env": {
+      "browser": true
+    },
+    "parserOptions": {
+      "ecmaVersion": 6,
+      "sourceType": "module",
+      "rules": {
+        "eslint no-undef": "error"
+      }
+    }
   }
 }

--- a/frontend/templates/content-item-header.tmpl
+++ b/frontend/templates/content-item-header.tmpl
@@ -8,13 +8,13 @@
     </span>
     <span class="actions">
         {{#if annotation.isMine}}
+        {{#unless annotation.createdFromQuestionnaire}}
         <i class="icon-pencil content-item-edit"
-           title="{{t "annotation.edit.edit"}}"
+            title="{{t "annotation.edit.edit"}}"
         ></i>
-        {{#unless @root.hasQuestionnaire}}
-            <i class="icon-trash content-item-trash"
-               title="{{t "annotation.edit.delete"}}"
-            ></i>
+        <i class="icon-trash content-item-trash"
+           title="{{t "annotation.edit.delete"}}"
+        ></i>
         {{/unless}}
         {{/if}}
     </span>

--- a/frontend/templates/list-annotation-expanded.tmpl
+++ b/frontend/templates/list-annotation-expanded.tmpl
@@ -74,7 +74,7 @@
     </div>
 
     {{#if isMine}}
-        {{#unless hasQuestionnaire}}
+        {{#unless createdFromQuestionnaire}}
             <div>
                 <span>{{t "annotation.add content.list prompt"}}</span>
                 <button class="btn add-free-text-content" type="button">


### PR DESCRIPTION
Annotations that were created by questionnaire must not be edited in the usual way.
Instead the questionnaire is now opened again to let users edit the annotation via questionnaire.

Fixes #507.
Fixes #508.