### PR TITLE
Fixing potential raise condition when saving categories

### DIFF
--- a/frontend/js/views/category-modal.js
+++ b/frontend/js/views/category-modal.js
@@ -96,7 +96,11 @@ define([
                 if (this.model.isNew()) {
                     annotationTool.video.get("categories").add(this.model);
                 }
-                this.model.save(null, { async: false });
+
+                // Save this to get an id if we do not have one.
+                if (!this.model.id) {
+                    this.model.save(null, { async: false });
+                }
 
                 // Fix the affiliation. We do this as a second step
                 // because the category needs an ID for this
@@ -114,7 +118,7 @@ define([
                         series_extid: null
                     };
                 }
-                this.model.save(seriesParams);
+                this.model.save(seriesParams, { async: false });
 
                 _.each(this.removeLabels, function (label) {
                     this.model.get("labels").get(label).destroy();


### PR DESCRIPTION
Sometimes when editing a category which is attached to a series and
then making this category local and saving it, the category labels get
duplicated. This might have to do with the asynchronous JavaScript
request for the category and its labels.

This patch reduces the number of requests sent, plus makes the save
operation for the category itself synchronous, ensuring the label
modifications happen after the operation is actually done.