### PR TITLE
Hide the fact that we are duplicating series labels better

### DIFF
--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
@@ -950,9 +950,7 @@ public final class ExtendedAnnotationServiceJpaImpl implements ExtendedAnnotatio
 
         // Update our labels with the labels from the master series category
         // Note: Maybe do an actual update instead of delete/create
-        for (Label label: labels) {
-          deleteLabel(label);
-        }
+        labels.replaceAll(this::deleteLabel);
         List<Label> newLabels = new ArrayList<>();
         for (Label seriesLabel : seriesCategoryLabels) {
           final LabelDto dto = LabelDto.create(some(seriesLabel.getId()), categoryId, seriesLabel.getValue(),


### PR DESCRIPTION
Seriously, though: The way series categories work with MCA is broken; cf. #648. This fixes a superficial symptom of that fact, namely #634, but it doesn't address the underlying problem of infinitely duplicating labels.

The problem with the old code was that the deleted labels are still included
in the response in their undeleted form. This patch just updates them in the response collection in-place.