### PR TITLE
Fix db compatibility issues with Opencast 13

### DIFF
--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestService.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestService.java
@@ -31,9 +31,6 @@ import org.osgi.service.component.annotations.Reference;
 
 import javax.ws.rs.Path;
 
-@Component(service = ExtendedAnnotationsRestService.class, property = {
-        "opencast.service.type=org.opencast.annotation",
-        "opencast.service.path=/extended-annotations"})
 @Path("/")
 @RestService(
     name = "extended-annotations",
@@ -41,6 +38,11 @@ import javax.ws.rs.Path;
     abstractText = "Scientific video annotations on Opencast media..",
     notes = { "The Annotation Tool does not yet provide REST documentation." }
 )
+@Component(service = ExtendedAnnotationsRestService.class,
+        immediate = true,
+        property = {
+        "opencast.service.type=org.opencast.annotation",
+        "opencast.service.path=/extended-annotations"})
 public class ExtendedAnnotationsRestService extends AbstractExtendedAnnotationsRestService {
 
   private ExtendedAnnotationService extendedAnnotationService;

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
@@ -1331,7 +1331,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
     return result;
   }
 
-  protected <T> TypedQuery<T> configureQuery(TypedQuery<T> q, Object... params) {
+  private <T> TypedQuery<T> configureQuery(TypedQuery<T> q, Object... params) {
     return (TypedQuery<T>) configureQuery((Query) q, params);
   }
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
@@ -1339,7 +1339,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
    * When creating queries on the em directly, we need to pay special attention to dates
    * Copied from https://github.com/opencast/opencast/blob/develop/modules/common/src/main/java/org/opencastproject/db/Queries.java#L58
    */
-  protected Query configureQuery(Query q, Object... params) {
+  private Query configureQuery(Query q, Object... params) {
     for (int i = 0; i < params.length; i++) {
       Object p = params[i];
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
@@ -149,17 +149,16 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
   private <A> A tx(java.util.function.Function<EntityManager, A> f) {
     try {
       return db.execTx(f);
-    } catch (Exception e) {
-      if (e instanceof ExtendedAnnotationException) {
-        throw (ExtendedAnnotationException) e;
-      } else if (e instanceof RollbackException) {
-        final Throwable cause = e.getCause();
-        String message = cause.getMessage().toLowerCase();
-        if (message.contains("unique") || message.contains("duplicate"))
-          throw new ExtendedAnnotationException(Cause.DUPLICATE);
-      } else if (e instanceof NoResultException) {
-        throw new ExtendedAnnotationException(Cause.NOT_FOUND);
+    } catch (NoResultException e) {
+      throw new ExtendedAnnotationException(Cause.NOT_FOUND);
+    } catch (RollbackException e) {
+      Throwable cause = e.getCause();
+      String message = cause.getMessage().toLowerCase();
+      if (message.contains("unique") || message.contains("duplicate")) {
+        throw new ExtendedAnnotationException(Cause.DUPLICATE);
       }
+      throw new ExtendedAnnotationException(Cause.SERVER_ERROR, e);
+    } catch (RuntimeException e) {
       throw new ExtendedAnnotationException(Cause.SERVER_ERROR, e);
     }
   }

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
@@ -191,22 +191,22 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
   @Override
   public boolean clearDatabase() throws ExtendedAnnotationException {
     return tx(em -> {
-        namedQuery.update("Annotation.clear").apply(em);
-        namedQuery.update("Track.clear").apply(em);
-        namedQuery.update("User.clear").apply(em);
-        namedQuery.update("Video.clear").apply(em);
-        namedQuery.update("Category.clear").apply(em);
-        namedQuery.update("Label.clear").apply(em);
-        namedQuery.update("Annotation.clear").apply(em);
-        namedQuery.update("Track.clear").apply(em);
-        namedQuery.update("User.clear").apply(em);
-        namedQuery.update("Video.clear").apply(em);
-        namedQuery.update("Category.clear").apply(em);
-        namedQuery.update("Label.clear").apply(em);
-        namedQuery.update("Scale.clear").apply(em);
-        namedQuery.update("ScaleValue.clear").apply(em);
-        namedQuery.update("Comment.clear").apply(em);
-        return true;
+      namedQuery.update("Annotation.clear").apply(em);
+      namedQuery.update("Track.clear").apply(em);
+      namedQuery.update("User.clear").apply(em);
+      namedQuery.update("Video.clear").apply(em);
+      namedQuery.update("Category.clear").apply(em);
+      namedQuery.update("Label.clear").apply(em);
+      namedQuery.update("Annotation.clear").apply(em);
+      namedQuery.update("Track.clear").apply(em);
+      namedQuery.update("User.clear").apply(em);
+      namedQuery.update("Video.clear").apply(em);
+      namedQuery.update("Category.clear").apply(em);
+      namedQuery.update("Label.clear").apply(em);
+      namedQuery.update("Scale.clear").apply(em);
+      namedQuery.update("ScaleValue.clear").apply(em);
+      namedQuery.update("Comment.clear").apply(em);
+      return true;
     });
   }
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
@@ -1316,9 +1316,6 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
           Option<Integer> limit, Pair<String, Object>... params) {
     List<T> result = tx(em -> {
       TypedQuery<T> partial = configureQuery(em.createNamedQuery(q, type), params);
-      for (Pair<String, Object> param : params) {
-        partial.setParameter(param.getLeft(), param.getRight());
-      }
       if (limit.isSome()) {
         partial.setMaxResults(limit.get());
       }

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
@@ -409,7 +409,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
   /** Generic update method. */
   private <A> void update(String q, long id, Effect<A> update) {
     tx(em -> {
-      A o = (A) namedQuery.find(q, Pair.of("id", id)).apply(em);
+      A o = (A) namedQuery.find(q, id(id)).apply(em);
 
       update.apply(o);
       return o;
@@ -1066,7 +1066,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
    */
   private <A, B> Option<A> findById(final Function<B, A> toA, final String queryName, final Object id) {
     Optional<B> result = (Optional<B>) tx(em -> {
-      return namedQuery.findOpt(queryName, Pair.of("id", id)).apply(em);
+      return namedQuery.findOpt(queryName, id(id)).apply(em);
     });
     if (result.isPresent()) {
       A appliedResult = toA.apply(result.get());

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
@@ -211,7 +211,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
 
   @Override
   public Option<User> getUser(final long id) {
-    return findById(toUser, "User.findById", id);
+    return findById(toUser, "User.findById", id, UserDto.class);
   }
 
   @Override
@@ -229,7 +229,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
 
   @Override
   public Option<User> getUserByExtId(final String id) {
-    return findById(toUser, "User.findByUserId", id);
+    return findById(toUser, "User.findByUserId", id, UserDto.class);
   }
 
   @Override
@@ -273,7 +273,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
 
   @Override
   public Option<Video> getVideo(final long id) throws ExtendedAnnotationException {
-    return findById(toVideo, "Video.findById", id);
+    return findById(toVideo, "Video.findById", id, VideoDto.class);
   }
 
   @Override
@@ -287,7 +287,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
 
   @Override
   public Option<Video> getVideoByExtId(final String id) throws ExtendedAnnotationException {
-    return findById(toVideo, "Video.findByExtId", id);
+    return findById(toVideo, "Video.findByExtId", id, VideoDto.class);
   }
 
   @Override
@@ -326,7 +326,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
 
   @Override
   public Option<Track> getTrack(final long trackId) throws ExtendedAnnotationException {
-    return findById(toTrack, "Track.findById", trackId);
+    return findById(toTrack, "Track.findById", trackId, TrackDto.class);
   }
 
   /** Remove all none values from the list of query parameters. */
@@ -427,7 +427,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
 
   @Override
   public Option<Annotation> getAnnotation(long id) throws ExtendedAnnotationException {
-    return findById(toAnnotation, "Annotation.findById", id);
+    return findById(toAnnotation, "Annotation.findById", id, AnnotationDto.class);
   }
 
   @Override
@@ -492,9 +492,9 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
   public Option<Scale> getScale(long id, boolean includeDeleted) throws ExtendedAnnotationException {
     final Option<Scale> scale;
     if (includeDeleted) {
-      scale = findById(toScale, "Scale.findByIdIncludeDeleted", id);
+      scale = findById(toScale, "Scale.findByIdIncludeDeleted", id, ScaleDto.class);
     } else {
-      scale = findById(toScale, "Scale.findById", id);
+      scale = findById(toScale, "Scale.findById", id, ScaleDto.class);
     }
     return scale;
   }
@@ -590,7 +590,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
 
   @Override
   public Option<ScaleValue> getScaleValue(long id) throws ExtendedAnnotationException {
-    return findById(toScaleValue, "ScaleValue.findById", id);
+    return findById(toScaleValue, "ScaleValue.findById", id, ScaleValueDto.class);
   }
 
   @Override
@@ -671,7 +671,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
   @Override
   public void updateCategoryAndDeleteOtherSeriesCategories(final Category c) throws ExtendedAnnotationException {
     // Get the pre-update version of the category, to figure out its seriesCategoryId
-    Option<Category> pastC = findById(toCategory, "Category.findById", c.getId());
+    Option<Category> pastC = findById(toCategory, "Category.findById", c.getId(), CategoryDto.class);
 
     // Get all categories on all videos belonging to the seriesCategoryId (including the master)
     if (pastC.isSome() && pastC.get().getSeriesCategoryId().isSome()) {
@@ -697,9 +697,9 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
   public Option<Category> getCategory(long id, boolean includeDeleted) throws ExtendedAnnotationException {
     Option<Category> category;
     if (includeDeleted) {
-      category = findById(toCategory, "Category.findByIdIncludeDeleted", id);
+      category = findById(toCategory, "Category.findByIdIncludeDeleted", id, CategoryDto.class);
     } else {
-      category = findById(toCategory, "Category.findById", id);
+      category = findById(toCategory, "Category.findById", id, CategoryDto.class);
     }
     return category;
   }
@@ -897,9 +897,9 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
   public Option<Label> getLabel(long id, boolean includeDeleted) throws ExtendedAnnotationException {
     Option<Label> label;
     if (includeDeleted) {
-      label = findById(toLabel, "Label.findByIdIncludeDeleted", id);
+      label = findById(toLabel, "Label.findByIdIncludeDeleted", id, LabelDto.class);
     } else {
-      label = findById(toLabel, "Label.findById", id);
+      label = findById(toLabel, "Label.findById", id, LabelDto.class);
     }
     return label;
   }
@@ -995,7 +995,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
 
   @Override
   public Option<Comment> getComment(long id) {
-    return findById(toComment, "Comment.findById", id);
+    return findById(toComment, "Comment.findById", id, CommentDto.class);
   }
 
   @Override
@@ -1057,29 +1057,6 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
   }
 
   private static final ExtendedAnnotationException notFound = new ExtendedAnnotationException(Cause.NOT_FOUND);
-
-  /**
-   * Do not nest inside a tx!
-   *
-   * @param id
-   *          value of the ":id" parameter in the named query.
-   */
-  private <A, B> Option<A> findById(final Function<B, A> toA, final String queryName, final Object id) {
-    Optional<B> result = (Optional<B>) tx(em -> {
-      return namedQuery.findOpt(queryName, id(id)).apply(em);
-    });
-    if (result.isPresent()) {
-      A appliedResult = toA.apply(result.get());
-      return some(appliedResult);
-    } else {
-      return none();
-    }
-  }
-
-  /** Create an "id" parameter pair. */
-  private static <A> Pair<String, A> id(A id) {
-    return Pair.of("id", id);
-  }
 
   @Override
   public Resource createResource() {
@@ -1298,6 +1275,29 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
         }
       }).value();
     }
+  }
+
+  /**
+   * Do not nest inside a tx!
+   *
+   * @param id
+   *          value of the ":id" parameter in the named query.
+   */
+  private <A, B> Option<A> findById(final Function<B, A> toA, final String queryName, final Object id, Class<B> type) {
+    Optional<B> result = tx(em -> {
+      return namedQuery.findOpt(queryName, type, id(id)).apply(em);
+    });
+    if (result.isPresent()) {
+      A appliedResult = toA.apply(result.get());
+      return some(appliedResult);
+    } else {
+      return none();
+    }
+  }
+
+  /** Create an "id" parameter pair. */
+  private static <A> Pair<String, A> id(A id) {
+    return Pair.of("id", id);
   }
 
   /**

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
@@ -1074,7 +1074,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
   }
 
   /** Create an "id" parameter pair. */
-  public static <A> Pair<String, A> id(A id) {
+  private static <A> Pair<String, A> id(A id) {
     return Pair.of("id", id);
   }
 

--- a/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/TestRestService.java
+++ b/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/TestRestService.java
@@ -15,7 +15,8 @@
  */
 package org.opencast.annotation.endpoint;
 
-import static org.opencastproject.util.persistence.PersistenceUtil.newTestEntityManagerFactory;
+import static org.opencastproject.db.DBTestEnv.getDbSessionFactory;
+import static org.opencastproject.db.DBTestEnv.newEntityManagerFactory;
 
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.impl.persistence.ExtendedAnnotationServiceJpaImpl;
@@ -51,7 +52,9 @@ public class TestRestService extends AbstractExtendedAnnotationsRestService {
     extendedAnnotationService.setSecurityService(getSecurityService());
     extendedAnnotationService.setAuthorizationService(getAuthorizationService());
     extendedAnnotationService.setEntityManagerFactory(
-            newTestEntityManagerFactory("org.opencast.annotation.impl.persistence"));
+            newEntityManagerFactory("org.opencast.annotation.impl.persistence"));
+    extendedAnnotationService.setDBSessionFactory(getDbSessionFactory());
+    extendedAnnotationService.activate();
   }
 
   @Override

--- a/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/impl/ExtendedAnnotationServiceJpaImplTest.java
+++ b/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/impl/ExtendedAnnotationServiceJpaImplTest.java
@@ -19,9 +19,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.opencastproject.db.DBTestEnv.getDbSessionFactory;
+import static org.opencastproject.db.DBTestEnv.newEntityManagerFactory;
 import static org.opencastproject.util.data.Option.none;
 import static org.opencastproject.util.data.Option.some;
-import static org.opencastproject.util.persistence.PersistenceUtil.newTestEntityManagerFactory;
 
 import org.opencast.annotation.api.Annotation;
 import org.opencast.annotation.api.Category;
@@ -673,8 +674,9 @@ public class ExtendedAnnotationServiceJpaImplTest {
     extendedAnnotationService.setSecurityService(securityService);
     extendedAnnotationService.setSearchService(searchService);
     extendedAnnotationService.setAuthorizationService(authorizationService);
-    extendedAnnotationService.setEntityManagerFactory(
-            newTestEntityManagerFactory("org.opencast.annotation.impl.persistence"));
+    extendedAnnotationService.setEntityManagerFactory(newEntityManagerFactory("org.opencast.annotation.impl.persistence"));
+    extendedAnnotationService.setDBSessionFactory(getDbSessionFactory());
+    extendedAnnotationService.activate();
     return extendedAnnotationService;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <pax.web.version>4.3.0</pax.web.version>
     <cxf.version>3.1.7</cxf.version>
     <jackson.version>2.7.0</jackson.version>
-    <opencast.version>[11,13-SNAPSHOT)</opencast.version>
+    <opencast.version>[11,13-SNAPSHOT]</opencast.version>
   </properties>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <pax.web.version>4.3.0</pax.web.version>
     <cxf.version>3.1.7</cxf.version>
     <jackson.version>2.7.0</jackson.version>
-    <opencast.version>[11,13-SNAPSHOT]</opencast.version>
+    <opencast.version>[13,16-SNAPSHOT)</opencast.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
Opencast 13 reworked some of their common db classes (in PR opencast#3903), which we also use in the Annotation Tool, thus breaking it.

This commit attempts to fix the breaking changes by using the new classes introduced in Opencast 13. From a user perspective, this should change exactly nothing. There is also no DB migration, as the db entries themselves have not changed.

This commit is based on groundwork by @KatrinIhler, massive thanks to her.

Should fix #595, and supersede #606