### PR TITLE
Reduce Categories per Page

### DIFF
--- a/frontend/js/configuration.js
+++ b/frontend/js/configuration.js
@@ -33,7 +33,7 @@ define(function () {
          * Define the number of categories pro tab in the annotate box. Bigger is number, thinner will be the columns for the categories.
          * @type {Number}
          */
-        CATEGORIES_PER_TAB: 7,
+        CATEGORIES_PER_TAB: 6,
 
         /**
          * Define if the structured annotations are or not enabled


### PR DESCRIPTION
This patch fixes the reduced space for showing the category titles by
allowing one less category per page.

The space is distributed equally between all categories on a place so
that now you have 1/6 instead of 1/7 of the overall available space.

This fixes #542