### PR TITLE
Fixes for serverless HLS

### DIFF
--- a/frontend/js/integrations/search.js
+++ b/frontend/js/integrations/search.js
@@ -159,6 +159,7 @@ define([
                         RegExp.prototype.test.bind(/application\/.*|video\/.*/),
                         _.property("mimetype")
                     ));
+                videos = _.sortBy(videos, "master").reverse();
                 videos.sort(
                     util.lexicographic([
                         util.firstWith(_.compose(

--- a/frontend/js/integrations/search.js
+++ b/frontend/js/integrations/search.js
@@ -159,9 +159,11 @@ define([
                         RegExp.prototype.test.bind(/application\/.*|video\/.*/),
                         _.property("mimetype")
                     ));
-                videos = _.sortBy(videos, "master").reverse();
                 videos.sort(
                     util.lexicographic([
+                        util.firstWith(
+                            _.property("master")
+                        ),
                         util.firstWith(_.compose(
                             RegExp.prototype.test.bind(/composite\/.*/),
                             _.property("type")

--- a/frontend/js/player-adapter-html5.js
+++ b/frontend/js/player-adapter-html5.js
@@ -85,7 +85,6 @@ define(
 
                 window.Hls = Hls;
                 mediaElementPlayer = new mejs.MediaElementPlayer(targetElement, {
-                    renderers: ["native_hls", "html5"],
                     alwaysShowControls: true,
                     autoRewind: false,
                     stretching: "fill",

--- a/frontend/js/player-adapter-html5.js
+++ b/frontend/js/player-adapter-html5.js
@@ -106,6 +106,7 @@ define(
                             // If duration is valid, we changed status
                             self.status = PlayerAdapter.STATUS.PAUSED;
                             self.dispatchEvent(new Event(PlayerAdapter.EVENTS.READY));
+                            mediaElementPlayer.updateDuration();
 
                             if (self.waitToPlay) {
                                 self.play();

--- a/frontend/js/player-adapter-html5.js
+++ b/frontend/js/player-adapter-html5.js
@@ -85,7 +85,7 @@ define(
 
                 window.Hls = Hls;
                 mediaElementPlayer = new mejs.MediaElementPlayer(targetElement, {
-                    renderers: ["html5", "native_hls"],
+                    renderers: ["native_hls", "html5"],
                     alwaysShowControls: true,
                     autoRewind: false,
                     stretching: "fill",
@@ -96,7 +96,7 @@ define(
                          */
                         $(mediaElement).on("canplay durationchange", function () {
                             // If duration is still not valid
-                            if (isNaN(self.getDuration()) || mediaElement.readyState < 1) {
+                            if (!isFinite(self.getDuration()) || mediaElement.readyState < 1) {
                                 return;
                             }
 


### PR DESCRIPTION
I made my own PR, I hope that's okay. The original draft is here: #627 
This PR contains the actual changes from @luniki + changes after review from @JulianKniephoff. The review is also to be found here: #627.

The 3 points Julian made:
1. Integrating the sort into the sorting below. I did that and it works. (https://github.com/opencast/annotation-tool/pull/627#discussion_r1745519948)
2. Is it possible to remove `renderers: ["html5", "native_hls"]`completly?: Yes, I removed it and it works. (https://github.com/opencast/annotation-tool/pull/627#discussion_r1745529603)
3. I didn't see a case where the duration was infinity, but that doesn't mean that Marcus didn't see something. I testet a small javascript function to see, how !isFinite and isNaN differs from each other:

```javascript
function compareIsNaNAndIsFinite() {
  const testValues = [NaN, "hello", undefined, "123", 123, Infinity, -Infinity, null, true, false, ""];

  console.log("Value\t\tisNaN(value)\t!isFinite(value)");
  console.log("------------------------------------------------");
  testValues.forEach(value => {
    console.log(
      `${String(value).padEnd(10)}\t${isNaN(value)}\t\t${!isFinite(value)}`
    );
  });
}

compareIsNaNAndIsFinite();
```
### The result:
```
Value		isNaN(value)	!isFinite(value)
------------------------------------------------
NaN       	true		true
hello     	true		true
undefined 	true		true
123       	false		false
123       	false		false
Infinity  	false		true
-Infinity 	false		true
null      	false		false
true      	false		false
false     	false		false
          	false		false
```
So I think, it's okay to use !isFinite() instead, because it can handle one more case, but behaves the same in the other cases.

I added another small line from Marcus, where he triggers an update for the video duration. It was reported, that the time wasn't displayed correctly.