### PR TITLE
Log Errors

### DIFF
--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/AbstractExtendedAnnotationsRestService.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/AbstractExtendedAnnotationsRestService.java
@@ -1051,6 +1051,7 @@ public abstract class AbstractExtendedAnnotationsRestService {
         case NOT_FOUND:
           return NOT_FOUND;
         default:
+          logger.error("The annotation tool endpoint experienced an unexpected error.", e);
           return SERVER_ERROR;
       }
     }


### PR DESCRIPTION
This patch prevents the REST interface from silencing actual server
errors. They should be logged and ultimately fixed.