### PR TITLE
Improve the access and visibility descriptions

### DIFF
--- a/frontend/js/views/track-modal.js
+++ b/frontend/js/views/track-modal.js
@@ -40,12 +40,6 @@ define([
             var access = ACCESS.render(this.track.get("access"));
             this.$el.find("[name='access-radio'][value='" + access + "']").prop("checked", true);
 
-            this.sharedWithEveryoneExplanation = this.$el.find(".explanation");
-            this.sharedWithEveryoneRadio = this.$el.find(
-                "[name='access-radio'][value='" + ACCESS.render(ACCESS.SHARED_WITH_EVERYONE) + "']"
-            );
-            this.fixExplanationVisibility();
-
             return this;
         },
 
@@ -95,14 +89,6 @@ define([
             show: true,
             backdrop: false,
             keyboard: true
-        },
-
-        fixExplanationVisibility: function (event) {
-            if (this.sharedWithEveryoneRadio.prop("checked")) {
-                this.sharedWithEveryoneExplanation.show();
-            } else {
-                this.sharedWithEveryoneExplanation.hide();
-            }
         },
 
         template: template

--- a/frontend/locales/de/translation.json
+++ b/frontend/locales/de/translation.json
@@ -223,11 +223,10 @@
   "timeline": {
     "change visibility": {
       "tooltip": "Sichtbarkeit ändern",
-      "to public": "Öffentlich machen",
-      "to private": "Privat machen",
-      "to shared with admin": "Mit Administratoren teilen",
-      "to shared with everyone": "Allen Benutzern automatisch anzeigen",
-      "to shared with everyone explanation": "Die Spur wird allen Benutzern automatisch und schreibgeschützt angezeigt. Andere Benutzer können also keine Änderungen vornehmen."
+      "to shared with everyone": "Standardmäßig anzeigen",
+      "to public": "Mit allen teilen",
+      "to shared with admin": "Mit Admin teilen",
+      "to private": "Privat schalten"
     },
     "track modals": {
       "header_add": "Neue Spur hinzufügen",
@@ -243,10 +242,10 @@
       },
       "access": {
         "label": "Zugriff",
-        "public": "Öffentlich",
-        "private": "Privat",
-        "shared with admin": "Mit Administrator teilen",
-        "shared with everyone": "Allen Benutzern automatisch anzeigen"
+        "shared with everyone": "<b>Standardmäßig angezeigt</b> (wird allen Nutzern automatisch angezeigt)",
+        "public": "<b>Mit allen geteilt</b> (alle Nutzer können zugreifen)",
+        "shared with admin": "<b>Mit Admin geteilt</b> (Administratoren können zugreifen)",
+        "private": "<b>Privat</b> (nur Besitzer hat Zugriff)"
       },
       "name": {
         "label": "Name",

--- a/frontend/locales/en/translation.json
+++ b/frontend/locales/en/translation.json
@@ -248,11 +248,10 @@
       },
       "access": {
         "label": "Access",
-        "public": "Public",
-        "private": "Private",
-        "shared with admin": "Share with admin",
-        "shared with everyone": "Automatically display to all users",
-        "shared with everyone explanation": "The track is displayed to all users automatically and in read-only mode. So other users can not make any changes."
+        "shared with everyone": "<b>Visible by default</b> (automatically shown to all users)",
+        "public": "<b>Shared with anyone</b> (any user may access this)",
+        "shared with admin": "<b>Shared with admin</b> (admins may access this)",
+        "private": "<b>Private</b> (only owner has access)"
       },
       "name": {
         "label": "Name",
@@ -262,10 +261,10 @@
     },
     "change visibility": {
       "tooltip": "Change visibility",
-      "to public": "Make public",
-      "to private": "Make private",
+      "to shared with everyone": "Make visible by default",
+      "to public": "Shared with anyone",
       "to shared with admin": "Share with admin",
-      "to shared with everyone": "Automatically display to all users"
+      "to private": "Make private"
     },
     "delete track": "Delete track",
     "name required": "Name is required!",

--- a/frontend/templates/track-modal.tmpl
+++ b/frontend/templates/track-modal.tmpl
@@ -1,9 +1,17 @@
+<style>
+.track-modal .control-label {
+    width: 100px;
+}
+.track-modal .controls {
+    margin-left: 140px;
+}
+</style>
 <form class="form-horizontal">
     <div class="modal-header">
         <h3>{{t "timeline.track modals.header" context=action}}</h3>
     </div>
     <div class="modal-body">
-        <fieldset>
+        <fieldset class="track-modal">
             <div class="alert alert-error" style="display:none">
                 <span><i class="icon-exclamation-sign"></i></span>
                 <span id="content"></span>
@@ -28,9 +36,6 @@
                         <label class="radio">
                             <input type="radio" name="access-radio" value="shared-with-everyone">
                             {{t "timeline.track modals.access.shared with everyone" context=action}}<br>
-                            <span class="explanation">
-                                {{t "timeline.track modals.access.shared with everyone explanation"}}
-                            </span>
                         </label>
                     {{/if}}
                     <label class="radio">


### PR DESCRIPTION
This patch updates the descriptions for the different access and
visibility options, making it more clear what the difference between
these options are.

![Screenshot from 2022-01-27 00-27-15](https://user-images.githubusercontent.com/1008395/151264665-c7f859e5-7b11-418b-9191-0284035bbec2.png)

This fixes #533

