### PR TITLE
Use composite videos in player if they exist

### DIFF
--- a/frontend/js/integrations/search.js
+++ b/frontend/js/integrations/search.js
@@ -184,6 +184,10 @@ define([
                 videos.sort(
                     util.lexicographic([
                         util.firstWith(_.compose(
+                            RegExp.prototype.test.bind(/composite\/.*/),
+                            _.property("type")
+                        )),
+                        util.firstWith(_.compose(
                             RegExp.prototype.test.bind(/presenter\/.*/),
                             _.property("type")
                         )),


### PR DESCRIPTION
This is achieved by preferring videos with composite/* flavor during sort.