### PR TITLE
Put Less into math mode `'always'`

### DIFF
--- a/frontend/Gruntfile.js
+++ b/frontend/Gruntfile.js
@@ -17,6 +17,7 @@ module.exports = function (grunt) {
                 syncImport: true,
                 compress: true,
                 sourceMap: true,
+                math: 'always',
                 sourceMapURL: 'style/style.css.map',
                 sourceMapBasepath: 'style'
             },


### PR DESCRIPTION
The upgrade to v4 of Less in b154c7b8a6767303fd9e9a443373d3c8f13faa33 introduced some changes that broke our version of Bootstrap. Specifically, division in `.less` files now has to be in parantheses by default. We fixed a few instances of that in the vendored files, but missed many others.

Instead of futzing around with these files even more, this patch puts Less in a compatibility mode. **Note**: This mode is deprecated, so this is only a temporary solution, until we find the time and money to update Bootstrap.

Fixes #632.