### PR TITLE
Always let the Backend decide who is Annotate-Admin

### DIFF
--- a/frontend/js/integrations/search.js
+++ b/frontend/js/integrations/search.js
@@ -89,38 +89,10 @@ define([
     var user = $.ajax({
         url: "/info/me.json"
     });
-    // Find out which roles should have admin rights
-    var adminRoles = mediaPackage.then(function (mediaPackage) {
-        // First we need to find the proper XACML file
-        var attachments = util.array(mediaPackage.attachments.attachment);
-        var selectedXACML = function () {
-            var seriesXACML;
-            for (var i = 0; i < attachments.length; i++) {
-                var attachment = attachments[i];
-                if (attachment.type === "security/xacml+episode") {
-                    // Immediately return an XACML belonging to this specific episode
-                    return attachment;
-                }
-                if (attachment.type === "security/xacml+series") {
-                    // Remember any series XACML on the way,
-                    //   so we can return that as a fallback
-                    seriesXACML = attachment;
-                }
-            }
-            return seriesXACML;
-        }();
-        return $.ajax({
-            url: selectedXACML.url,
-            crossDomain: true,
-            dataType: "xml"
-        });
-    }).then(function (xacmlData) {
-        // Then we need to extract the appropriate rules
-        return $(xacmlData).find("Rule").filter(function (index, rule) {
-            return $(rule).find("Action AttributeValue").text() === "annotate-admin";
-        }).map(function (index, rule) {
-            return $(rule).find("Condition AttributeValue").text();
-        }).toArray();
+    var isAdmin = $.ajax({
+        url: "/extended-annotations/users/is-annotate-admin/" + mediaPackageId
+    }).then(function (data) {
+        return data === 'true';
     });
 
     /**
@@ -145,17 +117,14 @@ define([
          * Authenticate the user
          */
         authenticate: function () {
-            $.when(user, adminRoles).then(function (userResult, adminRoles) {
+            $.when(user, isAdmin).then(function (userResult, isAdmin) {
                 var user = userResult[0];
                 var userData = user.user;
                 this.user = new User({
                     user_extid: userData.username,
                     nickname: userData.name || userData.username,
                     email: userData.email,
-                    isAdmin: _.intersection(
-                        adminRoles.concat(["ROLE_ADMIN"]),
-                        user.roles
-                    ).length > 0
+                    isAdmin: isAdmin
                 });
                 return this.user.save();
             }.bind(this)).then(function () {

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/AbstractExtendedAnnotationsRestService.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/AbstractExtendedAnnotationsRestService.java
@@ -16,6 +16,7 @@
 package org.opencast.annotation.endpoint;
 
 import static org.opencast.annotation.api.ExtendedAnnotationService.ANNOTATE_ACTION;
+import static org.opencast.annotation.api.ExtendedAnnotationService.ANNOTATE_ADMIN_ACTION;
 import static org.opencast.annotation.endpoint.util.Responses.buildOk;
 import static org.opencastproject.util.UrlSupport.uri;
 import static org.opencastproject.util.data.Arrays.array;
@@ -48,6 +49,7 @@ import org.opencast.annotation.impl.persistence.UserDto;
 import org.opencast.annotation.impl.persistence.VideoDto;
 
 import org.opencastproject.mediapackage.MediaPackage;
+import org.opencastproject.util.RestUtil;
 import org.opencastproject.util.data.Function;
 import org.opencastproject.util.data.Function0;
 import org.opencastproject.util.data.Option;
@@ -225,6 +227,17 @@ public abstract class AbstractExtendedAnnotationsRestService {
         });
       }
     });
+  }
+
+  @GET
+  @Produces(MediaType.TEXT_PLAIN)
+  @Path("/users/is-annotate-admin/{mpId}")
+  public Response isAnnotateAdmin(@PathParam("mpId") final String mpId) {
+    Option<MediaPackage> mpOpt = eas().findMediaPackage(mpId);
+    if (mpOpt.isSome()) {
+      return RestUtil.R.ok(eas().hasVideoAccess(mpOpt.get(), ANNOTATE_ADMIN_ACTION));
+    }
+    return RestUtil.R.ok(false);
   }
 
   @POST

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/VideoEndpoint.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/VideoEndpoint.java
@@ -1,7 +1,6 @@
 package org.opencast.annotation.endpoint;
 
 import static org.opencast.annotation.api.ExtendedAnnotationService.ANNOTATE_ACTION;
-import static org.opencast.annotation.api.ExtendedAnnotationService.ANNOTATE_ADMIN_ACTION;
 import static org.opencast.annotation.endpoint.AbstractExtendedAnnotationsRestService.BAD_REQUEST;
 import static org.opencast.annotation.endpoint.AbstractExtendedAnnotationsRestService.FORBIDDEN;
 import static org.opencast.annotation.endpoint.AbstractExtendedAnnotationsRestService.LOCATION;
@@ -41,7 +40,6 @@ import org.opencast.annotation.impl.persistence.TrackDto;
 import org.opencast.annotation.impl.persistence.VideoDto;
 
 import org.opencastproject.mediapackage.MediaPackage;
-import org.opencastproject.util.data.Function;
 import org.opencastproject.util.data.Function0;
 import org.opencastproject.util.data.Option;
 import org.opencastproject.util.data.functions.Functions;
@@ -71,39 +69,7 @@ public class VideoEndpoint {
   private final ExtendedAnnotationService eas;
 
   private final long videoId;
-
-  private static class VideoData {
-
-    enum Access {
-        NONE,
-        ANNOTATE,
-        ANNOTATE_ADMIN
-    }
-
-    private final Video video;
-    private final Access access;
-
-    VideoData(final Video video, final Access access) {
-      this.video = video;
-      this.access = access;
-    }
-
-    public Video getVideo() {
-      return video;
-    }
-
-    public Access getAccess() {
-      return access;
-    }
-  }
-
-  private final Option<VideoData> videoData;
-
-  private VideoData.Access getVideoAccess(MediaPackage mediaPackage) {
-    if (eas.hasVideoAccess(mediaPackage, ANNOTATE_ADMIN_ACTION)) return VideoData.Access.ANNOTATE_ADMIN;
-    if (eas.hasVideoAccess(mediaPackage, ANNOTATE_ACTION)) return VideoData.Access.ANNOTATE;
-    return VideoData.Access.NONE;
-  }
+  private final Option<Video> videoOpt;
 
   VideoEndpoint(final long videoId, final AbstractExtendedAnnotationsRestService host,
           final ExtendedAnnotationService eas) {
@@ -111,17 +77,11 @@ public class VideoEndpoint {
     this.host = host;
     this.eas = eas;
 
-    this.videoData = this.eas.getVideo(videoId).map(new Function<Video, VideoData>() {
-      @Override
-      public VideoData apply(final Video video) {
-        MediaPackage mediaPackage = eas.findMediaPackage(video.getExtId()).get();
-        VideoData.Access access = getVideoAccess(mediaPackage);
-        return new VideoData(video, access);
-      }
-    });
+    this.videoOpt = this.eas.getVideo(videoId);
 
-    for (VideoData videoData: this.videoData) {
-      if (videoData.getAccess() == VideoData.Access.NONE) {
+    if (this.videoOpt.isSome()) {
+      MediaPackage mediaPackage = eas.findMediaPackage(videoOpt.get().getExtId()).get();
+      if (!eas.hasVideoAccess(mediaPackage, ANNOTATE_ACTION)) {
         throw new WebApplicationException(FORBIDDEN);
       }
     }
@@ -133,12 +93,12 @@ public class VideoEndpoint {
     return run(nil, new Function0<Response>() {
       @Override
       public Response apply() {
-        return videoData.fold(new Option.Match<VideoData, Response>() {
+        return videoOpt.fold(new Option.Match<Video, Response>() {
           @Override
-          public Response some(VideoData v) {
-            if (!eas.hasResourceAccess(v.getVideo()))
+          public Response some(Video v) {
+            if (!eas.hasResourceAccess(v))
               return UNAUTHORIZED;
-            return buildOk(VideoDto.toJson.apply(eas, v.getVideo()));
+            return buildOk(VideoDto.toJson.apply(eas, v));
           }
 
           @Override
@@ -155,12 +115,12 @@ public class VideoEndpoint {
     return run(nil, new Function0<Response>() {
       @Override
       public Response apply() {
-        return videoData.fold(new Option.Match<VideoData, Response>() {
+        return videoOpt.fold(new Option.Match<Video, Response>() {
           @Override
-          public Response some(VideoData v) {
-            if (!eas.hasResourceAccess(v.getVideo()))
+          public Response some(Video v) {
+            if (!eas.hasResourceAccess(v))
               return UNAUTHORIZED;
-            return eas.deleteVideo(v.getVideo()) ? NO_CONTENT : NOT_FOUND;
+            return eas.deleteVideo(v) ? NO_CONTENT : NOT_FOUND;
           }
 
           @Override
@@ -211,7 +171,7 @@ public class VideoEndpoint {
       @Override
       public Response apply() {
         // check if video exists
-        if (videoData.isSome()) {
+        if (videoOpt.isSome()) {
           return eas.getTrack(id).fold(new Option.Match<Track, Response>() {
             // update track
             @Override
@@ -254,7 +214,7 @@ public class VideoEndpoint {
   @Path("tracks/{trackId}")
   public Response deleteTrack(@PathParam("trackId") final long trackId) {
     // TODO optimize querying for the existence of video and track
-    if (videoData.isSome()) {
+    if (videoOpt.isSome()) {
       return run(nil, new Function0<Response>() {
         @Override
         public Response apply() {
@@ -285,7 +245,7 @@ public class VideoEndpoint {
     return run(nil, new Function0<Response>() {
       @Override
       public Response apply() {
-        if (videoData.isSome()) {
+        if (videoOpt.isSome()) {
           return eas.getTrack(id).fold(new Option.Match<Track, Response>() {
             @Override
             public Response some(Track t) {
@@ -321,7 +281,7 @@ public class VideoEndpoint {
         final Option<Option<Map<String, String>>> tagsAndArray = trimToNone(tagsAnd).map(parseToJsonMap);
         final Option<Option<Map<String, String>>> tagsOrArray = trimToNone(tagsOr).map(parseToJsonMap);
 
-        if ((datem.isSome() && datem.get().isNone()) || videoData.isNone()
+        if ((datem.isSome() && datem.get().isNone()) || videoOpt.isNone()
                 || (tagsAndArray.isSome() && tagsAndArray.get().isNone())
                 || (tagsOrArray.isSome() && tagsOrArray.get().isNone())) {
           return BAD_REQUEST;
@@ -347,7 +307,7 @@ public class VideoEndpoint {
     return run(array(start), new Function0<Response>() {
       @Override
       public Response apply() {
-        if (videoData.isSome() && eas.getTrack(trackId).isSome()) {
+        if (videoOpt.isSome() && eas.getTrack(trackId).isSome()) {
           final Option<Option<Map<String, String>>> tagsMap = trimToNone(tags).map(parseToJsonMap);
           if (tagsMap.isSome() && tagsMap.get().isNone())
             return BAD_REQUEST;
@@ -383,7 +343,7 @@ public class VideoEndpoint {
         final Option<Map<String, String>> tags = tagsMap.bind(Functions.identity());
 
         // check if video and track exist
-        if (videoData.isSome() && eas.getTrack(trackId).isSome()) {
+        if (videoOpt.isSome() && eas.getTrack(trackId).isSome()) {
           return eas.getAnnotation(id).fold(new Option.Match<Annotation, Response>() {
             // update annotation
             @Override
@@ -424,7 +384,7 @@ public class VideoEndpoint {
   @DELETE
   @Path("tracks/{trackId}/annotations/{id}")
   public Response deleteAnnotation(@PathParam("trackId") final long trackId, @PathParam("id") final long id) {
-    if (videoData.isSome() && eas.getTrack(trackId).isSome()) {
+    if (videoOpt.isSome() && eas.getTrack(trackId).isSome()) {
       return run(nil, new Function0<Response>() {
         @Override
         public Response apply() {
@@ -453,7 +413,7 @@ public class VideoEndpoint {
   @Path("tracks/{trackId}/annotations/{id}")
   public Response getAnnotation(@PathParam("trackId") final long trackId, @PathParam("id") final long id) {
     // TODO optimize querying for the existence of video and track
-    if (videoData.isSome() && eas.getTrack(trackId).isSome()) {
+    if (videoOpt.isSome() && eas.getTrack(trackId).isSome()) {
       return run(nil, new Function0<Response>() {
         @Override
         public Response apply() {
@@ -488,7 +448,7 @@ public class VideoEndpoint {
     return run(nil, new Function0<Response>() {
       @Override
       public Response apply() {
-        if (videoData.isSome()) {
+        if (videoOpt.isSome()) {
           final Option<Double> startm = start > 0 ? some(start) : none();
           final Option<Double> endm = end > 0 ? some(end) : none();
           final Option<Integer> offsetm = offset > 0 ? some(offset) : none();
@@ -530,7 +490,7 @@ public class VideoEndpoint {
       @Override
       public Response apply() {
         final Option<Option<Map<String, String>>> tagsMap = trimToNone(tags).map(parseToJsonMap);
-        if (eas.getScale(scaleId, false).isNone() || videoData.isNone()
+        if (eas.getScale(scaleId, false).isNone() || videoOpt.isNone()
                 || (tagsMap.isSome() && tagsMap.get().isNone()))
           return BAD_REQUEST;
 
@@ -630,7 +590,7 @@ public class VideoEndpoint {
       @Override
       public Response apply() {
         final Option<Option<Map<String, String>>> tagsMap = trimToNone(tags).map(parseToJsonMap);
-        if (videoData.isNone() || (tagsMap.isSome() && tagsMap.get().isNone()))
+        if (videoOpt.isNone() || (tagsMap.isSome() && tagsMap.get().isNone()))
           return BAD_REQUEST;
 
         Resource resource = eas.createResource(tagsMap.bind(Functions.identity()));
@@ -744,7 +704,7 @@ public class VideoEndpoint {
 
   private Response postCommentResponse(final long trackId, final long annotationId, final Option<Long> replyToId,
           final String text, final String tags) {
-    if (videoData.isSome() && eas.getTrack(trackId).isSome()
+    if (videoOpt.isSome() && eas.getTrack(trackId).isSome()
             && eas.getAnnotation(annotationId).isSome()) {
       return run(array(text), new Function0<Response>() {
         @Override
@@ -772,7 +732,7 @@ public class VideoEndpoint {
   public Response putComment(@PathParam("trackId") final long trackId,
           @PathParam("annotationId") final long annotationId, @PathParam("commentId") final long commentId,
           @FormParam("text") final String text, @FormParam("tags") final String tags) {
-    if (videoData.isSome() && eas.getTrack(trackId).isSome()
+    if (videoOpt.isSome() && eas.getTrack(trackId).isSome()
             && eas.getAnnotation(annotationId).isSome()) {
       return run(array(text), new Function0<Response>() {
         @Override
@@ -820,7 +780,7 @@ public class VideoEndpoint {
   @Path("tracks/{trackId}/annotations/{annotationId}/comments/{id}")
   public Response deleteComment(@PathParam("trackId") final long trackId,
           @PathParam("annotationId") final long annotationId, @PathParam("id") final long commentId) {
-    if (videoData.isSome() && eas.getTrack(trackId).isSome()
+    if (videoOpt.isSome() && eas.getTrack(trackId).isSome()
             && eas.getAnnotation(annotationId).isSome()) {
       return run(nil, new Function0<Response>() {
         @Override
@@ -851,7 +811,7 @@ public class VideoEndpoint {
   @Path("tracks/{trackId}/annotations/{annotationId}/comments/{id}")
   public Response getComment(@PathParam("trackId") final long trackId,
           @PathParam("annotationId") final long annotationId, @PathParam("id") final long id) {
-    if (videoData.isSome() && eas.getTrack(trackId).isSome()
+    if (videoOpt.isSome() && eas.getTrack(trackId).isSome()
             && eas.getAnnotation(annotationId).isSome()) {
       return run(nil, new Function0<Response>() {
         @Override
@@ -889,7 +849,7 @@ public class VideoEndpoint {
 
   private Response getCommentsResponse(final long trackId, final long annotationId, final Option<Long> replyToId,
           final int limit, final int offset, final String date, final String tagsAnd, final String tagsOr) {
-    if (videoData.isSome() && eas.getTrack(trackId).isSome()
+    if (videoOpt.isSome() && eas.getTrack(trackId).isSome()
             && eas.getAnnotation(annotationId).isSome()) {
       return run(nil, new Function0<Response>() {
         @Override


### PR DESCRIPTION
The backend uses the authorization service of Opencast to check the rights a user has for a specific media package. This way, the configured ACL merge mode is taken into consideration. 
The frontend would only consider the event ACL if it existed, and disregard the series ACL entirely. This meant that if a user had access rights granted by a series, they would be able to use the annotation tool (because this check was always performed by the backend), but would not see the UI elements for annotate admins, even if the series granted him those rights.
This PR fixes that by introducing a new endpoint so the frontend can ask the backend whether the logged-in user is an annotate-admin.