### PR TITLE
Fixes for serverless HLS

### DIFF
--- a/frontend/js/integrations/search.js
+++ b/frontend/js/integrations/search.js
@@ -159,6 +159,7 @@ define([
                         RegExp.prototype.test.bind(/application\/.*|video\/.*/),
                         _.property("mimetype")
                     ));
+                videos = _.sortBy(videos, "master").reverse();
                 videos.sort(
                     util.lexicographic([
                         util.firstWith(_.compose(

--- a/frontend/js/player-adapter-html5.js
+++ b/frontend/js/player-adapter-html5.js
@@ -85,7 +85,7 @@ define(
 
                 window.Hls = Hls;
                 mediaElementPlayer = new mejs.MediaElementPlayer(targetElement, {
-                    renderers: ["html5", "native_hls"],
+                    renderers: ["native_hls", "html5"],
                     alwaysShowControls: true,
                     autoRewind: false,
                     stretching: "fill",
@@ -96,7 +96,7 @@ define(
                          */
                         $(mediaElement).on("canplay durationchange", function () {
                             // If duration is still not valid
-                            if (isNaN(self.getDuration()) || mediaElement.readyState < 1) {
+                            if (!isFinite(self.getDuration()) || mediaElement.readyState < 1) {
                                 return;
                             }
 


### PR DESCRIPTION
Actual changes from @luniki.

- Pefer master playlists over non-master playlists and mp4s
- Prefer native_hls renderer
- Wait for !isFinitite instead of isNan for this renderer