### PR TITLE
Rename columns named `value`

### DIFF
--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/AnnotationDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/AnnotationDto.java
@@ -103,7 +103,7 @@ public class AnnotationDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "value")
+  @Column(name = "value_")
   @CollectionTable(name = "xannotations_annotation_tags", joinColumns = @JoinColumn(name = "annotation_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/CategoryDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/CategoryDto.java
@@ -101,7 +101,7 @@ public class CategoryDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "value")
+  @Column(name = "value_")
   @CollectionTable(name = "xannotations_category_tags", joinColumns = @JoinColumn(name = "category_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/CommentDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/CommentDto.java
@@ -89,7 +89,7 @@ public class CommentDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "value")
+  @Column(name = "value_")
   @CollectionTable(name = "xannotations_comment_tags", joinColumns = @JoinColumn(name = "comment_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/LabelDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/LabelDto.java
@@ -77,7 +77,7 @@ public class LabelDto extends AbstractResourceDto {
   @Column(name = "series_label_id")
   private Long seriesLabelId;
 
-  @Column(name = "value", nullable = false)
+  @Column(name = "value_", nullable = false)
   private String value;
 
   @Column(name = "abbreviation", nullable = false)
@@ -95,7 +95,7 @@ public class LabelDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "value")
+  @Column(name = "value_")
   @CollectionTable(name = "xannotations_label_tags", joinColumns = @JoinColumn(name = "label_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ScaleDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ScaleDto.java
@@ -87,7 +87,7 @@ public class ScaleDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "value")
+  @Column(name = "value_")
   @CollectionTable(name = "xannotations_scale_tags", joinColumns = @JoinColumn(name = "scale_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ScaleValueDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/ScaleValueDto.java
@@ -75,7 +75,7 @@ public class ScaleValueDto extends AbstractResourceDto {
   @Column(name = "name", nullable = false)
   private String name;
 
-  @Column(name = "value", nullable = false)
+  @Column(name = "value_", nullable = false)
   private double value;
 
   @Column(name = "order_value", nullable = false)
@@ -87,7 +87,7 @@ public class ScaleValueDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "value")
+  @Column(name = "value_")
   @CollectionTable(name = "xannotations_scale_value_tags", joinColumns = @JoinColumn(name = "scale_value_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/TrackDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/TrackDto.java
@@ -87,7 +87,7 @@ public class TrackDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "value")
+  @Column(name = "value_")
   @CollectionTable(name = "xannotations_track_tags", joinColumns = @JoinColumn(name = "track_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/UserDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/UserDto.java
@@ -84,7 +84,7 @@ public class UserDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "value")
+  @Column(name = "value_")
   @CollectionTable(name = "xannotations_user_tags", joinColumns = @JoinColumn(name = "user_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 

--- a/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/VideoDto.java
+++ b/opencast-backend/annotation-impl/src/main/java/org/opencast/annotation/impl/persistence/VideoDto.java
@@ -73,7 +73,7 @@ public final class VideoDto extends AbstractResourceDto {
 
   @ElementCollection
   @MapKeyColumn(name = "name")
-  @Column(name = "value")
+  @Column(name = "value_")
   @CollectionTable(name = "xannotations_video_tags", joinColumns = @JoinColumn(name = "video_id"))
   protected Map<String, String> tags = new HashMap<String, String>();
 


### PR DESCRIPTION
`value` is a keyword in SQL.

This addresses #660.

This used to not be an issue, and it continues to work with MariaDB and Postgres, but newer versions of h2, specifically the one used in Opencast, choke on this.

I tried to work around this using quoting, but Postgres treats quoted identifiers in a non-standard way, so that doesn't work cross-platform, either.

I opted to just rename the columns `value_`, which is [not ideal](#663), but since this targets `stable`, it's the simplest way to handle forward merges.

Note, that you need to migrate your database! Due to the exact compatibility issues this is trying to fix, it's hard to provide a portable script. Please refer to the documentation of your respective database to do something to the effect of

```sql
alter table xannotations_annotation_tags rename column value to value_;
alter table xannotations_category_tags rename column value to value_;
alter table xannotations_comment_tags rename column value to value_;
alter table xannotations_label_tags rename column value to value_;
alter table xannotations_scale_tags rename column value to value_;
alter table xannotations_scale_value_tags rename column value to value_;
alter table xannotations_track_tags rename column value to value_;
alter table xannotations_user_tags rename column value to value_;
alter table xannotations_video_tags rename column value to value_;
alter table xannotations_label rename column value to value_;
alter table xannotations_scale_value rename column value to value_;
```