### PR TITLE
Categories belongig to a series: Duplicated Labels

### DIFF
--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
@@ -916,6 +916,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
           throws ExtendedAnnotationException {
 
     List<Label> labels;
+    List<Label> deletedLabels = new ArrayList<>();
 
     if (since.isSome()) {
       List<LabelDto> labelDtos = findAllWithOffsetAndLimit(LabelDto.class, "Label.findAllOfCategorySince", offset, limit,
@@ -945,7 +946,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
         // Update our labels with the labels from the master series category
         // Note: Maybe do an actual update instead of delete/create
         for (Label label: labels) {
-          deleteLabel(label);
+          deletedLabels.add(deleteLabel(label));
         }
         List<Label> newLabels = new ArrayList<>();
         for (Label seriesLabel : seriesCategoryLabels) {
@@ -967,7 +968,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
         // @todo CC | Fix: 2) Overriding labels (like old code did) prevented accessing potentially deleted labels, breaking annotations that use it (= full app error).
         // @todo CC | Fix: 3) Remove temporary workaround that simply merges old + new labels (just to get the app running until a fix is there)
         List<Label> merged = new ArrayList<>();
-        merged.addAll(labels);
+        merged.addAll(deletedLabels);
         merged.addAll(newLabels);
 
         labels = merged;


### PR DESCRIPTION
This PR-Draft relates to https://github.com/opencast/annotation-tool/issues/634 and https://github.com/opencast/annotation-tool/issues/601 . 

I "fixed" the current implementation in a way that the labels view now should not be showing duplicated labels anymore.

However, the implemenation is still majorly flawed as indicated in the comments: 
https://github.com/jduehring/annotation-tool/blob/0cb527bdaf654e287a1f4ecbfa927d0f9a546bc3/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java#L967C9-L969C145

When updating the labels for a series from the master series category, they currently are beeing deleted and newly created each time the app gets refreshed. But since the app tries to keep track of deleted labels, they essentially get duplicated in the background (which can still be seen in the "edit category" view) .  

We could probably try to filter all deleted labels and only show the newly created ones, but that doesnt fix the underlying issue of creating more and more (deleted) labels each refresh. Ideally the labels should only be created once and only update, if new lables have been created in the master series category. Unfortunately that does'nt seem as straight forward as it sounds. 

I could not implement a working, satisfying solution yet and will discuss this matter with @JulianKniephoff and/or @mwygas in January to hopefully make quick progress here. 