### PR TITLE
fix loading when 'video' key is missing

### DIFF
--- a/frontend/js/integrations/search.js
+++ b/frontend/js/integrations/search.js
@@ -184,8 +184,8 @@ define([
                         return {
                             src: track.url,
                             type: track.mimetype,
-                            framerate: track.video.framerate,
-                            resolution: track.video.resolution
+                            framerate: track.video && track.video.framerate,
+                            resolution: track.video && track.video.resolution
                         };
                     })
                 );


### PR DESCRIPTION
After updating to OC 16.4 we had the issue that the videos did not load in the OAT. @luniki found out that it is related to HLS tracks missing the "video" key. The changes in this PR fix this by only using tracks that have the correct keys. 

We are however unsure as to why this was no issue with older versions of the OAT. 