### PR TITLE
Fix height of container for creating new annotations

### DIFF
--- a/frontend/style/annotations/annotate.less
+++ b/frontend/style/annotations/annotate.less
@@ -30,8 +30,8 @@ i.check {
         flex-direction: column;
 
         .categories-container-scroll {
-            overflow-y: scroll;
-            height: 100vh;
+            overflow-y: auto;
+            height: auto;
         }
 
         .dropdown {


### PR DESCRIPTION
This PR should fix https://github.com/opencast/annotation-tool/issues/630 . 

For some reason the default height for the container containing the labels was set to `100vh`. I set this to `auto` so that it won't use the whole screen height. 

I also changed the value for `overflow-y` to `auto` so that the scrollbar for labels is only visible, when neccessary. 