### PR TITLE
Fix deleting scales

### DIFF
--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -884,11 +884,6 @@ define(
                     return target.get("name");
                 },
                 destroy: function (scale, callback) {
-                    _.invoke(
-                        _.clone(scale.get("scaleValues").models),
-                        "destroy",
-                        { error: function () { throw "cannot delete scale value"; } }
-                    );
                     scale.destroy({
                         success: function () {
                             if (callback) {

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/AbstractExtendedAnnotationsRestService.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/AbstractExtendedAnnotationsRestService.java
@@ -68,6 +68,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -436,8 +437,17 @@ public abstract class AbstractExtendedAnnotationsRestService {
         return eas().getScale(id, false).fold(new Option.Match<Scale, Response>() {
           @Override
           public Response some(Scale s) {
-            if (!hasResourceAccess(s, videoInterface))
+            if (!hasResourceAccess(s, videoInterface)) {
               return UNAUTHORIZED;
+            }
+            // Delete all scale values
+            List<ScaleValue> values = eas().getScaleValues(s.getId(), Option.none(), Option.none(), Option.none(),
+                    Option.none(), Option.none());
+            for (ScaleValue value: values) {
+              logger.debug("Deleting {}", value.getName());
+              eas().deleteScaleValue(value);
+            }
+            // Delete scale itself
             return eas().deleteScale(s) ? NO_CONTENT : NOT_FOUND;
           }
 


### PR DESCRIPTION
This patch fixes the problem that deleting scales will occasional fail
due to timing issues since the values belonging to the scale being
deleted are not yet deleted.

Instead of trying to get the timing right and waiting for requests in
the frontend, this patch fixes the problem in the backend, automatically
deleting all its values along with a scale.