### PR TITLE
Fix `deployTo` declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
             <phase>install</phase>
             <configuration>
               <target if="deployTo">
-                <copy file="${project.build.directory}/${project.build.finalName}.jar" todir="${deployTo}/deploy"
+                <copy file="${project.build.directory}/${project.build.finalName}.jar" todir="${deployTo}"
                   overwrite="true" failonerror="false" />
               </target>
             </configuration>


### PR DESCRIPTION
The documentation tells you to use `deployTo` to define the target
directory the bundles are written to:

>     mvn clean install -DdeployTo=<opencast-deploy-dir>
>
> where` <opencast-deploy-dir>` is the Karaf hot deployment folder of
> your Opencast installation. (This is usually something like
> `/usr/share/opencast/deploy` if using the official packages.

Unfortunately, this does not work and will create a subdirectory in
there instead. This fixes the issue by removing the hard-coded `/deploy`
from the maven configuration.