### PR TITLE
Insert space instead of linebreak for shortened title 

### DIFF
--- a/frontend/style/annotations/list.less
+++ b/frontend/style/annotations/list.less
@@ -337,8 +337,12 @@
             top: 2px;
             width: 60%; // Mobile
 
-            br{
-                display: none;
+            br {
+                content: ""
+            }
+
+            br:after {
+                content: "\00a0"
             }
         }
 

--- a/frontend/style/annotations/list.less
+++ b/frontend/style/annotations/list.less
@@ -336,6 +336,10 @@
             position: relative;
             top: 2px;
             width: 60%; // Mobile
+
+            br{
+                display: none;
+            }
         }
 
         .content-item .actions {


### PR DESCRIPTION
This PR should fix https://github.com/opencast/annotation-tool/issues/597 . 

It replaces `br` tags with a whitespace, so that no multiple lines are displayed. Also a whitespace is added so that if there are multiple short paragraphs the title remains readable. 