### PR TITLE
Revert "Update `h2`"

### DIFF
--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/AnnotationDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/AnnotationDto.java
@@ -98,7 +98,7 @@ public class AnnotationDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "\"VALUE\"")
+  @Column(name = "value")
   @CollectionTable(name = "xannotations_annotation_tags", joinColumns = @JoinColumn(name = "annotation_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/CategoryDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/CategoryDto.java
@@ -96,7 +96,7 @@ public class CategoryDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "\"VALUE\"")
+  @Column(name = "value")
   @CollectionTable(name = "xannotations_category_tags", joinColumns = @JoinColumn(name = "category_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/CommentDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/CommentDto.java
@@ -84,7 +84,7 @@ public class CommentDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "\"VALUE\"")
+  @Column(name = "value")
   @CollectionTable(name = "xannotations_comment_tags", joinColumns = @JoinColumn(name = "comment_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/LabelDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/LabelDto.java
@@ -72,7 +72,7 @@ public class LabelDto extends AbstractResourceDto {
   @Column(name = "series_label_id")
   private Long seriesLabelId;
 
-  @Column(name = "\"VALUE\"", nullable = false)
+  @Column(name = "value", nullable = false)
   private String value;
 
   @Column(name = "abbreviation", nullable = false)
@@ -90,7 +90,7 @@ public class LabelDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "\"VALUE\"")
+  @Column(name = "value")
   @CollectionTable(name = "xannotations_label_tags", joinColumns = @JoinColumn(name = "label_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ScaleDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ScaleDto.java
@@ -82,7 +82,7 @@ public class ScaleDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "\"VALUE\"")
+  @Column(name = "value")
   @CollectionTable(name = "xannotations_scale_tags", joinColumns = @JoinColumn(name = "scale_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ScaleValueDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ScaleValueDto.java
@@ -70,7 +70,7 @@ public class ScaleValueDto extends AbstractResourceDto {
   @Column(name = "name", nullable = false)
   private String name;
 
-  @Column(name = "\"VALUE\"", nullable = false)
+  @Column(name = "value", nullable = false)
   private double value;
 
   @Column(name = "order_value", nullable = false)
@@ -82,7 +82,7 @@ public class ScaleValueDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "\"VALUE\"")
+  @Column(name = "value")
   @CollectionTable(name = "xannotations_scale_value_tags", joinColumns = @JoinColumn(name = "scale_value_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/TrackDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/TrackDto.java
@@ -82,7 +82,7 @@ public class TrackDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "\"VALUE\"")
+  @Column(name = "value")
   @CollectionTable(name = "xannotations_track_tags", joinColumns = @JoinColumn(name = "track_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/UserDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/UserDto.java
@@ -79,7 +79,7 @@ public class UserDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "\"VALUE\"")
+  @Column(name = "value")
   @CollectionTable(name = "xannotations_user_tags", joinColumns = @JoinColumn(name = "user_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/VideoDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/VideoDto.java
@@ -68,7 +68,7 @@ public final class VideoDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "\"VALUE\"")
+  @Column(name = "value")
   @CollectionTable(name = "xannotations_video_tags", joinColumns = @JoinColumn(name = "video_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/resources/META-INF/persistence.xml
+++ b/opencast-backend/annotation-impl/src/main/resources/META-INF/persistence.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence
-    version="2.1"
-    xmlns="http://xmlns.jcp.org/xml/ns/persistence"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
->
+<persistence version="2.1" xmlns="http://xmlns.jcp.org/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence     http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
   <persistence-unit name="org.opencast.annotation.impl.persistence" transaction-type="RESOURCE_LOCAL">
     <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
     <non-jta-data-source>osgi:service/javax.sql.DataSource/(osgi.jndi.service.name=jdbc/opencast)</non-jta-data-source>
@@ -21,6 +16,8 @@
     <properties>
       <property name="eclipselink.ddl-generation" value="create-tables"/>
       <property name="eclipselink.logging.logger" value="JavaLogger"/>
+      <property name="eclipselink.create-ddl-jdbc-file-name" value="create-matterhorn-extended-annotation-impl.jdbc"/>
+      <property name="eclipselink.drop-ddl-jdbc-file-name" value="drop-matterhorn-extended-annotation-impl.jdbc"/>
     </properties>
   </persistence-unit>
 </persistence>

--- a/pom.xml
+++ b/pom.xml
@@ -521,8 +521,7 @@
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
-        <version>2.2.220</version>
-        <scope>test</scope>
+        <version>1.3.176</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Reverts opencast/annotation-tool#611

Unfortunately this doesn't work with Postgres. 😔

H2 and MariaDB treat unquoted identifiers as uppercase by default, but Postgres lowercases them.

So this will always be a breaking change for **someone**, and I think this is the time where we finally need to look into a proper migration mechanism.