### PR TITLE
Vendor some old Opencast code

### DIFF
--- a/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/Annotation.java
+++ b/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/Annotation.java
@@ -21,7 +21,7 @@
 
 package org.opencast.annotation.api;
 
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Option;
 
 /** Class representing an annotation. */
 public interface Annotation extends Resource {

--- a/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/Category.java
+++ b/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/Category.java
@@ -21,7 +21,7 @@
 
 package org.opencast.annotation.api;
 
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Option;
 
 /** A class representing a category of the annotation tool. */
 public interface Category extends Resource {

--- a/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/Comment.java
+++ b/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/Comment.java
@@ -21,7 +21,7 @@
 
 package org.opencast.annotation.api;
 
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Option;
 
 /** A class representing a comment of an annotation. */
 public interface Comment extends Resource {

--- a/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/ExtendedAnnotationService.java
+++ b/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/ExtendedAnnotationService.java
@@ -20,9 +20,9 @@
  */
 
 package org.opencast.annotation.api;
+import org.opencast.annotation.util.data.Option;
 
 import org.opencastproject.mediapackage.MediaPackage;
-import org.opencastproject.util.data.Option;
 
 import java.util.Date;
 import java.util.List;

--- a/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/Label.java
+++ b/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/Label.java
@@ -21,7 +21,7 @@
 
 package org.opencast.annotation.api;
 
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Option;
 
 /** A class representing a label of the annotation tool. */
 public interface Label extends Resource {

--- a/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/Resource.java
+++ b/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/Resource.java
@@ -21,7 +21,7 @@
 
 package org.opencast.annotation.api;
 
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Option;
 
 import java.util.Date;
 import java.util.Map;

--- a/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/Scale.java
+++ b/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/Scale.java
@@ -21,7 +21,7 @@
 
 package org.opencast.annotation.api;
 
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Option;
 
 /** A class representing a scale of the annotation tool. */
 public interface Scale extends Resource {

--- a/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/Track.java
+++ b/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/Track.java
@@ -21,7 +21,7 @@
 
 package org.opencast.annotation.api;
 
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Option;
 
 /** Class representing a track. */
 public interface Track extends Resource {

--- a/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/User.java
+++ b/opencast-backend/annotation-api/src/main/java/org/opencast/annotation/api/User.java
@@ -21,7 +21,7 @@
 
 package org.opencast.annotation.api;
 
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Option;
 
 /** A class representing a user of the annotation tool. */
 public interface User extends Resource {

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/AbstractExtendedAnnotationsRestService.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/AbstractExtendedAnnotationsRestService.java
@@ -24,12 +24,12 @@ package org.opencast.annotation.endpoint;
 import static org.opencast.annotation.api.ExtendedAnnotationService.ANNOTATE_ACTION;
 import static org.opencast.annotation.api.ExtendedAnnotationService.ANNOTATE_ADMIN_ACTION;
 import static org.opencast.annotation.endpoint.util.Responses.buildOk;
+import static org.opencast.annotation.util.data.Arrays.array;
+import static org.opencast.annotation.util.data.Option.none;
+import static org.opencast.annotation.util.data.Option.option;
+import static org.opencast.annotation.util.data.Option.some;
+import static org.opencast.annotation.util.data.functions.Strings.trimToNone;
 import static org.opencastproject.util.UrlSupport.uri;
-import static org.opencastproject.util.data.Arrays.array;
-import static org.opencastproject.util.data.Option.none;
-import static org.opencastproject.util.data.Option.option;
-import static org.opencastproject.util.data.Option.some;
-import static org.opencastproject.util.data.functions.Strings.trimToNone;
 
 import org.opencast.annotation.api.Category;
 import org.opencast.annotation.api.ExtendedAnnotationException;
@@ -53,14 +53,14 @@ import org.opencast.annotation.impl.persistence.ScaleDto;
 import org.opencast.annotation.impl.persistence.ScaleValueDto;
 import org.opencast.annotation.impl.persistence.UserDto;
 import org.opencast.annotation.impl.persistence.VideoDto;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Function0;
+import org.opencast.annotation.util.data.Option;
+import org.opencast.annotation.util.data.functions.Functions;
+import org.opencast.annotation.util.data.functions.Strings;
 
 import org.opencastproject.mediapackage.MediaPackage;
 import org.opencastproject.util.RestUtil;
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Function0;
-import org.opencastproject.util.data.Option;
-import org.opencastproject.util.data.functions.Functions;
-import org.opencastproject.util.data.functions.Strings;
 
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.format.ISODateTimeFormat;

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/VideoEndpoint.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/VideoEndpoint.java
@@ -33,12 +33,12 @@ import static org.opencast.annotation.endpoint.AbstractExtendedAnnotationsRestSe
 import static org.opencast.annotation.endpoint.AbstractExtendedAnnotationsRestService.parseToJsonMap;
 import static org.opencast.annotation.endpoint.AbstractExtendedAnnotationsRestService.run;
 import static org.opencast.annotation.endpoint.util.Responses.buildOk;
+import static org.opencast.annotation.util.data.Arrays.array;
+import static org.opencast.annotation.util.data.Option.none;
+import static org.opencast.annotation.util.data.Option.option;
+import static org.opencast.annotation.util.data.Option.some;
+import static org.opencast.annotation.util.data.functions.Strings.trimToNone;
 import static org.opencastproject.util.UrlSupport.uri;
-import static org.opencastproject.util.data.Arrays.array;
-import static org.opencastproject.util.data.Option.none;
-import static org.opencastproject.util.data.Option.option;
-import static org.opencastproject.util.data.Option.some;
-import static org.opencastproject.util.data.functions.Strings.trimToNone;
 
 import org.opencast.annotation.api.Annotation;
 import org.opencast.annotation.api.Category;
@@ -59,12 +59,12 @@ import org.opencast.annotation.impl.persistence.CommentDto;
 import org.opencast.annotation.impl.persistence.ScaleDto;
 import org.opencast.annotation.impl.persistence.TrackDto;
 import org.opencast.annotation.impl.persistence.VideoDto;
+import org.opencast.annotation.util.data.Function0;
+import org.opencast.annotation.util.data.Option;
+import org.opencast.annotation.util.data.functions.Functions;
+import org.opencast.annotation.util.data.functions.Strings;
 
 import org.opencastproject.mediapackage.MediaPackage;
-import org.opencastproject.util.data.Function0;
-import org.opencastproject.util.data.Option;
-import org.opencastproject.util.data.functions.Functions;
-import org.opencastproject.util.data.functions.Strings;
 
 import java.net.URI;
 import java.util.Date;

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/util/Responses.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/endpoint/util/Responses.java
@@ -21,7 +21,7 @@
 
 package org.opencast.annotation.endpoint.util;
 
-import static org.opencastproject.util.data.functions.Strings.asStringNull;
+import static org.opencast.annotation.util.data.functions.Strings.asStringNull;
 
 import org.json.simple.JSONObject;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/AnnotationImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/AnnotationImpl.java
@@ -25,9 +25,8 @@ import org.opencast.annotation.api.Annotation;
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Resource;
 import org.opencast.annotation.api.Track;
-
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Option;
 
 import java.util.Objects;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/CategoryImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/CategoryImpl.java
@@ -24,8 +24,7 @@ package org.opencast.annotation.impl;
 import org.opencast.annotation.api.Category;
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Resource;
-
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Option;
 
 import java.util.Objects;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/CommentImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/CommentImpl.java
@@ -25,9 +25,8 @@ import org.opencast.annotation.api.Annotation;
 import org.opencast.annotation.api.Comment;
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Resource;
-
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Option;
 
 import java.util.Objects;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/Jsons.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/Jsons.java
@@ -21,12 +21,12 @@
 
 package org.opencast.annotation.impl;
 
-import static org.opencastproject.util.data.Tuple.tuple;
+import static org.opencast.annotation.util.data.Tuple.tuple;
 
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Monadics;
-import org.opencastproject.util.data.Option;
-import org.opencastproject.util.data.Tuple;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Monadics;
+import org.opencast.annotation.util.data.Option;
+import org.opencast.annotation.util.data.Tuple;
 
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/LabelImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/LabelImpl.java
@@ -25,9 +25,8 @@ import org.opencast.annotation.api.Category;
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Label;
 import org.opencast.annotation.api.Resource;
-
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Option;
 
 import java.util.Objects;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/ResourceImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/ResourceImpl.java
@@ -21,12 +21,11 @@
 
 package org.opencast.annotation.impl;
 
-import static org.opencastproject.util.data.Option.none;
+import static org.opencast.annotation.util.data.Option.none;
 
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Resource;
-
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Option;
 
 import java.util.Date;
 import java.util.HashMap;

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/ScaleImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/ScaleImpl.java
@@ -24,8 +24,7 @@ package org.opencast.annotation.impl;
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Resource;
 import org.opencast.annotation.api.Scale;
-
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Option;
 
 import java.util.Objects;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/ScaleValueImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/ScaleValueImpl.java
@@ -25,9 +25,8 @@ import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Resource;
 import org.opencast.annotation.api.Scale;
 import org.opencast.annotation.api.ScaleValue;
-
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Option;
 
 import java.util.Objects;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/TrackImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/TrackImpl.java
@@ -21,13 +21,12 @@
 
 package org.opencast.annotation.impl;
 
-import static org.opencastproject.util.data.Option.some;
+import static org.opencast.annotation.util.data.Option.some;
 
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Resource;
 import org.opencast.annotation.api.Track;
-
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Option;
 
 import java.util.Objects;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/UserImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/UserImpl.java
@@ -23,8 +23,7 @@ package org.opencast.annotation.impl;
 
 import org.opencast.annotation.api.Resource;
 import org.opencast.annotation.api.User;
-
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Option;
 
 import java.util.Objects;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/VideoImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/VideoImpl.java
@@ -21,13 +21,12 @@
 
 package org.opencast.annotation.impl;
 
-import static org.opencastproject.util.data.Option.some;
+import static org.opencast.annotation.util.data.Option.some;
 
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Resource;
 import org.opencast.annotation.api.Video;
-
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Option;
 
 import java.util.Objects;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/AbstractResourceDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/AbstractResourceDto.java
@@ -29,11 +29,11 @@ import static org.opencast.annotation.impl.Jsons.p;
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Resource;
 import org.opencast.annotation.api.User;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Function2;
+import org.opencast.annotation.util.data.Option;
 
 import org.opencastproject.util.DateTimeSupport;
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Function2;
-import org.opencastproject.util.data.Option;
 
 import org.json.simple.JSONObject;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/AnnotationDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/AnnotationDto.java
@@ -25,8 +25,8 @@ import static org.opencast.annotation.impl.Jsons.conc;
 import static org.opencast.annotation.impl.Jsons.jA;
 import static org.opencast.annotation.impl.Jsons.jO;
 import static org.opencast.annotation.impl.Jsons.p;
-import static org.opencastproject.util.data.Monadics.mlist;
-import static org.opencastproject.util.data.Option.option;
+import static org.opencast.annotation.util.data.Monadics.mlist;
+import static org.opencast.annotation.util.data.Option.option;
 
 import org.opencast.annotation.api.Annotation;
 import org.opencast.annotation.api.ExtendedAnnotationService;
@@ -35,10 +35,9 @@ import org.opencast.annotation.api.Resource;
 import org.opencast.annotation.api.ScaleValue;
 import org.opencast.annotation.impl.AnnotationImpl;
 import org.opencast.annotation.impl.ResourceImpl;
-
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Function2;
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Function2;
+import org.opencast.annotation.util.data.Option;
 
 import org.json.simple.JSONObject;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/CategoryDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/CategoryDto.java
@@ -25,18 +25,17 @@ import static org.opencast.annotation.impl.Jsons.conc;
 import static org.opencast.annotation.impl.Jsons.jA;
 import static org.opencast.annotation.impl.Jsons.jO;
 import static org.opencast.annotation.impl.Jsons.p;
-import static org.opencastproject.util.data.Monadics.mlist;
-import static org.opencastproject.util.data.Option.option;
+import static org.opencast.annotation.util.data.Monadics.mlist;
+import static org.opencast.annotation.util.data.Option.option;
 
 import org.opencast.annotation.api.Category;
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Resource;
 import org.opencast.annotation.impl.CategoryImpl;
 import org.opencast.annotation.impl.ResourceImpl;
-
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Function2;
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Function2;
+import org.opencast.annotation.util.data.Option;
 
 import org.json.simple.JSONObject;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/CommentDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/CommentDto.java
@@ -25,18 +25,17 @@ import static org.opencast.annotation.impl.Jsons.conc;
 import static org.opencast.annotation.impl.Jsons.jA;
 import static org.opencast.annotation.impl.Jsons.jO;
 import static org.opencast.annotation.impl.Jsons.p;
-import static org.opencastproject.util.data.Monadics.mlist;
-import static org.opencastproject.util.data.Option.option;
+import static org.opencast.annotation.util.data.Monadics.mlist;
+import static org.opencast.annotation.util.data.Option.option;
 
 import org.opencast.annotation.api.Comment;
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Resource;
 import org.opencast.annotation.impl.CommentImpl;
 import org.opencast.annotation.impl.ResourceImpl;
-
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Function2;
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Function2;
+import org.opencast.annotation.util.data.Option;
 
 import org.json.simple.JSONObject;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ExtendedAnnotationServiceJpaImpl.java
@@ -30,11 +30,11 @@ import static org.opencast.annotation.impl.persistence.ScaleValueDto.toScaleValu
 import static org.opencast.annotation.impl.persistence.TrackDto.toTrack;
 import static org.opencast.annotation.impl.persistence.UserDto.toUser;
 import static org.opencast.annotation.impl.persistence.VideoDto.toVideo;
+import static org.opencast.annotation.util.data.Monadics.mlist;
+import static org.opencast.annotation.util.data.Option.none;
+import static org.opencast.annotation.util.data.Option.option;
+import static org.opencast.annotation.util.data.Option.some;
 import static org.opencastproject.db.Queries.namedQuery;
-import static org.opencastproject.util.data.Monadics.mlist;
-import static org.opencastproject.util.data.Option.none;
-import static org.opencastproject.util.data.Option.option;
-import static org.opencastproject.util.data.Option.some;
 
 import org.opencast.annotation.api.Annotation;
 import org.opencast.annotation.api.Category;
@@ -59,6 +59,12 @@ import org.opencast.annotation.impl.ScaleValueImpl;
 import org.opencast.annotation.impl.TrackImpl;
 import org.opencast.annotation.impl.UserImpl;
 import org.opencast.annotation.impl.VideoImpl;
+import org.opencast.annotation.util.data.Effect;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Function0;
+import org.opencast.annotation.util.data.Option;
+import org.opencast.annotation.util.data.Option.Match;
+import org.opencast.annotation.util.data.Predicate;
 
 import org.opencastproject.db.DBSession;
 import org.opencastproject.db.DBSessionFactory;
@@ -69,12 +75,6 @@ import org.opencastproject.security.api.SecurityConstants;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.api.UnauthorizedException;
 import org.opencastproject.util.NotFoundException;
-import org.opencastproject.util.data.Effect;
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Function0;
-import org.opencastproject.util.data.Option;
-import org.opencastproject.util.data.Option.Match;
-import org.opencastproject.util.data.Predicate;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.joda.time.base.AbstractInstant;

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/LabelDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/LabelDto.java
@@ -25,8 +25,8 @@ import static org.opencast.annotation.impl.Jsons.conc;
 import static org.opencast.annotation.impl.Jsons.jA;
 import static org.opencast.annotation.impl.Jsons.jO;
 import static org.opencast.annotation.impl.Jsons.p;
-import static org.opencastproject.util.data.Monadics.mlist;
-import static org.opencastproject.util.data.Option.option;
+import static org.opencast.annotation.util.data.Monadics.mlist;
+import static org.opencast.annotation.util.data.Option.option;
 
 import org.opencast.annotation.api.Category;
 import org.opencast.annotation.api.ExtendedAnnotationService;
@@ -34,10 +34,9 @@ import org.opencast.annotation.api.Label;
 import org.opencast.annotation.api.Resource;
 import org.opencast.annotation.impl.LabelImpl;
 import org.opencast.annotation.impl.ResourceImpl;
-
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Function2;
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Function2;
+import org.opencast.annotation.util.data.Option;
 
 import org.json.simple.JSONObject;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ScaleDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ScaleDto.java
@@ -25,18 +25,17 @@ import static org.opencast.annotation.impl.Jsons.conc;
 import static org.opencast.annotation.impl.Jsons.jA;
 import static org.opencast.annotation.impl.Jsons.jO;
 import static org.opencast.annotation.impl.Jsons.p;
-import static org.opencastproject.util.data.Monadics.mlist;
-import static org.opencastproject.util.data.Option.option;
+import static org.opencast.annotation.util.data.Monadics.mlist;
+import static org.opencast.annotation.util.data.Option.option;
 
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Resource;
 import org.opencast.annotation.api.Scale;
 import org.opencast.annotation.impl.ResourceImpl;
 import org.opencast.annotation.impl.ScaleImpl;
-
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Function2;
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Function2;
+import org.opencast.annotation.util.data.Option;
 
 import org.json.simple.JSONObject;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ScaleValueDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ScaleValueDto.java
@@ -25,8 +25,8 @@ import static org.opencast.annotation.impl.Jsons.conc;
 import static org.opencast.annotation.impl.Jsons.jA;
 import static org.opencast.annotation.impl.Jsons.jO;
 import static org.opencast.annotation.impl.Jsons.p;
-import static org.opencastproject.util.data.Monadics.mlist;
-import static org.opencastproject.util.data.Option.option;
+import static org.opencast.annotation.util.data.Monadics.mlist;
+import static org.opencast.annotation.util.data.Option.option;
 
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Resource;
@@ -34,9 +34,8 @@ import org.opencast.annotation.api.Scale;
 import org.opencast.annotation.api.ScaleValue;
 import org.opencast.annotation.impl.ResourceImpl;
 import org.opencast.annotation.impl.ScaleValueImpl;
-
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Function2;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Function2;
 
 import org.json.simple.JSONObject;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/TrackDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/TrackDto.java
@@ -25,18 +25,17 @@ import static org.opencast.annotation.impl.Jsons.conc;
 import static org.opencast.annotation.impl.Jsons.jA;
 import static org.opencast.annotation.impl.Jsons.jO;
 import static org.opencast.annotation.impl.Jsons.p;
-import static org.opencastproject.util.data.Monadics.mlist;
-import static org.opencastproject.util.data.Option.option;
+import static org.opencast.annotation.util.data.Monadics.mlist;
+import static org.opencast.annotation.util.data.Option.option;
 
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Resource;
 import org.opencast.annotation.api.Track;
 import org.opencast.annotation.impl.ResourceImpl;
 import org.opencast.annotation.impl.TrackImpl;
-
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Function2;
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Function2;
+import org.opencast.annotation.util.data.Option;
 
 import org.json.simple.JSONObject;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/UserDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/UserDto.java
@@ -25,18 +25,17 @@ import static org.opencast.annotation.impl.Jsons.conc;
 import static org.opencast.annotation.impl.Jsons.jA;
 import static org.opencast.annotation.impl.Jsons.jO;
 import static org.opencast.annotation.impl.Jsons.p;
-import static org.opencastproject.util.data.Monadics.mlist;
-import static org.opencastproject.util.data.Option.option;
+import static org.opencast.annotation.util.data.Monadics.mlist;
+import static org.opencast.annotation.util.data.Option.option;
 
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Resource;
 import org.opencast.annotation.api.User;
 import org.opencast.annotation.impl.ResourceImpl;
 import org.opencast.annotation.impl.UserImpl;
-
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Function2;
-import org.opencastproject.util.data.Option;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Function2;
+import org.opencast.annotation.util.data.Option;
 
 import org.json.simple.JSONObject;
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/VideoDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/VideoDto.java
@@ -24,16 +24,15 @@ package org.opencast.annotation.impl.persistence;
 import static org.opencast.annotation.impl.Jsons.conc;
 import static org.opencast.annotation.impl.Jsons.jO;
 import static org.opencast.annotation.impl.Jsons.p;
-import static org.opencastproject.util.data.Option.option;
+import static org.opencast.annotation.util.data.Option.option;
 
 import org.opencast.annotation.api.ExtendedAnnotationService;
 import org.opencast.annotation.api.Resource;
 import org.opencast.annotation.api.Video;
 import org.opencast.annotation.impl.ResourceImpl;
 import org.opencast.annotation.impl.VideoImpl;
-
-import org.opencastproject.util.data.Function;
-import org.opencastproject.util.data.Function2;
+import org.opencast.annotation.util.data.Function;
+import org.opencast.annotation.util.data.Function2;
 
 import org.json.simple.JSONObject;
 

--- a/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestServiceTest.java
+++ b/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/endpoint/ExtendedAnnotationsRestServiceTest.java
@@ -29,9 +29,9 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.opencast.annotation.endpoint.ExtendedAnnotationsRestServiceTest.RegexMatcher.regex;
+import static org.opencast.annotation.util.data.Option.none;
+import static org.opencast.annotation.util.data.Option.some;
 import static org.opencastproject.test.rest.RestServiceTestEnv.testEnvForClasses;
-import static org.opencastproject.util.data.Option.none;
-import static org.opencastproject.util.data.Option.some;
 
 import org.opencast.annotation.api.Annotation;
 import org.opencast.annotation.api.Resource;

--- a/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/impl/ExtendedAnnotationServiceJpaImplTest.java
+++ b/opencast-backend/annotation-impl/src/test/java/org/opencast/annotation/impl/ExtendedAnnotationServiceJpaImplTest.java
@@ -26,10 +26,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.opencast.annotation.util.data.Option.none;
+import static org.opencast.annotation.util.data.Option.some;
 import static org.opencastproject.db.DBTestEnv.getDbSessionFactory;
 import static org.opencastproject.db.DBTestEnv.newEntityManagerFactory;
-import static org.opencastproject.util.data.Option.none;
-import static org.opencastproject.util.data.Option.some;
 
 import org.opencast.annotation.api.Annotation;
 import org.opencast.annotation.api.Category;
@@ -45,14 +45,14 @@ import org.opencast.annotation.api.Track;
 import org.opencast.annotation.api.User;
 import org.opencast.annotation.api.Video;
 import org.opencast.annotation.impl.persistence.ExtendedAnnotationServiceJpaImpl;
+import org.opencast.annotation.util.data.Effect0;
+import org.opencast.annotation.util.data.Option;
 
 import org.opencastproject.search.api.SearchService;
 import org.opencastproject.security.api.AuthorizationService;
 import org.opencastproject.security.api.DefaultOrganization;
 import org.opencastproject.security.api.SecurityService;
 import org.opencastproject.security.util.SecurityUtil;
-import org.opencastproject.util.data.Effect0;
-import org.opencastproject.util.data.Option;
 
 import org.easymock.EasyMock;
 import org.junit.Before;

--- a/opencast-backend/pom.xml
+++ b/opencast-backend/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>jaxb-api</artifactId>
       <version>2.3.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.opencast.annotate</groupId>
+      <artifactId>annnotation-tool-opencast-util</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/opencast-util/dependency-reduced-pom.xml
+++ b/opencast-util/dependency-reduced-pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>annotation-tool</artifactId>
+    <groupId>org.opencast.annotate</groupId>
+    <version>${revision}</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>annnotation-tool-opencast-util</artifactId>
+  <packaging>bundle</packaging>
+  <name>Opencast Annotation Tool :: Opencast Utils</name>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <relocations>
+                <relocation>
+                  <pattern>org.opencastproject.util</pattern>
+                  <shadedPattern>org.opencast.annotation.util</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Export-Package>org.opencast.annotation.util,
+              org.opencast.annotation.util.data,
+              org.opencast.annotation.util.data.functions</Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/opencast-util/pom.xml
+++ b/opencast-util/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.opencast.annotate</groupId>
+    <artifactId>annotation-tool</artifactId>
+    <version>${revision}</version>
+  </parent>
+
+  <artifactId>annnotation-tool-opencast-util</artifactId>
+  <packaging>bundle</packaging>
+
+  <name>Opencast Annotation Tool :: Opencast Utils</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.opencastproject</groupId>
+      <artifactId>opencast-common</artifactId>
+      <version>18.5</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <!-- Filter out signature files from META-INF to avoid "Invalid signature file digest for Manifest main attributes" errors -->
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <relocations>
+                <relocation>
+                  <pattern>org.opencastproject.util</pattern>
+                  <shadedPattern>org.opencast.annotation.util</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Export-Package>
+              org.opencast.annotation.util;version=${project.version},
+              org.opencast.annotation.util.data;version=${project.version},
+              org.opencast.annotation.util.data.functions;version=${project.version}
+            </Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
 
   <modules>
     <module>frontend</module>
+    <module>opencast-util</module>
     <module>opencast-backend</module>
   </modules>
 


### PR DESCRIPTION
The Annotation Tool freely used some of Opencasts internal utility classes. See also #658.
These were removed somewhere around Opencast 18.5, 19. Since we currently don't have the time to rip them out from the Annotation Tool as well, here is a very crude temporary solution:

We just steal the code from the released 18.5 jar! Or rather we steal the entire jar
(with some transitive dependencies even),
and relocate and subsequently export only the parts that we need. The relocation is necessary to avoid conflicts in OSGi, stealing the entire bundle is necessary because of internal/transitive dependencies.