### PR TITLE
Restore necessary dependencies for Opencast 13

### DIFF
--- a/opencast-backend/annotation-impl/pom.xml
+++ b/opencast-backend/annotation-impl/pom.xml
@@ -138,7 +138,6 @@
     <dependency>
       <groupId>org.eclipse.persistence</groupId>
       <artifactId>org.eclipse.persistence.jpa</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.persistence</groupId>

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
@@ -53,6 +53,9 @@ import org.opencast.annotation.impl.ScaleValueImpl;
 import org.opencast.annotation.impl.TrackImpl;
 import org.opencast.annotation.impl.UserImpl;
 import org.opencast.annotation.impl.VideoImpl;
+import org.opencast.annotation.impl.persistence.util.PersistenceEnv;
+import org.opencast.annotation.impl.persistence.util.PersistenceEnvs;
+import org.opencast.annotation.impl.persistence.util.Queries;
 
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.search.api.SearchQuery;
@@ -70,9 +73,6 @@ import org.opencastproject.util.data.Option.Match;
 import org.opencastproject.util.data.Predicate;
 import org.opencastproject.util.data.Tuple;
 import org.opencastproject.util.data.functions.Options;
-import org.opencastproject.util.persistence.PersistenceEnv;
-import org.opencastproject.util.persistence.PersistenceEnvs;
-import org.opencastproject.util.persistence.Queries;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -1270,7 +1270,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
   }
 
   /**
-   * Wrapper for {@link org.opencastproject.util.persistence.Queries#named}
+   * Wrapper for {@link org.opencast.annotation.impl.persistence.util.Queries#named}
    * to support safe varargs without warnings
    */
   // TODO Why this wrapper ...

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/util/PersistenceEnv.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/util/PersistenceEnv.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencast.annotation.impl.persistence.util;
+
+import org.opencastproject.util.data.Function;
+
+import javax.persistence.EntityManager;
+
+/** Persistence environment to perform a transaction. */
+public abstract class PersistenceEnv {
+  /** Run code inside a transaction. */
+  public abstract <A> A tx(Function<EntityManager, A> transactional);
+
+  /** {@link #tx(org.opencastproject.util.data.Function)} as a function. */
+  public <A> Function<Function<EntityManager, A>, A> tx() {
+    return new Function<Function<EntityManager, A>, A>() {
+      @Override
+      public A apply(Function<EntityManager, A> transactional) {
+        return tx(transactional);
+      }
+    };
+  }
+}

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/util/PersistenceEnvs.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/util/PersistenceEnvs.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencast.annotation.impl.persistence.util;
+
+import static org.opencast.annotation.impl.persistence.util.PersistenceUtil.createEntityManager;
+import static org.opencastproject.util.data.Option.none;
+import static org.opencastproject.util.data.functions.Misc.chuck;
+
+import org.opencastproject.util.data.Function;
+import org.opencastproject.util.data.Option;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+
+/** Persistence environment factory. */
+public final class PersistenceEnvs {
+  private PersistenceEnvs() {
+  }
+
+  private interface Transactional {
+    /** Run a function in a transactional context. */
+    <A> A tx(Function<EntityManager, A> transactional);
+  }
+
+  private static final ThreadLocal<Option<Transactional>> emStore = new ThreadLocal<Option<Transactional>>() {
+    @Override protected Option<Transactional> initialValue() {
+      return none();
+    }
+  };
+
+  /**
+   * Create a new, concurrently usable persistence environment which uses JPA local transactions.
+   * <p>
+   * Transaction propagation is supported on a per thread basis.
+   */
+  public static PersistenceEnv persistenceEnvironment(final EntityManagerFactory emf) {
+    final Transactional startTx = new Transactional() {
+      @Override
+      public <A> A tx(Function<EntityManager, A> transactional) {
+        for (final EntityManager em : createEntityManager(emf)) {
+          final EntityTransaction tx = em.getTransaction();
+          try {
+            tx.begin();
+            emStore.set(Option.<Transactional>some(new Transactional() {
+              @Override public <A> A tx(Function<EntityManager, A> transactional) {
+                return transactional.apply(em);
+              }
+            }));
+            A ret = transactional.apply(em);
+            tx.commit();
+            return ret;
+          } catch (Exception e) {
+            if (tx.isActive()) {
+              tx.rollback();
+            }
+            // propagate exception
+            return chuck(e);
+          } finally {
+            if (em.isOpen())
+              em.close();
+            emStore.remove();
+          }
+        }
+        return chuck(new IllegalStateException("EntityManager is already closed"));
+      }
+    };
+    return new PersistenceEnv() {
+      Transactional currentTx() {
+        return emStore.get().getOrElse(startTx);
+      }
+
+      @Override public <A> A tx(Function<EntityManager, A> transactional) {
+        return currentTx().tx(transactional);
+      }
+    };
+  }
+}

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/util/PersistenceUtil.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/util/PersistenceUtil.java
@@ -1,0 +1,328 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencast.annotation.impl.persistence.util;
+
+import static org.opencastproject.util.data.Monadics.mlist;
+import static org.opencastproject.util.data.Option.none;
+import static org.opencastproject.util.data.Option.option;
+import static org.opencastproject.util.data.Option.some;
+
+import org.opencastproject.util.data.Function;
+import org.opencastproject.util.data.Option;
+import org.opencastproject.util.data.Tuple;
+
+import com.mchange.v2.c3p0.ComboPooledDataSource;
+
+import org.eclipse.persistence.config.PersistenceUnitProperties;
+
+import java.beans.PropertyVetoException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.NoResultException;
+import javax.persistence.NonUniqueResultException;
+import javax.persistence.Query;
+import javax.persistence.TemporalType;
+import javax.persistence.spi.PersistenceProvider;
+
+/** Functions supporting persistence. */
+
+/**
+ * Functions supporting persistence.
+ */
+public final class PersistenceUtil {
+  private PersistenceUtil() {
+  }
+
+  /** Create a new entity manager or return none, if the factory has already been closed. */
+  public static Option<EntityManager> createEntityManager(EntityManagerFactory emf) {
+    try {
+      return some(emf.createEntityManager());
+    } catch (IllegalStateException ex) {
+      // factory is already closed
+      return none();
+    }
+  }
+
+  /**
+   * Create a new, concurrently usable persistence environment which uses JPA local transactions.
+   * <p>
+   * Transaction propagation is supported on a per thread basis.
+   *
+   * @deprecated use {@link PersistenceEnvs#persistenceEnvironment(EntityManagerFactory)}
+   */
+  @Deprecated
+  public static PersistenceEnv newPersistenceEnvironment(final EntityManagerFactory emf) {
+    return PersistenceEnvs.persistenceEnvironment(emf);
+  }
+
+  /**
+   * Create a named query with a list of parameters. Values of type {@link Date} are recognized and set as a timestamp (
+   * {@link TemporalType#TIMESTAMP}.
+   *
+   * @deprecated use {@link Queries#named} query(EntityManager, String, Class, Object[])
+   */
+  @Deprecated
+  public static Query createNamedQuery(EntityManager em, String queryName, Tuple<String, ?>... params) {
+    final Query q = em.createNamedQuery(queryName);
+    for (Tuple<String, ?> p : params) {
+      final Object value = p.getB();
+      if (value instanceof Date) {
+        q.setParameter(p.getA(), (Date) p.getB(), TemporalType.TIMESTAMP);
+      } else {
+        q.setParameter(p.getA(), p.getB());
+      }
+    }
+    return q;
+  }
+
+  /**
+   * Run an update (UPDATE or DELETE) query and ensure that at least one row got affected.
+   *
+   * @deprecated use {@link Queries#named} #update(EntityManager, String, Object[])
+   */
+  @Deprecated
+  public static boolean runUpdate(EntityManager em, String queryName, Tuple<String, ?>... params) {
+    return createNamedQuery(em, queryName, params).executeUpdate() > 0;
+  }
+
+  /**
+   * Run a query (SELECT) that should return a single result.
+   *
+   * @deprecated use {@link Queries#named} #findSingle(EntityManager, String, Object[])
+   */
+  @Deprecated
+  public static <A> Option<A> runSingleResultQuery(EntityManager em, String queryName, Tuple<String, ?>... params) {
+    try {
+      return some((A) createNamedQuery(em, queryName, params).getSingleResult());
+    } catch (NoResultException e) {
+      return none();
+    } catch (NonUniqueResultException e) {
+      return none();
+    }
+  }
+
+  /**
+   * Run a query that should return the first result of it.
+   *
+   * @deprecated use {@link Queries#named} findFirst(EntityManager, String, Object[])
+   */
+  @Deprecated
+  public static <A> Option<A> runFirstResultQuery(EntityManager em, String queryName, Tuple<String, ?>... params) {
+    try {
+      return some((A) createNamedQuery(em, queryName, params).setMaxResults(1).getSingleResult());
+    } catch (NoResultException e) {
+      return none();
+    } catch (NonUniqueResultException e) {
+      return none();
+    }
+  }
+
+  /**
+   * Execute a <code>COUNT(x)</code> query.
+   *
+   * @deprecated use {@link Queries#named} count(EntityManager, String, Object[])
+   */
+  @Deprecated
+  public static long runCountQuery(EntityManager em, String queryName, Tuple<String, ?>... params) {
+    return ((Number) createNamedQuery(em, queryName, params).getSingleResult()).longValue();
+  }
+
+  /** @deprecated use {@link Queries#find(Class, Object)} */
+  @Deprecated
+  public static <A> Function<EntityManager, Option<A>> findById(final Class<A> clazz, final Object primaryKey) {
+    return new Function<EntityManager, Option<A>>() {
+      @Override
+      public Option<A> apply(EntityManager em) {
+        return option(em.find(clazz, primaryKey));
+      }
+    };
+  }
+
+  /**
+   * Find a single object.
+   *
+   * @param params
+   *          the query parameters
+   * @param toA
+   *          map to the desired result object
+   * @deprecated
+   */
+  @Deprecated
+  public static <A, B> Option<A> find(EntityManager em, final Function<B, A> toA, final String queryName,
+          final Tuple<String, ?>... params) {
+    return PersistenceUtil.<B> runSingleResultQuery(em, queryName, params).map(toA);
+  }
+
+  /**
+   * Find multiple objects.
+   *
+   * @deprecated use {@link Queries#named} findAll(EntityManager, String, Object[])
+   */
+  @Deprecated
+  public static <A> List<A> findAll(EntityManager em, final String queryName, final Tuple<String, ?>... params) {
+    return createNamedQuery(em, queryName, params).getResultList();
+  }
+
+  /**
+   * Find multiple objects with optional pagination.
+   *
+   * @deprecated use {@link Queries#named} findAll(EntityManager, String, Option, Option, Object[])
+   */
+  @Deprecated
+  public static <A> List<A> findAll(EntityManager em, final String queryName, Option<Integer> offset,
+          Option<Integer> limit, final Tuple<String, ?>... params) {
+    final Query q = createNamedQuery(em, queryName, params);
+    for (Integer x : offset)
+      q.setFirstResult(x);
+    for (Integer x : limit)
+      q.setMaxResults(x);
+    return q.getResultList();
+  }
+
+  /**
+   * Find multiple objects.
+   *
+   * @param params
+   *          the query parameters
+   * @param toA
+   *          map to the desired result object
+   * @deprecated use {@link Queries#named} findAll(EntityManager, String, Object[]) instead
+   */
+  @Deprecated
+  public static <A, B> List<A> findAll(EntityManager em, final Function<B, A> toA, final String queryName,
+          final Tuple<String, ?>... params) {
+    return mlist((List<B>) createNamedQuery(em, queryName, params).getResultList()).map(toA).value();
+  }
+
+  /**
+   * Find multiple objects with optional pagination.
+   *
+   * @param params
+   *          the query parameters
+   * @param toA
+   *          map to the desired result object
+   * @deprecated use {@link Queries#named} findAll(EntityManager, String, Option, Option, Object[]) instead
+   */
+  @Deprecated
+  public static <A, B> List<A> findAll(EntityManager em, final Function<B, A> toA, Option<Integer> offset,
+          Option<Integer> limit, final String queryName, final Tuple<String, ?>... params) {
+    final Query q = createNamedQuery(em, queryName, params);
+    for (Integer x : offset)
+      q.setFirstResult(x);
+    for (Integer x : limit)
+      q.setMaxResults(x);
+    return mlist((List<B>) q.getResultList()).map(toA).value();
+  }
+
+  /**
+   * Create function to persist object <code>a</code> using {@link EntityManager#persist(Object)}.
+   *
+   * @deprecated use {@link Queries#persist(Object)}
+   */
+  @Deprecated
+  public static <A> Function<EntityManager, A> persist(final A a) {
+    return new Function<EntityManager, A>() {
+      @Override
+      public A apply(EntityManager em) {
+        em.persist(a);
+        return a;
+      }
+    };
+  }
+
+  /**
+   * Create function to merge an object <code>a</code> with the persisten context of the given entity manage.
+   */
+  @Deprecated
+  public static <A> Function<EntityManager, A> merge(final A a) {
+    return new Function<EntityManager, A>() {
+      @Override
+      public A apply(EntityManager em) {
+        em.merge(a);
+        return a;
+      }
+    };
+  }
+
+  public static EntityManagerFactory newEntityManagerFactory(String emName, String vendor, String driver, String url,
+          String user, String pwd, Map<String, ?> persistenceProps, PersistenceProvider pp) {
+    // Set up the database
+    final ComboPooledDataSource pooledDataSource = new ComboPooledDataSource();
+    try {
+      pooledDataSource.setDriverClass(driver);
+    } catch (PropertyVetoException e) {
+      throw new RuntimeException(e);
+    }
+    pooledDataSource.setJdbcUrl(url);
+    pooledDataSource.setUser(user);
+    pooledDataSource.setPassword(pwd);
+
+    // Set up the persistence properties
+    final Map<String, Object> props = new HashMap<>(persistenceProps);
+    props.put("javax.persistence.nonJtaDataSource", pooledDataSource);
+    props.put("eclipselink.target-database", vendor);
+
+    final EntityManagerFactory emf = pp.createEntityManagerFactory(emName, props);
+    if (emf == null) {
+      throw new Error("Cannot create entity manager factory for persistence unit " + emName
+              + ". Maybe you misspelled the name of the persistence unit?");
+    }
+    return emf;
+  }
+
+  /**
+   * Create a new entity manager factory backed by an in-memory H2 database for testing purposes.
+   *
+   * @param emName
+   *          name of the persistence unit (see META-INF/persistence.xml)
+   */
+  public static EntityManagerFactory newTestEntityManagerFactory(String emName) {
+    Map<String, String> persistenceProperties = new HashMap<>();
+    persistenceProperties.put(PersistenceUnitProperties.DDL_GENERATION, PersistenceUnitProperties.DROP_AND_CREATE);
+    persistenceProperties.put(PersistenceUnitProperties.DDL_GENERATION_MODE, PersistenceUnitProperties.DDL_DATABASE_GENERATION);
+    return newEntityManagerFactory(emName, "Auto", "org.h2.Driver", "jdbc:h2:./target/db" + System.currentTimeMillis(),
+            "sa", "sa", persistenceProperties, testPersistenceProvider());
+  }
+
+  /** Create a new persistence provider for unit tests. */
+  public static PersistenceProvider testPersistenceProvider() {
+    return new org.eclipse.persistence.jpa.PersistenceProvider();
+  }
+
+  /**
+   * Create a new persistence environment based on an entity manager factory backed by an in-memory H2 database for
+   * testing purposes.
+   *
+   * @param emName
+   *          name of the persistence unit (see META-INF/persistence.xml)
+   * @deprecated use {@link PersistenceEnvs#testPersistenceEnv(String)}
+   */
+  @Deprecated
+  public static PersistenceEnv newTestPersistenceEnv(String emName) {
+    return newPersistenceEnvironment(newTestEntityManagerFactory(emName));
+  }
+}

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/util/Queries.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/util/Queries.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ *
+ * The Apereo Foundation licenses this file to you under the Educational
+ * Community License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License
+ * at:
+ *
+ *   http://opensource.org/licenses/ecl2.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.opencast.annotation.impl.persistence.util;
+
+import static org.opencastproject.util.data.Option.option;
+
+import org.opencastproject.util.data.Function;
+import org.opencastproject.util.data.Option;
+import org.opencastproject.util.data.Tuple;
+
+import org.joda.time.base.AbstractInstant;
+
+import java.util.Date;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import javax.persistence.TemporalType;
+import javax.persistence.TypedQuery;
+
+/** JPA query constructors. */
+// CHECKSTYLE:OFF
+public final class Queries {
+  private Queries() {
+  }
+
+  /** {@link javax.persistence.EntityManager#find(Class, Object)} as a function wrapping the result into an Option. */
+  public static <A> Function<EntityManager, Option<A>> find(final Class<A> clazz, final Object primaryKey) {
+    return new Function<EntityManager, Option<A>>() {
+      @Override public Option<A> apply(EntityManager em) {
+        return option(em.find(clazz, primaryKey));
+      }
+    };
+  }
+
+  /** {@link javax.persistence.EntityManager#persist(Object)} as a function. */
+  public static <A> Function<EntityManager, A> persist(final A a) {
+    return new Function<EntityManager, A>() {
+      @Override public A apply(EntityManager em) {
+        em.persist(a);
+        return a;
+      }
+    };
+  }
+
+  /**
+   * Set a list of named parameters on a query.
+   *
+   * Values of type {@link java.util.Date} and {@link org.joda.time.base.AbstractInstant}
+   * are recognized and set as a timestamp ({@link javax.persistence.TemporalType#TIMESTAMP}.
+   */
+  public static <A extends Query> A setParams(A q, Tuple<String, ?>... params) {
+    for (Tuple<String, ?> p : params) {
+      final Object value = p.getB();
+      if (value instanceof Date) {
+        q.setParameter(p.getA(), (Date) value, TemporalType.TIMESTAMP);
+      }
+      if (value instanceof AbstractInstant) {
+        q.setParameter(p.getA(), ((AbstractInstant) value).toDate(), TemporalType.TIMESTAMP);
+      } else {
+        q.setParameter(p.getA(), p.getB());
+      }
+    }
+    return q;
+  }
+
+  // -------------------------------------------------------------------------------------------------------------------
+
+  /** Named queries with support for named parameters. */
+  public static final TypedQueriesBase<Tuple<String, ?>> named = new TypedQueriesBase<Tuple<String, ?>>() {
+    @Override public Query query(EntityManager em, String q, Tuple<String, ?>... params) {
+      return setParams(em.createNamedQuery(q), params);
+    }
+
+    @Override
+    public <A> TypedQuery<A> query(EntityManager em, String q, Class<A> type, Tuple<String, ?>... params) {
+      return setParams(em.createNamedQuery(q, type), params);
+    }
+  };
+
+  // -------------------------------------------------------------------------------------------------------------------
+
+  public static abstract class TypedQueriesBase<P> extends QueriesBase<P> {
+    protected TypedQueriesBase() {
+    }
+
+    /**
+     * Create a typed query from <code>q</code> with a list of parameters.
+     * Values of type {@link java.util.Date} are recognized
+     * and set as a timestamp ({@link javax.persistence.TemporalType#TIMESTAMP}.
+     */
+    public abstract <A> TypedQuery<A> query(EntityManager em,
+            String queryName,
+            Class<A> type,
+            Tuple<String, ?>... params);
+  }
+
+  // -------------------------------------------------------------------------------------------------------------------
+
+  public static abstract class QueriesBase<P> {
+    protected QueriesBase() {
+    }
+
+    /**
+     * Create a query from <code>q</code> with a list of parameters.
+     * Values of type {@link java.util.Date} are recognized
+     * and set as a timestamp ({@link javax.persistence.TemporalType#TIMESTAMP}.
+     */
+    public abstract Query query(EntityManager em, String q, P... params);
+
+    /** Run an update (UPDATE or DELETE) query and ensure that at least one row got affected. */
+    public boolean update(EntityManager em, String q, P... params) {
+      return query(em, q, params).executeUpdate() > 0;
+    }
+
+    /** {@link #update(EntityManager, String, Object[])} as a function. */
+    public Function<EntityManager, Boolean> update(final String q, final P... params) {
+      return new Function<EntityManager, Boolean>() {
+        @Override public Boolean apply(EntityManager em) {
+          return update(em, q, params);
+        }
+      };
+    }
+  }
+}

