### PR TITLE
Fix REST Docs exception

### DIFF
--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestService.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestService.java
@@ -22,6 +22,7 @@ import org.opencast.annotation.api.ExtendedAnnotationService;
 
 import org.opencastproject.util.UrlSupport;
 import org.opencastproject.util.data.Tuple;
+import org.opencastproject.util.doc.rest.RestService;
 
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
@@ -34,6 +35,12 @@ import javax.ws.rs.Path;
         "opencast.service.type=org.opencast.annotation",
         "opencast.service.path=/extended-annotations"})
 @Path("/")
+@RestService(
+    name = "extended-annotations",
+    title = "Annotation Tool Backend",
+    abstractText = "Scientific video annotations on Opencast media..",
+    notes = { }
+)
 public class ExtendedAnnotationsRestService extends AbstractExtendedAnnotationsRestService {
 
   private ExtendedAnnotationService extendedAnnotationService;

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestService.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestService.java
@@ -39,7 +39,7 @@ import javax.ws.rs.Path;
     name = "extended-annotations",
     title = "Annotation Tool Backend",
     abstractText = "Scientific video annotations on Opencast media..",
-    notes = { }
+    notes = { "The Annotation Tool does not yet provide REST documentation." }
 )
 public class ExtendedAnnotationsRestService extends AbstractExtendedAnnotationsRestService {
 


### PR DESCRIPTION
This patch fixes the problem with Opencast's REST docs presenting an
exception when trying to view the endpoint documentation.

This does not address the completely missing documentation for all the
Annotation Tool endpoints.