### PR TITLE
Insert new annotations as point-in-time annotations

### DIFF
--- a/frontend/js/models/annotation.js
+++ b/frontend/js/models/annotation.js
@@ -46,7 +46,7 @@ define(
                 return {
                     start: 0,
 
-                    // Value > 0 for time based annotation by default (contrary to point annotation)
+                    // Value = 0 for point annotation as default
                     duration: 0,
 
                     comments: new Comments([], { annotation: this }),

--- a/frontend/js/models/annotation.js
+++ b/frontend/js/models/annotation.js
@@ -47,7 +47,7 @@ define(
                     start: 0,
 
                     // Value > 0 for time based annotation by default (contrary to point annotation)
-                    duration: 0.5,
+                    duration: 0,
 
                     comments: new Comments([], { annotation: this }),
                     content: new AnnotationContent([])


### PR DESCRIPTION
This PR should fix https://github.com/opencast/annotation-tool/issues/631. 

Instead of inserting new annotations as a time based annotation with a fixed duration, they now get added as a point annotation esuring that they have a sesible width in the timeline as well as an anchor. 
If needed the user can of course still simply convert the annotation to a time-based one. 