### PR TITLE
Fix wrong dcTitle key

### DIFF
--- a/frontend/js/integrations/search.js
+++ b/frontend/js/integrations/search.js
@@ -115,7 +115,7 @@ define([
                 return {
                     video_extid: id,
                     series_extid: mediaPackage.series,
-                    title: result.dcTitle
+                    title: result.dc.title
                 };
             });
         },

--- a/frontend/js/integrations/search.js
+++ b/frontend/js/integrations/search.js
@@ -111,11 +111,11 @@ define([
          * @return {Promise.<object>} Metadata about the video
          */
         getVideoParameters: function () {
-            return $.when(mediaPackageId, searchResult, mediaPackage).then(function (id, result, mediaPackage) {
+            return mediaPackage.then(function (mediaPackage) {
                 return {
-                    video_extid: id,
+                    video_extid: mediaPackage.id,
                     series_extid: mediaPackage.series,
-                    title: result.dc.title
+                    title: mediaPackage.title,
                 };
             });
         },


### PR DESCRIPTION
This PR fixes https://github.com/opencast/annotation-tool/issues/633 . 

The structure of the field `result.dcTitle` changed at some point in OC, so that we need to call the sub-field `dc.title` . 