### PR TITLE
Create a nice base for modal views and refactor some of our code to use it

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -112,7 +112,6 @@
 
       <div class="modal" id="scale-editor" style="display:none"></div>
       <div class="modal" id="alert" style="display:none"></div>
-      <div class="modal" id="tracks-selection" style="display:none"></div>
       <div tabindex="-1" id="annotation-shortcut-focus"></div>
     </div>
     <div id="print-view"></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -111,7 +111,6 @@
       <div id="main-container"></div>
 
       <div class="modal" id="scale-editor" style="display:none"></div>
-      <div class="modal" id="alert" style="display:none"></div>
       <div tabindex="-1" id="annotation-shortcut-focus"></div>
     </div>
     <div id="print-view"></div>

--- a/frontend/js/alerts.js
+++ b/frontend/js/alerts.js
@@ -16,10 +16,9 @@
 define([
     "views/alert"
 ], function (
-    AlertView
+    AlertModal
 ) { "use strict";
 
-var alertModal = new AlertView();
 
 /**
  * Handy functions to show alerts.
@@ -28,36 +27,36 @@ var alertModal = new AlertView();
 var alerts = {
     /**
      * Display an alert modal
-     * @param {String} message The message to display
+     * @param {string} message The message to display
      */
     error: function (message) {
-        alertModal.show(message, AlertView.TYPES.ERROR);
+        new AlertModal(AlertModal.TYPES.ERROR).show(message);
     },
 
     /**
      * Display a fatal error.
      * In addition to what {@link alertError} does, this also disables user interaction.
      * It effectively "crashes" the application with a (hopefully useful) error message.
-     * @param {String} message The error message to display
+     * @param {string} message The error message to display
      */
     fatal: function (message) {
-        alertModal.show(message, AlertView.TYPES.FATAL);
+        new AlertModal(AlertModal.TYPES.FATAL).show(message);
     },
 
     /**
      * Display an warning modal
-     * @param {String} message The message to display
+     * @param {string} message The message to display
      */
     warning: function (message) {
-        alertModal.show(message, AlertView.TYPES.WARNING);
+        new AlertModal(AlertModal.TYPES.WARNING).show(message);
     },
 
     /**
      * Display an information modal
-     * @param {String} message The message to display
+     * @param {string} message The message to display
      */
     info: function (message) {
-        alertModal.show(message, AlertView.TYPES.INFO);
+        new AlertModal(AlertModal.TYPES.INFO).show(message);
     }
 };
 

--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -86,7 +86,7 @@ define(
                 start: function (target, type, confirmCallback, closeCallback) {
 
                     if (!target.isEditable()) {
-                        alerts.warning("You are not authorized to deleted this " + type.name + "!");
+                        alerts.warning("delete operations.unauthorized", { context: type.name });
                         return;
                     }
 
@@ -656,7 +656,7 @@ define(
                         video.save(null, {
                             error: _.bind(function (model, response, options) {
                                 if (response.status === 403) {
-                                    alerts.fatal(i18next.t("annotation not allowed"));
+                                    alerts.fatal("annotation not allowed");
                                     this.views.main.loadingBox.hide();
                                 }
                             }, this)

--- a/frontend/js/views/alert.js
+++ b/frontend/js/views/alert.js
@@ -19,16 +19,14 @@
  */
 define(
     [
-        "jquery",
         "underscore",
-        "backbone",
+        "views/modal",
         "templates/alert-modal",
         "bootstrap"
     ],
     function (
-        $,
         _,
-        Backbone,
+        Modal,
         AlertTemplate
     ) {
         "use strict";
@@ -39,10 +37,7 @@ define(
          * @augments module:Backbone.View
          * @memberOf module:views-alert
          */
-        var Alert = Backbone.View.extend({
-
-            el: $("#alert"),
-
+        var Alert = Modal.extend({
             /**
              * Alert template
              * @type {HandlebarsTemplate}
@@ -54,47 +49,27 @@ define(
              * @type {object}
              */
             events: {
-                "click #confirm-alert": "hide"
+                "click .confirm-alert": "remove"
             },
 
             /**
              * Constructor
+             * @param {object} attr Object literal containing the view initialization attributes.
+             *     Sensible values for this parameter can be found in {@link Alert.TYPES}.
              */
-            initialize: function () {
-                _.bindAll(this, "show", "hide");
+            initialize: function (attr) {
+                Modal.prototype.initialize.call(this, attr.modalOptions);
+                _.extend(this, _.pick(attr, Alert.ATTRIBUTES));
+
+                this.render();
             },
 
             /**
-             * Display the modal with the given message as the given alert type
-             * @param  {String} message The message to display
-             * @param  {String | Object} type The name of the alert type or the type object itself, see {@link module:views-alert.Alert#TYPES}
+             * Draw the modal
+             * @return {Alert} this alert modal
              */
-            show: function (message, type) {
-                var params;
-
-                if (_.isString(type)) {
-                    type = Alert.TYPES[type.toUpperCase()];
-                }
-
-                if (_.isUndefined(message) || _.isUndefined(type) ||
-                    _.isUndefined(type.title)  || _.isUndefined(type.className)) {
-                    throw "Alert modal requires a valid type and a message!";
-                }
-
-                params = _.extend(type, { message: message });
-
-                this.$el.empty();
-                this.$el.append(this.template(params));
-                this.delegateEvents();
-
-                this.$el.modal(_.defaults(type.modalOptions || {}, { show: true, backdrop: true, keyboard: false }));
-            },
-
-            /**
-             * Hide the modal
-             */
-            hide: function () {
-                this.$el.modal("hide");
+            render: function () {
+                this.$el.html(this.template(_.pick(this, Alert.ATTRIBUTES)));
             }
         }, {
             /**
@@ -105,26 +80,27 @@ define(
             TYPES: {
                 ERROR: {
                     title: "alert.error.title",
-                    className: "alert-error"
+                    severity: "alert-error"
                 },
                 FATAL: {
                     title: "alert.fatal.title",
                     className: "alert-error",
-                    hideButtons: true,
-                    modalOptions: {
-                        backdrop: "static",
-                        keyboard: false
-                    }
+                    hideButtons: true
                 },
                 WARNING: {
                     title: "alert.warning.title",
-                    className: ""
                 },
                 INFO: {
                     title: "alert.info.title",
-                    className: "alert-info"
+                    severity: "alert-info"
                 }
-            }
+            },
+            ATTRIBUTES: [
+                "title",
+                "message",
+                "severity",
+                "hideButtons"
+            ]
         });
 
         return Alert;

--- a/frontend/js/views/loop.js
+++ b/frontend/js/views/loop.js
@@ -211,7 +211,7 @@ var LoopView = Backbone.View.extend({
             "change #loop-length": function (event) {
                 var newLength = parseInt(event.target.value, 10);
                 if (isNaN(newLength) || newLength <= 0 || newLength > duration) {
-                    alerts.error(i18next.t("loop controller.invalid loop length"));
+                    alerts.error("loop controller.invalid loop length");
                     lengthInput.val(loopLength);
                     slider.slider("setValue", loopLength);
                     return;

--- a/frontend/js/views/main.js
+++ b/frontend/js/views/main.js
@@ -393,7 +393,7 @@ define(
                         resolveView("player", annotationTool.playerAdapter);
                     }
                     function failed() {
-                        alerts.fatal(i18next.t("startup.video.failed"));
+                        alerts.fatal("startup.video.failed");
                     }
                     self.listenToOnce(annotationTool, annotationTool.EVENTS.VIDEO_LOADED, function () {
                         if (annotationTool.playerAdapter.getStatus() === PlayerAdapter.STATUS.PAUSED) {

--- a/frontend/js/views/modal.js
+++ b/frontend/js/views/modal.js
@@ -1,0 +1,67 @@
+/**
+ *  Copyright 2021, ELAN e.V., Germany
+ *  Licensed under the Educational Community License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance
+ *  with the License. You may obtain a copy of the License at
+ *
+ *  http://www.osedu.org/licenses/ECL-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an "AS IS"
+ *  BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ *  or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+define([
+    "underscore",
+    "backbone",
+    "bootstrap"
+], function (
+    _,
+    Backbone
+) {
+    "use strict";
+
+    var Modal = Backbone.View.extend({
+
+        className: "modal",
+
+        attributes: {
+            tabindex: -1
+        },
+
+        show: function (options) {
+            this.$el.modal(
+                _.chain(this.modalOptions)
+                    .extend(options)
+                    .extend({ show: true })
+                    .value()
+            );
+        },
+
+        hide: function () {
+            this.$el.modal("hide");
+        },
+
+        initialize: function (options) {
+            _.chain(this.modalOptions)
+                .defaults({
+                    // By default, the modal should not be closable implicitly,
+                    // so that the client is forced to take care of any cleanup logic.
+                    // Additionally, we are truly modal by default,
+                    // i.e. the user can't muck about with the state of the app
+                    // outside of the dialog.
+                    backdrop: "static",
+                    keyboard: false
+                })
+                .extend(options);
+        },
+
+        remove: function () {
+            this.hide();
+        }
+    });
+
+    return Modal;
+});

--- a/frontend/js/views/tracks-selection.js
+++ b/frontend/js/views/tracks-selection.js
@@ -103,9 +103,7 @@ define(
             },
 
             /**
-             * Display the modal with the given message as the given alert type
-             * @param  {String} message The message to display
-             * @param  {String | Object} type The name of the alert type or the type object itself, see {@link module:views-tracks-selection.Alert#TYPES}
+             * Display the modal
              */
             show: function () {
                 this.$el.empty();

--- a/frontend/js/views/tracks-selection.js
+++ b/frontend/js/views/tracks-selection.js
@@ -21,15 +21,15 @@ define(
     [
         "jquery",
         "underscore",
-        "backbone",
         "sortable",
+        "views/modal",
         "templates/tracks-selection-modal"
     ],
     function (
         $,
         _,
-        Backbone,
         Sortable,
+        Modal,
         TracksSelectionTmpl
     ) {
         "use strict";
@@ -60,9 +60,14 @@ define(
          * @augments module:Backbone.View
          * @memberOf module:views-tracks-selection
          */
-        var TracksSelectionView = Backbone.View.extend({
+        var TracksSelectionView = Modal.extend({
 
-            tag: $("#tracks-selection"),
+            id: "tracks-selection",
+
+            modalOptions: {
+                backdrop: true,
+                keyboard: true
+            },
 
             /**
              * Template
@@ -92,12 +97,8 @@ define(
              * Constructor
              */
             initialize: function () {
-                _.bindAll(
-                    this,
-                    "show",
-                    "hide",
-                    "search"
-                );
+
+                Modal.prototype.initialize.apply(this, arguments);
 
                 this.tracks = annotationTool.getTracks();
             },
@@ -157,14 +158,7 @@ define(
                 this.order = annotationTool.tracksOrder;
                 this.renderSelection();
 
-                this.$el.modal({ show: true, backdrop: false, keyboard: false });
-            },
-
-            /**
-             * Hide the modal
-             */
-            hide: function () {
-                this.$el.modal("hide");
+                Modal.prototype.show.apply(this, arguments);
             },
 
             /**

--- a/frontend/locales/de/translation.json
+++ b/frontend/locales/de/translation.json
@@ -89,8 +89,11 @@
     "name": "Standard {{nickname}}"
   },
   "delete modal": {
-    "title": "$t(models.nominative, {\"context\": \"{{context}}\" }) löschen",
-    "warning": "Wollen Sie $t(models.accusative, {\"context\": \"{{context}}\" }) „{{content}}“ wirklich löschen?"
+    "title": "$t(models.{{context}}.identifier) löschen",
+    "warning": "Wollen Sie $t(models.determined, { 'determiner': 'definite article', 'case': 'accusative' }) „{{content}}“ wirklich löschen?"
+  },
+  "delete operations": {
+    "unauthorized": "Sie sind nicht autorisiert, $t(models.determined, { 'determiner': 'demonstrative', 'case': 'accusative' }) zu löschen!"
   },
   "description": "Werkzeug zur Videoannotation",
   "loop controller": {
@@ -282,20 +285,51 @@
   },
   "untitled video": "Video ohne Titel",
   "models": {
-    "nominative_annotation": "Annotation",
-    "nominative_comment": "Kommentar",
-    "nominative_label": "Etikett",
-    "nominative_track": "Spur",
-    "nominative_category": "Kategorie",
-    "nominative_scale value": "Skalenwert",
-    "nominative_scale": "Skala",
-    "accusative_annotation": "die Annotation",
-    "accusative_comment": "den Kommentar",
-    "accusative_label": "das Etikett",
-    "accusative_track": "die Spur",
-    "accusative_category": "die Kategorie",
-    "accusative_scale value": "den Skalenwert",
-    "accusative_scale": "die Skala"
+    "annotation": {
+      "identifier": "Annotation",
+      "gender": "female"
+    },
+    "comment": {
+      "identifier": "Kommentar",
+      "gender": "male"
+    },
+    "label": {
+      "identifier": "Etikett",
+      "gender": "neutral"
+    },
+    "track": {
+      "identifier": "Spur",
+      "gender": "female"
+    },
+    "category": {
+      "identifier": "Kategorie",
+      "gender": "female"
+    },
+    "scale value": {
+      "identifier": "Skalenwert",
+      "gender": "male"
+    },
+    "scale": {
+      "identifier": "Skala",
+      "gender": "female"
+    },
+    "determined": "$t(determiners.{{determiner}}.{{case}}.$t(models.{{context}}.gender))",
+  },
+  "determiners": {
+    "definite article": {
+      "accusative": {
+        "male": "den",
+        "female": "die",
+        "neutral": "das"
+      }
+    },
+    "demonstratives": {
+      "accusative": {
+        "male accusative": "diesen",
+        "female accusative": "diese",
+        "neutral accusative": "dieses",
+      }
+    },
   },
   "views": {
     "annotate": "Neue Annotationen erstellen",

--- a/frontend/locales/de/translation.json
+++ b/frontend/locales/de/translation.json
@@ -26,7 +26,6 @@
     "download categories": "Kategorien herunterladen",
     "edit category scaling": "Skala für diese Kategorie bearbeiten",
     "edit mode": "Bearbeiten",
-    "insert": "$t(common actions.insert)",
     "items visibility": {
       "collapse all": "Alle zuklappen",
       "expand all": "Alle aufklappen",
@@ -58,24 +57,18 @@
     "track": "auf",
     "comments": {
       "author": "Kommentar von",
-      "cancel": "$t(common actions.cancel)",
       "count": "Ein Kommentar",
       "count_plural": "{{count}} Kommentare",
       "created": "am {{date}}",
-      "delete": "$t(common actions.delete)",
       "edit": {
         "button": "Bearbeiten",
-        "cancel": "$t(common actions.cancel)",
-        "save": "$t(common actions.save)"
       },
-      "insert": "$t(common actions.insert)",
       "modified": "zuletzt verändert am {{date}}",
       "placeholder": "Einen Kommentar für diese Annotation schreiben",
       "title": "Kommentare"
     },
     "edit": {
       "delete": "Annotation löschen.",
-      "double click to edit": "$t(common actions.double click to edit)",
       "edit": "Annotation bearbeiten.",
       "end time": "Schluss",
       "free text placeholder": "Freitext …",
@@ -96,15 +89,10 @@
     "name": "Standard {{nickname}}"
   },
   "delete modal": {
-    "cancel": "$t(common actions.cancel)",
-    "delete": "$t(common actions.delete)",
     "title": "$t(models.nominative, {\"context\": \"{{context}}\" }) löschen",
     "warning": "Wollen Sie $t(models.accusative, {\"context\": \"{{context}}\" }) „{{content}}“ wirklich löschen?"
   },
   "description": "Werkzeug zur Videoannotation",
-  "list annotation": {
-    "double click to edit": "$t(common actions.double click to edit)"
-  },
   "loop controller": {
     "enable": "Schleifen aktivieren",
     "constrain": "Neue Annotationen auf die aktuelle Schleife einschränken",
@@ -184,8 +172,6 @@
   },
   "required fields": "Pflichtfelder",
   "scale editor": {
-    "cancel": "$t(common actions.cancel)",
-    "delete": "$t(common actions.delete)",
     "description": {
       "label": "Beschreibung",
       "placeholder": "Beschreibung der Kategorie einfügen"
@@ -203,7 +189,6 @@
     "new scale name": "Neue Skala",
     "new scale value": "Neuer Skalenwert",
     "no scale": "-- KEINE SKALA --",
-    "save": "$t(common actions.save)",
     "values": {
       "add": "Skalenwert hinzufügen",
       "name": {
@@ -243,7 +228,6 @@
       "button_update": "Spur bearbeiten",
       "action_add": "Hinzufügen",
       "action_update": "Aktualisieren",
-      "cancel": "$t(common actions.cancel)",
       "description": {
         "label": "Beschreibung",
         "placeholder_add": "Beschreibung für die neue Spur einfügen",
@@ -286,8 +270,6 @@
   "track management": {
     "action": "Spuren verwalten",
     "(un-)select all": "Alle (de-)selektieren",
-    "cancel": "$t(common actions.cancel)",
-    "ok": "$t(common actions.ok)",
     "search": {
       "clear": "Löschen",
       "hint": "Benutzer mit öffentlichen Annotationen",

--- a/frontend/locales/en/translation.json
+++ b/frontend/locales/en/translation.json
@@ -316,5 +316,8 @@
     "insert": "Insert",
     "save": "Save",
     "delete": "Delete"
+  },
+  "delete operations": {
+    "unauthorized": "You are not authorized to deleted this {{context}}!"
   }
 }

--- a/frontend/style/annotations/base_layout.less
+++ b/frontend/style/annotations/base_layout.less
@@ -144,7 +144,7 @@ body {
     }
 }
 
-#alert {
+.alert {
     overflow: visible!important;
 
     h4 {

--- a/frontend/templates/alert-modal.tmpl
+++ b/frontend/templates/alert-modal.tmpl
@@ -1,14 +1,11 @@
-<div class="modal" id="modal-alert">
-    <div class="modal-body">
-        <div class="alert {{class}} alert-block">
-            <h4>{{t title}}</h4>
-
-            {{message}}
-        </div>
+<div class="modal-body">
+    <div class="alert {{#if severity}}alert-{{severity}}{{/if}} alert-block">
+        <h4>{{t title}}</h4>
+        {{t message}}
     </div>
-    {{#unless hideButtons}}
-        <div class="modal-footer">
-            <button type="button" id="confirm-alert" class="btn btn-primary">{{t "alert.ok"}}</button>
-        </div>
-    {{/unless}}
 </div>
+{{#unless hideButtons}}
+    <div class="modal-footer">
+        <button type="button" class="btn btn-primary confirm-alert">{{t "alert.ok"}}</button>
+    </div>
+{{/unless}}


### PR DESCRIPTION
We have quite a few modals by now, and a few more are coming as part of Bern 2021-1. This provides a nice base with some of the boilerplate code necessary to make a modal view. It also refactors some of our code to use it, though not all of it unfortunately. What's missing is the delete modals which are ... special, and the scale editor which will be rewritten as part of Bern 2021-1.