### PR TITLE
Make tool work with Solr removal

### DIFF
--- a/frontend/js/integrations/search.js
+++ b/frontend/js/integrations/search.js
@@ -87,7 +87,7 @@ define([
         data: "id=" + mediaPackageId + "&limit=1",
         dataType: "json"
     }).then(function (data) {
-        return data["search-results"].result;
+        return data.result[0];
     });
     var mediaPackage = searchResult.then(function (result) {
         return result.mediapackage;

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
@@ -60,12 +60,12 @@ import org.opencast.annotation.impl.VideoImpl;
 import org.opencastproject.db.DBSession;
 import org.opencastproject.db.DBSessionFactory;
 import org.opencastproject.mediapackage.MediaPackage;
-import org.opencastproject.search.api.SearchQuery;
-import org.opencastproject.search.api.SearchResultItem;
 import org.opencastproject.search.api.SearchService;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
+import org.opencastproject.security.api.UnauthorizedException;
+import org.opencastproject.util.NotFoundException;
 import org.opencastproject.util.data.Effect;
 import org.opencastproject.util.data.Function;
 import org.opencastproject.util.data.Function0;
@@ -1271,14 +1271,11 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
 
   @Override
   public Option<MediaPackage> findMediaPackage(String id) {
-    return head(searchService.getByQuery(new SearchQuery().withId(id)).getItems()).map(
-            new Function<>() {
-              @Override
-              public MediaPackage apply(SearchResultItem searchResultItem) {
-                return searchResultItem.getMediaPackage();
-              }
-            }
-    );
+    try {
+      return Option.some(searchService.get(id));
+    } catch (NotFoundException | UnauthorizedException e) {
+      return Option.none();
+    }
   }
 
   @Override

--- a/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/TestRestService.java
+++ b/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/TestRestService.java
@@ -22,9 +22,6 @@ import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.impl.persistence.ExtendedAnnotationServiceJpaImpl;
 
 import org.opencastproject.mediapackage.MediaPackage;
-import org.opencastproject.search.api.SearchQuery;
-import org.opencastproject.search.api.SearchResult;
-import org.opencastproject.search.api.SearchResultItem;
 import org.opencastproject.search.api.SearchService;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.DefaultOrganization;
@@ -47,7 +44,7 @@ public class TestRestService extends AbstractExtendedAnnotationsRestService {
   // Haven't found out who's responsible forf this but that's the way it is.
   public static final ExtendedAnnotationServiceJpaImpl extendedAnnotationService =
           new ExtendedAnnotationServiceJpaImpl();
-  static {
+  static  {
     extendedAnnotationService.setSearchService(getSearchService());
     extendedAnnotationService.setSecurityService(getSecurityService());
     extendedAnnotationService.setAuthorizationService(getAuthorizationService());
@@ -90,17 +87,12 @@ public class TestRestService extends AbstractExtendedAnnotationsRestService {
   private static SearchService getSearchService() {
     MediaPackage mediaPackage = EasyMock.createNiceMock(MediaPackage.class);
 
-    SearchResultItem searchResultItem = EasyMock.createNiceMock(SearchResultItem.class);
-    EasyMock.expect(searchResultItem.getMediaPackage()).andReturn(mediaPackage).anyTimes();
-    EasyMock.replay(searchResultItem);
-
-    SearchResult searchResult = EasyMock.createNiceMock(SearchResult.class);
-    EasyMock.expect(searchResult.getItems()).andReturn(new SearchResultItem[]{searchResultItem}).anyTimes();
-    EasyMock.replay(searchResult);
-
     SearchService searchService = EasyMock.createNiceMock(SearchService.class);
-    EasyMock.expect(searchService.getByQuery(EasyMock.anyObject(SearchQuery.class)))
-            .andReturn(searchResult).anyTimes();
+    try {
+      EasyMock.expect(searchService.get(EasyMock.anyObject(String.class))).andReturn(mediaPackage).anyTimes();
+    } catch (Exception e) {
+      // Do nothing. We just have to pretend to handle checked exceptions somehow to appease the compiler.
+    }
     EasyMock.replay(searchService);
     return searchService;
   }

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <opencast.build.version>14.0</opencast.build.version>
-    <opencast.deploy.version>;version="${opencast.build.version}"</opencast.deploy.version>
+    <opencast.build.version>16-SNAPSHOT</opencast.build.version>
+    <opencast.deploy.version>;version=16.0</opencast.deploy.version>
   </properties>
 
   <build>


### PR DESCRIPTION
Over in Opencast, there is a pull request that makes changes to the Opencast Search Service, breaking the Annotation Tool:
https://github.com/opencast/opencast/pull/5597

Since that pull request 5597 is all but assured to go into Opencast 16, this commit attempts to fix
the errors that 5597 would introduce.

This DOES constitute a breaking change.