### PR TITLE
Prevent Scrolling in Dialog

### DIFF
--- a/frontend/style/bootstrap/modals.less
+++ b/frontend/style/bootstrap/modals.less
@@ -60,7 +60,7 @@
 .modal-body {
   position: relative;
   overflow-y: auto;
-  max-height: 400px;
+  max-height: 450px;
   padding: 15px;
 }
 // Remove bottom margin if need be


### PR DESCRIPTION
This patch allows slightly more space to be used by modal dialogs,
allowing the category and scale modification dialogs to work without
scroll bars.