--- a/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/TestRestService.java
+++ b/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/TestRestService.java
@@ -15,7 +15,7 @@
  */
 package org.opencast.annotation.endpoint;
 
-import static org.opencastproject.util.persistence.PersistenceUtil.newTestEntityManagerFactory;
+import static org.opencast.annotation.impl.persistence.util.PersistenceUtil.newTestEntityManagerFactory;
 
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.impl.persistence.ExtendedAnnotationServiceJpaImpl;

--- a/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/impl/ExtendedAnnotationServiceJpaImplTest.java
+++ b/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/impl/ExtendedAnnotationServiceJpaImplTest.java
@@ -19,9 +19,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.opencast.annotation.impl.persistence.util.PersistenceUtil.newTestEntityManagerFactory;
 import static org.opencastproject.util.data.Option.none;
 import static org.opencastproject.util.data.Option.some;
-import static org.opencastproject.util.persistence.PersistenceUtil.newTestEntityManagerFactory;
 
 import org.opencast.annotation.api.Annotation;
 import org.opencast.annotation.api.Category;

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <pax.web.version>4.3.0</pax.web.version>
     <cxf.version>3.1.7</cxf.version>
     <jackson.version>2.7.0</jackson.version>
-    <opencast.version>[11,13-SNAPSHOT)</opencast.version>
+    <opencast.version>[12,14-SNAPSHOT)</opencast.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
This temporarily includes the missing dependencies for the annotation tool that were removed for Opencast 13 (see https://github.com/opencast/opencast/pull/3903). For the future, the annotation tool should be reworked so it works with the new persistence utility classes in Opencast.

This fixes #595 and officially makes the Annotation Tool compatible with Opencast 13.