### PR TITLE
Call tracks.showTracks in any case

### DIFF
--- a/frontend/js/annotation-tool.js
+++ b/frontend/js/annotation-tool.js
@@ -225,15 +225,15 @@ define(
                             wait: true,
                             success: function () { ready.resolve(); }
                         });
-                    } else {
-                        tracks.showTracks(
-                            tracks.filter(function (track) {
-                                return track.isMine()
-                                    || track.get("access") === ACCESS.SHARED_WITH_EVERYONE;
-                            })
-                        );
-                        ready.resolve();
                     }
+                    tracks.showTracks(
+                        tracks.filter(function (track) {
+                            return track.isMine()
+                                || track.get("access") === ACCESS.SHARED_WITH_EVERYONE;
+                        })
+                    );
+                    ready.resolve();
+
                     return ready.then(function () { return tracks; });
                 }, this)).then(_.bind(function (tracks) {
                     // At least one private track should exist, we select the first one


### PR DESCRIPTION
This PR should fix https://github.com/opencast/annotation-tool/issues/573 . 

I haven't spent much time/thoughts on this so there is probably a better solution, but calling `tracks.showTracks()` in any case (even after initially creating the users own track) seems to fix the issue. 